### PR TITLE
Add lagged ensemble perturbation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parallel inference example
 - Perturbation method section in userguide
 - WeatherBench Climatology data source
+- Add lagged ensemble perturbation method
 
 ### Changed
 

--- a/docs/modules/perturbation.rst
+++ b/docs/modules/perturbation.rst
@@ -21,5 +21,6 @@ creating ensemble forecasts.
    perturbation.Brown
    perturbation.BredVector
    perturbation.Gaussian
+   perturbation.LaggedEnsemble
    perturbation.SphericalGaussian
    perturbation.Zero

--- a/earth2studio/perturbation/__init__.py
+++ b/earth2studio/perturbation/__init__.py
@@ -18,5 +18,6 @@ from .base import Perturbation
 from .brown import Brown  # noqa
 from .bv import BredVector  # noqa
 from .gaussian import Gaussian  # noqa
+from .lagged import LaggedEnsemble  # noqa
 from .spherical import SphericalGaussian  # noqa
 from .zero import Zero  # noqa

--- a/earth2studio/perturbation/lagged.py
+++ b/earth2studio/perturbation/lagged.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+
+from earth2studio.data import DataSource, fetch_data
+from earth2studio.utils.coords import handshake_dim
+from earth2studio.utils.type import CoordSystem, LeadTimeArray
+
+
+class LaggedEnsemble:
+    """Lagged Ensemble perturbation method. This method creates an ensemble
+    by collecting initial conditions from different times, but verifying
+    at the same time.
+
+    Parameters
+    ----------
+    source: DataSource
+        The source for which to draw initial conditions from.
+    lags: LeadTimeArray
+        The list lags, in the form of LeadTimeArray, i.e., np.timedelta64, to include.
+        Positive lags refer to future times whereas negative lags refer to
+        previous times.  Using positive lags should not be used for forecasting
+        purposes but can be used for hindcasting. A lag of zero is effectively
+        an unperturbed ensemble member.
+
+        For example,
+            lags = np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")])
+            creates an ensemble with two lags, one of which is the current time and
+            one is 6 hours in the past.
+
+    Note
+    ----
+    For additional information:
+
+    - https://doi.org/10.1111/j.1600-0870.1983.tb00189.x
+    """
+
+    def __init__(
+        self,
+        source: DataSource,
+        lags: LeadTimeArray,
+    ):
+        self.source = source
+        self.lags = lags
+
+    @torch.inference_mode()
+    def __call__(
+        self,
+        x: torch.Tensor,
+        coords: CoordSystem,
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """Apply perturbation method
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor intended to apply perturbation on
+        coords : CoordSystem
+            Ordered dict representing coordinate system that describes the tensor
+
+        Returns
+        -------
+        tuple[torch.Tensor, CoordSystem]:
+            Ouput tensor and respective coordinate system dictionary
+        """
+
+        # Assume order of dimensions here
+        handshake_dim(coords, "ensemble", 0)
+        handshake_dim(coords, "time", 1)
+        handshake_dim(coords, "lead_time", 2)
+
+        if len(coords["ensemble"]) != len(self.lags):
+            raise ValueError(
+                f"Warning! The number of lags, {len(self.lags)}, does not match "
+                f"the number of ensemble members requested, {len(coords['ensemble'])}."
+            )
+
+        for i, lag in enumerate(self.lags):
+            x[i] = fetch_data(
+                source=self.source,
+                time=coords["time"] + lag,
+                variable=coords["variable"],
+                lead_time=coords["lead_time"],
+                device=x.device,
+            )[0]
+
+        return x, coords

--- a/test/perturbation/test_lagged.py
+++ b/test/perturbation/test_lagged.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+
+from earth2studio.data import GFS, Random, fetch_data
+from earth2studio.perturbation import LaggedEnsemble
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        np.array([np.datetime64("2024-01-01T00:00:00")]),
+        np.array(
+            [np.datetime64("1999-10-11T12:00"), np.datetime64("2001-06-04T00:00")]
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "lags",
+    [
+        np.array([np.timedelta64(0, "h")]),
+        np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")]),
+        np.array([np.timedelta64(-12, "h"), np.timedelta64(6, "h")]),
+    ],
+)
+@pytest.mark.parametrize(
+    "lead_time",
+    [
+        np.array([np.timedelta64(0, "h")]),
+        np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")]),
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda:0",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="cuda missing"
+            ),
+        ),
+    ],
+)
+def test_lagged_api(time, lags, lead_time, device):
+
+    # Construct Domain Coordinates
+    dc = OrderedDict(
+        {
+            "lat": np.linspace(-90, 90, 360),
+            "lon": np.linspace(0, 360, 720, endpoint=False),
+        }
+    )
+
+    coords = OrderedDict(
+        {
+            "ensemble": np.arange(len(lags)),
+            "time": time,
+            "lead_time": lead_time,
+            "variable": ["t2m", "tcwv"],
+            "lat": dc["lat"],
+            "lon": dc["lon"],
+        }
+    )
+
+    # Initialize Data Source
+    r = Random(dc)
+
+    # Initialize Lagged Ensemble
+    le = LaggedEnsemble(r, lags)
+
+    x = torch.randn(
+        [len(c) for c in coords.values()], device=device, dtype=torch.float32
+    )
+
+    y, y_coords = le(x, coords)
+
+    with pytest.raises(ValueError):
+        # Test with wrong size of ensemble
+        coords["ensemble"] = np.arange(len(lags) + 1)
+        x = torch.randn(
+            [len(c) for c in coords.values()], device=device, dtype=torch.float32
+        )
+        y, y_coords = le(x, coords)
+
+
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda:0",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="cuda missing"
+            ),
+        ),
+    ],
+)
+def test_lagged_accuracy(device):
+
+    time = np.array([np.datetime64("2024-01-01T00:00:00")])
+    lead_time = np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")])
+    lags = np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")])
+    variable = np.array(["t2m", "tcwv"])
+
+    # Construct Domain Coordinates
+    dc = OrderedDict(
+        {
+            "lat": np.linspace(-90, 90, 360),
+            "lon": np.linspace(0, 360, 720, endpoint=False),
+        }
+    )
+
+    coords = OrderedDict(
+        {
+            "ensemble": np.arange(len(lags)),
+            "time": time,
+            "lead_time": lead_time,
+            "variable": variable,
+            "lat": dc["lat"],
+            "lon": dc["lon"],
+        }
+    )
+
+    # Initialize Data Source
+    gfs = GFS()
+    x0, c = fetch_data(
+        source=GFS(), time=time, variable=variable, lead_time=lead_time, device=device
+    )
+    x = x0.clone().unsqueeze(0).repeat(len(lags), 1, 1, 1, 1, 1)
+
+    # Initialize Lagged Ensemble
+    le = LaggedEnsemble(gfs, lags)
+
+    y, y_coords = le(x, coords)
+
+    assert torch.allclose(y[1], x0), torch.linalg.norm(y[1] - x0) / torch.linalg.norm(
+        x0
+    )
+    assert torch.allclose(y[0, 0, 1], x0[0, 0]), torch.linalg.norm(
+        y[0, 0, 1] - x0[0, 0]
+    ) / torch.linalg.norm(x0[0, 0])


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

Adds the ability to perturb using a lagged ensemble perturbation strategy.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
