### PR TITLE
add reading ability and reloading netcdf/zarr stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parallel inference example
 - Perturbation method section in userguide
 - WeatherBench Climatology data source
+- Added the ability to reload zarr and netcdf backends
+- Added the ability to read from an IOBackend
 
 ### Changed
 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated perturbation methods API `PerturbationMethod` -> `Perturbation`.
   These now generate noise and apply it to the input tensor.
 - Removed original `Perturbation` class
+- NetCDF reads are now mode='r+' instead of 'w'.
 
 ### Deprecated
 

--- a/earth2studio/io/kv.py
+++ b/earth2studio/io/kv.py
@@ -196,3 +196,30 @@ class KVBackend:
             },
             **xr_kwargs,
         )
+
+    def read(
+        self, coords: CoordSystem, array_name: str, device: torch.device = "cpu"
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """
+        Read data from the current KV store using the passed array_name.
+
+        Parameters
+        ----------
+        coords : OrderedDict
+            Coordinates of the data to be read.
+        array_name : str | list[str]
+            Name(s) of the array(s) to read from.
+        device : torch.device
+            device to place the read data from, by default 'cpu'
+        """
+
+        x = self.root[array_name][
+            np.ix_(
+                *[
+                    np.where(np.in1d(self.coords[dim], value))[0]
+                    for dim, value in coords.items()
+                ]
+            )
+        ]
+
+        return x.to(device), coords

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -19,7 +19,7 @@ from collections.abc import Iterator
 
 import numpy as np
 import torch
-from cftime import date2num
+from cftime import date2num, num2date
 from netCDF4 import Dataset, Variable
 
 from earth2studio.utils.time import timearray_to_datetime
@@ -51,13 +51,33 @@ class NetCDF4Backend:
         # Set persist to false if diskless is false
         self.root = Dataset(
             file_name,
-            "w",
+            "r+",
             format="NETCDF4",
             diskless=diskless,
             persist=persist if diskless else False,
         )
 
         self.coords: CoordSystem = OrderedDict({})
+        for dim in self.root.dimensions:
+            print(dim)
+            if dim == "time":
+                print(dim)
+                nums = self.root[dim]
+                print(nums)
+                dates = num2date(
+                    nums, units=self.root[dim].units, calendar=self.root[dim].calendar
+                )
+                print(dates)
+                self.coords[dim] = np.array(
+                    [np.datetime64(d.isoformat()) for d in dates]
+                )
+            elif dim == "lead_time":
+                nums = self.root[dim][:]
+                self.coords[dim] = np.array(
+                    [np.timedelta64(n, self.root[dim].units) for n in nums]
+                )
+            else:
+                self.coords[dim] = self.root[dim][:]
 
     def __contains__(self, item: str) -> bool:
         """Checks if item in netCDF4 variables.
@@ -230,6 +250,33 @@ class NetCDF4Backend:
                         ]
                     )
                 ] = xi.to("cpu", non_blocking=True).numpy()
+
+    def read(
+        self, coords: CoordSystem, array_name: str, device: torch.device = "cpu"
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """
+        Read data from the current netcdf store using the passed array_name.
+
+        Parameters
+        ----------
+        coords : OrderedDict
+            Coordinates of the data to be read.
+        array_name : str | list[str]
+            Name(s) of the array(s) to read from.
+        device : torch.device
+            device to place the read data from, by default 'cpu'
+        """
+
+        x = self.root[array_name][
+            tuple(
+                [
+                    np.where(np.in1d(self.coords[dim], value))[0]
+                    for dim, value in coords.items()
+                ]
+            )
+        ]
+
+        return torch.as_tensor(x, device=device), coords
 
     def close(
         self,

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -59,15 +59,11 @@ class NetCDF4Backend:
 
         self.coords: CoordSystem = OrderedDict({})
         for dim in self.root.dimensions:
-            print(dim)
             if dim == "time":
-                print(dim)
                 nums = self.root[dim]
-                print(nums)
                 dates = num2date(
                     nums, units=self.root[dim].units, calendar=self.root[dim].calendar
                 )
-                print(dates)
                 self.coords[dim] = np.array(
                     [np.datetime64(d.isoformat()) for d in dates]
                 )

--- a/earth2studio/io/xarray.py
+++ b/earth2studio/io/xarray.py
@@ -170,3 +170,34 @@ class XarrayBackend:
                         ]
                     )
                 ] = xi.to("cpu", non_blocking=True).numpy()
+
+    def read(
+        self,
+        coords: CoordSystem,
+        array_name: str,
+        device: torch.device = "cpu",
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """
+        Read data from the current xarray dataset using the passed array_name.
+
+        Parameters
+        ----------
+        coords : OrderedDict
+            Coordinates of the data to be read.
+        array_name : str | list[str]
+            Name(s) of the array(s) to read from.
+        device : torch.device
+            device to place the read data from, by default 'cpu'
+        """
+
+        x = self.root[array_name].values[
+            np.ix_(
+                *[
+                    np.where(np.in1d(self.coords[dim], value))[0]
+                    for dim, value in coords.items()
+                ]
+            )
+        ]
+
+        return torch.as_tensor(x, dtype=dtype, device=device), coords

--- a/test/io/test_kv.py
+++ b/test/io/test_kv.py
@@ -102,6 +102,9 @@ def test_kv_fields(time: list[np.datetime64], variable: list[str], device: str) 
     z.write(partial_data, partial_coords, array_name)
     assert torch.allclose(z[array_name][0, 0, :, :180], partial_data)
 
+    xx, _ = z.read(partial_coords, array_name, device=device)
+    assert torch.allclose(partial_data, xx)
+
     # test to xarray
     ds = z.to_xarray()
     assert isinstance(ds, xr.Dataset)

--- a/test/io/test_netcdf4.py
+++ b/test/io/test_netcdf4.py
@@ -124,6 +124,10 @@ def test_netcdf4_fields(
     partial_data = torch.randn((1, 1, 1, 180, 180), device=device)
     nc.write(partial_data, partial_coords, array_name)
     assert np.allclose(nc[array_name][0, 0, 0, :, :180], partial_data.to("cpu").numpy())
+
+    xx, _ = nc.read(partial_coords, array_name, device=device)
+    assert torch.allclose(partial_data, xx)
+
     nc.close()
 
     # Test Directory Store
@@ -164,6 +168,10 @@ def test_netcdf4_fields(
             nc[array_name][0, 0, 0, :, :180], partial_data.to("cpu").numpy()
         )
         nc.close()
+
+        nc = NetCDF4Backend(file_name)
+        for coord in nc.coords:
+            assert np.all(total_coords[coord] == nc.coords[coord])
 
 
 @pytest.mark.parametrize(

--- a/test/io/test_xarray.py
+++ b/test/io/test_xarray.py
@@ -104,6 +104,9 @@ def test_xarray_fields(
     z.write(partial_data, partial_coords, array_name)
     assert np.allclose(z[array_name][0, 0, :, :180], partial_data.cpu().numpy())
 
+    xx, _ = z.read(partial_coords, array_name, device=device)
+    assert torch.allclose(partial_data, xx)
+
 
 @pytest.mark.parametrize(
     "time",

--- a/test/io/test_zarr.py
+++ b/test/io/test_zarr.py
@@ -146,6 +146,9 @@ def test_zarr_field(
     z.write(partial_data, partial_coords, array_name)
     assert np.allclose(z[array_name][0, 0, :, :180], partial_data.to("cpu").numpy())
 
+    xx, _ = z.read(partial_coords, array_name, device=device)
+    assert torch.allclose(partial_data, xx)
+
     # Test Directory Store
     with tempfile.TemporaryDirectory() as td:
         file_name = os.path.join(td, "temp_zarr.zarr")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
- Added the ability to reload zarr and netcdf backends
- Added the ability to read from an IOBackend
- NetCDF reads are now mode='r+' instead of 'w'.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
