### PR TITLE
Model Package Update to improve Model file caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NetCDF reads are now mode='r+' instead of 'w'.
 - Change 'output_coords' for models from a property to a method that
   accepts input coordinates to determine the corresponding outputs.
+- Updated Package to use WholeFileCacheFileSystem. Extend package API to open and
+  resolve. Deprication warning added to get.
 
 ### Deprecated
 

--- a/docs/userguide/advanced/auto.md
+++ b/docs/userguide/advanced/auto.md
@@ -70,8 +70,8 @@ primitive abstract filesystem.
 ## Package
 
 The {py:class}`earth2studio.models.auto.Package` class is an abstract representation of
-a remote storage location.
-This class abstracts away the download and caching of files.
+a storage location that contains some artifacts used to load a pre-trained model.
+This class abstracts away the download and caching of files on the local machine.
 Given that a supported remote store type is used, the use of the package class is as
 follows:
 
@@ -82,7 +82,10 @@ from earth2studio.models.auto import Package
 package = Package("ngc://models/nvidia/modulus/modulus_fcn@v0.2")
 
 # Fetch a file from the remote store using the get method
-cached_path_to_file = package.get("fcn.zip")
+cached_path_to_file = package.resolve("fcn.zip")
+
+# Open a buffered reader of the file
+opened_file = package.open("fcn.zip")
 ```
 
 The cached path is a directory on the local file system which can be configured via
@@ -90,8 +93,8 @@ environment variables.
 See {ref}`configuration_userguide` section for details.
 
 :::{note}
-Earth2Studio file system borrows uses and is inspired by
-[Fsspec](https://filesystem-spec.readthedocs.io/en/latest/).
+Earth2Studio file system borrows uses [Fsspec](https://filesystem-spec.readthedocs.io/en/latest/)
+caching for files in packages.
 We encourage users that are interested in this type of utility to learn more about
-Fsspec and the specification it defines.
+Fsspec and the specification it defines for advanced usage.
 :::

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -15,11 +15,262 @@
 # limitations under the License.
 
 import hashlib
+import io
 import os
+import re
 from typing import Any
 
+import fsspec
+import s3fs
+from fsspec.callbacks import Callback, TqdmCallback
+from fsspec.compression import compr
+from fsspec.core import BaseCache
+from fsspec.implementations.cached import LocalTempFile, WholeFileCacheFileSystem
+from fsspec.implementations.http import HTTPFileSystem
+from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
+from fsspec.utils import infer_compression
 from huggingface_hub import HfFileSystem
+from loguru import logger
 from modulus.utils.filesystem import _download_cached
+from tqdm import tqdm
+
+# TODO: Make this package wide? Same as in run.py
+logger.remove()
+logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
+
+
+class CallbackWholeFileCacheFileSystem(WholeFileCacheFileSystem):
+    """Extension of Fsspec WholeFileCacheFileSystem to include callback function when
+    downloading files to cache (progress bar).
+
+    See: https://github.com/fsspec/filesystem_spec/blob/8be9763e5f895073a9f46c8147aebbc64933e013/fsspec/implementations/cached.py#L651
+    """
+
+    def _open(self, path, mode="rb", **kwargs):  # type: ignore
+        path = self._strip_protocol(path)
+        if "r" not in mode:
+            hash = self._mapper(path)
+            fn = os.path.join(self.storage[-1], hash)
+            user_specified_kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                # those kwargs were added by open(), we don't want them
+                if k not in ["autocommit", "block_size", "cache_options"]
+            }
+            return LocalTempFile(self, path, mode=mode, fn=fn, **user_specified_kwargs)
+        detail = self._check_file(path)
+        if detail:
+            detail, fn = detail
+            _, blocks = detail["fn"], detail["blocks"]
+            if blocks is True:
+                f = open(fn, mode)
+                f.original = detail.get("original")
+                return f
+            else:
+                raise ValueError(
+                    f"Attempt to open partially cached file {path}"
+                    f" as a wholly cached file"
+                )
+        else:
+            fn = self._make_local_details(path)
+        kwargs["mode"] = mode
+
+        # call target filesystems open
+        self._mkcache()
+        if self.compression:
+            with self.fs._open(path, **kwargs) as f, open(fn, "wb") as f2:
+                if isinstance(f, AbstractBufferedFile):
+                    # want no type of caching if just downloading whole thing
+                    f.cache = BaseCache(0, f.cache.fetcher, f.size)
+                comp = (
+                    infer_compression(path)
+                    if self.compression == "infer"
+                    else self.compression
+                )
+                f = compr[comp](f, mode="rb")
+                data = True
+                while data:
+                    block = getattr(f, "blocksize", 5 * 2**20)
+                    data = f.read(block)
+                    f2.write(data)  # type: ignore
+        else:
+            if "callback" in kwargs:  # Patch here
+                self.fs.get_file(path, fn, callback=kwargs["callback"])
+            else:
+                self.fs.get_file(path, fn)
+        self.save_cache()
+        return self._open(path, mode)  # type: ignore
+
+
+class TqdmFormat(tqdm):
+    """Provides a `total_time` format parameter. Not used.
+    See: https://filesystem-spec.readthedocs.io/en/stable/api.html#fsspec.callbacks.TqdmCallback
+    """
+
+    @property
+    def format_dict(self) -> dict:
+        d = super().format_dict
+        # total_time = d["elapsed"] * (d["total"] or 0) / max(d["n"], 1)
+        # d.update(total_time=self.format_interval(total_time) + " in total")
+        # d.update(total=round(d["total"] / 10**9), n=round(d["n"] / 10**9))
+        # d.update(n_fmt=f"{round(d['n'] / 10**9)}{d['unit']}")
+        return d
+
+
+class TqdmCallbackRelative(TqdmCallback):
+    """Simple extention of Tqdm callback to support progress bar on recurrive gets"""
+
+    def branched(self, path_1, path_2, **kwargs) -> Callback:  # type: ignore
+        tqdm_kwargs = self._tqdm_kwargs
+        tqdm_kwargs["unit"] = "B"
+        tqdm_kwargs["unit_scale"] = True
+        tqdm_kwargs["unit_divisor"] = 1024
+        callback = TqdmCallback(
+            tqdm_kwargs=tqdm_kwargs,
+            tqdm_cls=self._tqdm_cls,
+        )
+        return callback
+
+
+class PackageV2:
+    """A generic file system abstraction with local caching, uses FSSpec
+    WholeFileCacheFileSystem to manage files. Designed to be used for accessing remote
+    resources, particularly checkpoint files for pre-trained models. Presently supports
+    public folders on NGC, huggingface repos, s3 and any other built in file system
+    Fsspec supports.
+
+    Parameters
+    ----------
+    root : str
+        Root directory for file system
+    fs : AbstractFileSystem | None, optional
+        The target filesystem to run under neath. If none is provided one will get
+        initialized based on root url, by default None
+    cache_options : dict, optional
+        Caching options provided to Fsspec. See CachingFileSystem in fsspec to see
+        valid options https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.cached.CachingFileSystem,
+        by default {}
+    """
+
+    def __init__(
+        self, root: str, fs: AbstractFileSystem | None = None, cache_options: dict = {}
+    ):
+
+        self.cache_options = cache_options.copy()
+        if "cache_storage" not in self.cache_options:
+            self.cache_options["cache_storage"] = os.environ.get(
+                "EARTH2STUDIO_CACHE", self.default_cache()
+            )
+
+        self.root = root
+
+        if fs is not None:
+            pass
+        elif root.startswith("ngc://models/"):
+            # Taken from Modulus file utils
+            # Strip ngc model url prefix
+            suffix = "ngc://models/"
+            # The regex check
+            pattern = re.compile(rf"{suffix}[\w-]+(/[\w-]+)?/[\w-]+@[A-Za-z0-9.]+")
+            if not pattern.match(root):
+                raise ValueError(
+                    "Invalid URL, should be of form ngc://models/<org_id/team_id/model_id>@<version>\n"
+                    + f" got {root}"
+                )
+            root = root.replace(suffix, "")
+            if len(root.split("@")[0].split("/")) == 3:
+                (org, team, model_version) = root.split("/", 2)
+                (model, version) = model_version.split("@", 1)
+            else:
+                (org, model_version) = root.split("/", 1)
+                (model, version) = model_version.split("@", 1)
+                team = None
+            if team:
+                self.root = f"https://api.ngc.nvidia.com/v2/models/{org}/{team}/{model}/versions/{version}/files/"
+            else:
+                self.root = f"https://api.ngc.nvidia.com/v2/models/{org}/{model}/versions/{version}/files/"
+            fs = HTTPFileSystem(block_size=2**10)
+        elif root.startswith("hf://"):
+            fs = HfFileSystem(target_options={"default_block_size": 2**20})
+        elif root.startswith("s3://"):
+            fs = s3fs.S3FileSystem(
+                anon=True,
+                client_kwargs={},
+                target_options={"default_block_size": 2**20},
+            )
+        else:
+            fs = fsspec.filesystem(root)
+
+        self.fs = CallbackWholeFileCacheFileSystem(fs=fs, **self.cache_options)
+
+    @classmethod
+    def default_cache(cls, path: str = "") -> str:
+        """Default cache location for packages located in `~/.cache/earth2studio`
+
+        Parameters
+        ----------
+        path : str, optional
+            Sub-path in cache direction, by default ""
+
+        Returns
+        -------
+        str
+            Local cache path
+        """
+        default_cache = os.path.join(os.path.expanduser("~"), ".cache", "earth2studio")
+        return os.path.join(default_cache, path)
+
+    @property
+    def cache(self) -> str:
+        """Cache path"""
+        return self.cache_options["cache_storage"]
+
+    def open(self, file_path: str) -> io.BufferedReader:
+        """Open file inside package, caching it to local cache store in the process
+
+        Parameters
+        ----------
+        file_path : str
+            Local file path in package directory
+
+        Returns
+        -------
+        io.BufferedReader
+            Opened file, can get file path with BufferedReader.name
+        """
+        full_path = os.path.join(self.root, file_path)
+        filename = os.path.basename(full_path)
+
+        with TqdmCallbackRelative(
+            tqdm_kwargs={
+                "desc": "Earth2Studio Package Download",
+                "bar_format": f"Downloading {filename}: "
+                + "{percentage:.0f}%|{bar}{r_bar}",
+                "unit": "B",
+                "unit_scale": True,
+                "unit_divisor": 1024,
+            },
+            tqdm_cls=TqdmFormat,
+        ) as callback:
+            return self.fs.open(full_path, callback=callback)
+
+    def resolve(self, file_path: str) -> str:
+        """Resolves current relative file path to absolute path inside Package cache
+
+        Parameters
+        ----------
+        path : str
+            local path of file in package directory
+
+        Returns
+        -------
+        str
+            File path inside cache
+        """
+        local_file_path = ""
+        with self.open(file_path) as file:
+            local_file_path = file.name
+        return local_file_path
 
 
 class Package:

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -109,10 +109,6 @@ class TqdmFormat(tqdm):
     @property
     def format_dict(self) -> dict:
         d = super().format_dict
-        # total_time = d["elapsed"] * (d["total"] or 0) / max(d["n"], 1)
-        # d.update(total_time=self.format_interval(total_time) + " in total")
-        # d.update(total=round(d["total"] / 10**9), n=round(d["n"] / 10**9))
-        # d.update(n_fmt=f"{round(d['n'] / 10**9)}{d['unit']}")
         return d
 
 

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -159,6 +159,8 @@ class Package:
         self.cache_options = cache_options.copy()
         if "cache_storage" not in self.cache_options:
             self.cache_options["cache_storage"] = self.default_cache()
+        if "expiry_time" not in self.cache_options:
+            self.cache_options["expiry_time"] = 31622400  # 1 year
 
         self.root = root
 

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -140,8 +140,8 @@ class Package:
     root : str
         Root directory for file system
     fs : AbstractFileSystem | None, optional
-        The target filesystem to run under neath. If none is provided one will get
-        initialized based on root url, by default None
+        The target filesystem to run underneath. If none is provided a fsspec filesystem
+        will get initialized based on the protocal of the root url, by default None
     cache : bool, optional
         Toggle local caching, typically you want this to be true unless the package is
         a local file system, by default True

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -286,7 +286,7 @@ class Package:
             File path inside cache
         """
         warnings.warn(
-            "Package.get(path) depricated. Use Package.resolve(path) instead."
+            "Package.get(path) deprecated. Use Package.resolve(path) instead."
         )
         return self.resolve(file_path)
 

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -129,7 +129,7 @@ class TqdmCallbackRelative(TqdmCallback):
 
 
 class Package:
-    """A generic file system abstraction with local caching, uses FSSpec
+    """A generic file system abstraction with local caching, uses Fsspec
     WholeFileCacheFileSystem to manage files. Designed to be used for accessing remote
     resources, particularly checkpoint files for pre-trained models. Presently supports
     public folders on NGC, huggingface repos, s3 and any other built in file system
@@ -143,7 +143,7 @@ class Package:
         The target filesystem to run under neath. If none is provided one will get
         initialized based on root url, by default None
     cache_options : dict, optional
-        Caching options provided to Fsspec. See CachingFileSystem in fsspec to see
+        Caching options provided to Fsspec. See CachingFileSystem in fsspec for
         valid options https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.cached.CachingFileSystem,
         by default {}
     """

--- a/earth2studio/models/px/fcn.py
+++ b/earth2studio/models/px/fcn.py
@@ -23,7 +23,7 @@ import numpy as np
 import torch
 from modulus.models.afno import AFNO
 
-from earth2studio.models.auto import AutoModelMixin, PackageV2
+from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
@@ -153,12 +153,12 @@ class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return "fcn"
 
     @classmethod
-    def load_default_package(cls) -> PackageV2:  # type: ignore
+    def load_default_package(cls) -> Package:
         """Load prognostic package"""
-        return PackageV2(
+        return Package(
             "ngc://models/nvidia/modulus/modulus_fcn@v0.2",
             cache_options={
-                "cache_storage": PackageV2.default_cache("fcn"),
+                "cache_storage": Package.default_cache("fcn"),
                 "same_names": True,
             },
         )
@@ -166,7 +166,7 @@ class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     @classmethod
     def load_model(
         cls,
-        package: PackageV2,  # type: ignore
+        package: Package,
     ) -> PrognosticModel:
         """Load prognostic from package"""
         fcn_zip = Path(package.resolve("fcn.zip"))

--- a/earth2studio/models/px/fengwu.py
+++ b/earth2studio/models/px/fengwu.py
@@ -28,7 +28,7 @@ except ImportError:
     InferenceSession = TypeVar("InferenceSession")  # type: ignore
 import torch
 
-from earth2studio.models.auto import AutoModelMixin, PackageV2
+from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
@@ -226,12 +226,12 @@ class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return self
 
     @classmethod
-    def load_default_package(cls) -> PackageV2:  # type: ignore
+    def load_default_package(cls) -> Package:
         """Load prognostic package"""
-        return PackageV2(
+        return Package(
             "hf://NickGeneva/earth_ai/fengwu",
             cache_options={
-                "cache_storage": PackageV2.default_cache("fengwu"),
+                "cache_storage": Package.default_cache("fengwu"),
                 "same_names": True,
             },
         )
@@ -239,7 +239,7 @@ class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     @classmethod
     def load_model(
         cls,
-        package: PackageV2,  # type: ignore
+        package: Package,
     ) -> PrognosticModel:
         """Load prognostic from package"""
         onnx_file = package.resolve("fengwu_v1.onnx")

--- a/earth2studio/models/px/fuxi.py
+++ b/earth2studio/models/px/fuxi.py
@@ -236,7 +236,13 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     @classmethod
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
-        return Package("hf://NickGeneva/earth_ai/fuxi")
+        return Package(
+            "hf://NickGeneva/earth_ai/fuxi",
+            cache_options={
+                "cache_storage": Package.default_cache("fuxi"),
+                "same_names": True,
+            },
+        )
 
     @classmethod
     def load_model(
@@ -246,13 +252,13 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         """Load prognostic from package"""
 
         # Short model
-        onnx_short = package.get("short.onnx")
+        onnx_short = package.resolve("short.onnx")
         package.get("short", same_names=True)
         # Medium model
-        onnx_medium = package.get("medium.onnx")
+        onnx_medium = package.resolve("medium.onnx")
         package.get("medium", same_names=True)
         # Long model
-        onnx_long = package.get("long.onnx")
+        onnx_long = package.resolve("long.onnx")
         package.get("long", same_names=True)
 
         return cls(onnx_short, onnx_medium, onnx_long)

--- a/earth2studio/models/px/fuxi.py
+++ b/earth2studio/models/px/fuxi.py
@@ -253,13 +253,13 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
         # Short model
         onnx_short = package.resolve("short.onnx")
-        package.get("short", same_names=True)
+        package.open("short")
         # Medium model
         onnx_medium = package.resolve("medium.onnx")
-        package.get("medium", same_names=True)
+        package.open("medium")
         # Long model
         onnx_long = package.resolve("long.onnx")
-        package.get("long", same_names=True)
+        package.open("long")
 
         return cls(onnx_short, onnx_medium, onnx_long)
 

--- a/earth2studio/models/px/pangu.py
+++ b/earth2studio/models/px/pangu.py
@@ -23,7 +23,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
 from collections import OrderedDict
 from collections.abc import Generator, Iterator
 from typing import TypeVar
@@ -204,7 +203,13 @@ class PanguBase(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     @classmethod
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
-        return Package("hf://NickGeneva/earth_ai/pangu")
+        return Package(
+            "hf://NickGeneva/earth_ai/pangu",
+            cache_options={
+                "cache_storage": Package.default_cache("pangu"),
+                "same_names": True,
+            },
+        )
 
     def to(self, device: str | torch.device | int) -> PrognosticModel:
         """Move model (and default ORT session) to device"""
@@ -370,7 +375,7 @@ class Pangu24(PanguBase):
         # Ghetto at the moment because NGC files are zipped. This will download zip and
         # unpack them then give the cached folder location from which we can then
         # access the needed files.
-        onnx_file = package.get("pangu_weather_24.onnx")
+        onnx_file = package.resolve("pangu_weather_24.onnx")
         return cls(onnx_file)
 
     @batch_func()
@@ -471,8 +476,8 @@ class Pangu6(PanguBase):
         # Ghetto at the moment because NGC files are zipped. This will download zip and
         # unpack them then give the cached folder location from which we can then
         # access the needed files.
-        onnx_file_24 = package.get("pangu_weather_24.onnx")
-        onnx_file_6 = package.get("pangu_weather_6.onnx")
+        onnx_file_24 = package.resolve("pangu_weather_24.onnx")
+        onnx_file_6 = package.resolve("pangu_weather_6.onnx")
         return cls(onnx_file_24, onnx_file_6)
 
     @batch_func()
@@ -589,9 +594,9 @@ class Pangu3(PanguBase):
         # Ghetto at the moment because NGC files are zipped. This will download zip and
         # unpack them then give the cached folder location from which we can then
         # access the needed files.
-        onnx_file_24 = package.get("pangu_weather_24.onnx")
-        onnx_file_6 = package.get("pangu_weather_6.onnx")
-        onnx_file = package.get("pangu_weather_3.onnx")
+        onnx_file_24 = package.resolve("pangu_weather_24.onnx")
+        onnx_file_6 = package.resolve("pangu_weather_6.onnx")
+        onnx_file = package.resolve("pangu_weather_3.onnx")
         return cls(onnx_file_24, onnx_file_6, onnx_file)
 
     @batch_func()

--- a/earth2studio/models/px/sfno.py
+++ b/earth2studio/models/px/sfno.py
@@ -225,6 +225,7 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             },
         )
         package.root = os.path.join(package.root, "sfno_73ch_small")
+        return package
 
     @classmethod
     def load_model(

--- a/earth2studio/models/px/sfno.py
+++ b/earth2studio/models/px/sfno.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import OrderedDict
 from collections.abc import Generator, Iterator
 
@@ -215,9 +216,15 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     @classmethod
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
-        return Package(
-            "ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0/sfno_73ch_small"
+
+        package = Package(
+            "ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0",
+            cache_options={
+                "cache_storage": Package.default_cache("sfno"),
+                "same_names": True,
+            },
         )
+        package.root = os.path.join(package.root, "sfno_73ch_small")
 
     @classmethod
     def load_model(
@@ -234,10 +241,10 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         model.eval()
 
         # Load center and std normalizations
-        local_center = torch.Tensor(np.load(package.get("global_means.npy")))[
+        local_center = torch.Tensor(np.load(package.resolve("global_means.npy")))[
             :, : len(VARIABLES)
         ]
-        local_std = torch.Tensor(np.load(package.get("global_stds.npy")))[
+        local_std = torch.Tensor(np.load(package.resolve("global_stds.npy")))[
             :, : len(VARIABLES)
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "eccodes>=1.4.0",
     "ecmwflibs>=0.5.2",
     "ecmwf-opendata>=0.2.0",
-    "fsspec>=2023.1.0",
+    "fsspec>=2024.2.0",
     "gcsfs",
     "h5py>=3.2.0",
     "h5netcdf>=1.0.0",

--- a/test/models/dx/test_corrdiff.py
+++ b/test/models/dx/test_corrdiff.py
@@ -170,7 +170,7 @@ def test_corrdiff_exceptions(x, device):
 
 
 @pytest.mark.ci_cache
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_corrdiff_package(device, model_cache_context):
     # Test the cached model package CorrDiffTaiwan

--- a/test/models/test_auto_models.py
+++ b/test/models/test_auto_models.py
@@ -88,7 +88,7 @@ def test_package(url, file, cache_folder, model_cache_context):
     if url is None:
         url = "file://" / cache_folder
     with model_cache_context(EARTH2STUDIO_CACHE=str(cache_folder.resolve())):
-        package = Package(url)
+        package = Package(str(url))
         file_path = package.resolve(file)
         assert Path(file_path).is_file()
 
@@ -99,12 +99,12 @@ def test_auto_model_mixin():
         AutoModelMixin.load_default_package()
 
     with pytest.raises(NotImplementedError):
-        package = Package("./package")
+        package = "./package"
         AutoModelMixin.load_model(package)
 
     with pytest.raises(NotImplementedError):
         AutoModelMixin.from_pretrained()
 
     with pytest.raises(NotImplementedError):
-        package = Package("./package")
+        package = "./package"
         AutoModelMixin.from_pretrained(package)

--- a/test/models/test_auto_models.py
+++ b/test/models/test_auto_models.py
@@ -89,7 +89,7 @@ def test_package(url, file, cache_folder, model_cache_context):
         url = "file://" / cache_folder
     with model_cache_context(EARTH2STUDIO_CACHE=str(cache_folder.resolve())):
         package = Package(url)
-        file_path = package.get(file)
+        file_path = package.resolve(file)
         assert Path(file_path).is_file()
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Refactoring of how the `earth2studio.models.px.auto.Package` class works to lean more into Fsspec to use more of their existing caching system as well as provide better downloading feedback for users via tqdm. Also adds better ability to customize caching directly in model, namely default can not hash file names to make cache readable. I made the call to decouple this from Modulus file system, which operates a little differently, because it takes too long to upstream.

**There is a slight "bug"/limitation in Fsspec which is the reason this took long to figure out related to the call back for caching**. Had to  extend the caching cache to fix.

Closes: https://github.com/NVIDIA/earth2studio/issues/46
Closes: https://github.com/NVIDIA/earth2studio/issues/59

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
