### PR TITLE
Adding IMERG Data source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,5 @@ repos:
                 test |
                 docs |
                 earth2studio/models/nn)
-        args: [--show-error-codes, --ignore-missing-imports]
+        args: [--show-error-codes]
         additional_dependencies: ['types-requests']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,3 +72,5 @@ repos:
                 test |
                 docs |
                 earth2studio/models/nn)
+        args: [--show-error-codes, --ignore-missing-imports]
+        additional_dependencies: ['types-requests']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,4 @@ repos:
                 test |
                 docs |
                 earth2studio/models/nn)
-        args: [--show-error-codes]
         additional_dependencies: ['types-requests']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and metrics API.
 - Added Lexicon and Automodel userguide
 - Added an 'output_coords' method to Statistics and Metrics.
+- Added IMERG data source
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ doctest:
 .PHONY: coverage
 coverage:
 	coverage combine
-	coverage report --fail-under=89
+	coverage report --fail-under=90
 
 .PHONY: docs
 docs:

--- a/docs/modules/datasources.rst
+++ b/docs/modules/datasources.rst
@@ -28,6 +28,7 @@ Used for fetching initial conditions for inference and validation data for scori
    data.GFS
    data.HRRR
    data.IFS
+   data.IMERG
    data.Random
    data.WB2ERA5
    data.WB2ERA5_121x240

--- a/earth2studio/data/ifs.py
+++ b/earth2studio/data/ifs.py
@@ -170,7 +170,7 @@ class IFS:
             # Provided [-180, 180], roll to [0, 360]
             da = xr.open_dataarray(
                 grib_file, engine="cfgrib", backend_kwargs={"indexpath": ""}
-            ).roll(longitude=-len(self.IFS_LON) // 2)
+            ).roll(longitude=-len(self.IFS_LON) // 2, roll_coords=True)
             ifsda[0, i] = modifier(da.values)
 
         return ifsda

--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -207,9 +207,7 @@ class IMERG:
             try:
                 imerg_name, modifier = IMERGLexicon[variable]
             except KeyError as e:
-                logger.error(
-                    f"variable id {variable} not found in IMERG lexicon, good luck"
-                )
+                logger.error(f"variable id {variable} not found in IMERG lexicon.")
                 raise KeyError(str(e))
 
             data = np.nan_to_num(raw_ds[imerg_name].isel(time=0).values.T)

--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -42,12 +42,12 @@ LOCAL_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "earth2studio")
 class IMERG:
     """The Integrated Multi-satellitE Retrievals (IMERG) for GPM. MERG is a NASA product
     that estimates the global surface precipitation rates at a high resolution of 0.1
-    degree every half-hour beginning 2000. Provides total, probability and index
+    degree every half-hour beginning in 2000. Provides total, probability and index
     precipitation fields for the past half hour.
 
     Note
     ----
-    This datasource requires users to register for NASA's Earthdata portal:
+    This data source requires users to register for NASA's Earthdata portal:
     https://urs.earthdata.nasa.gov/. Users must supply their username and password
     for AuthN when using this data source. Users should be sure "NASA GESDISC DATA
     ARCHIVE" is an approved application on their profile:
@@ -57,7 +57,7 @@ class IMERG:
     ----------
     auth : aiohttp.BasicAuth | None
         BasicAuth object with user's EarthData username and password for basic HTTP
-        authentication. If none is provide, one will be constructed using the
+        authentication. If none is provided, one will be constructed using the
         `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables, by default
         None
     cache : bool, optional
@@ -78,10 +78,10 @@ class IMERG:
     - https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07
     """
 
-    # PYData doesnt work: https://github.com/pydap/pydap/issues/188
+    # PYDap doesnt work: https://github.com/pydap/pydap/issues/188
 
     IMERG_LAT = np.linspace(89.95, -89.95, 1800)
-    IMERG_LON = np.linspace(0, 359.9, 3600)
+    IMERG_LON = np.linspace(0.05, 359.95, 3600)
 
     def __init__(
         self,
@@ -105,7 +105,7 @@ class IMERG:
                 or "EARTHDATA_PASSWORD" not in os.environ
             ):
                 raise ValueError(
-                    "Both environment variables EARTHDATA_USERNAME and EARTHDATA_PASSWORD must be set to NASA Earthdata credentials for IMERG datasource."
+                    "Both environment variables EARTHDATA_USERNAME and EARTHDATA_PASSWORD must be set to NASA Earthdata credentials for IMERG data source."
                 )
             auth = aiohttp.BasicAuth(
                 os.environ["EARTHDATA_USERNAME"], os.environ["EARTHDATA_PASSWORD"]
@@ -158,7 +158,7 @@ class IMERG:
         time: datetime,
         variables: list[str],
     ) -> xr.DataArray:
-        """Retrives IMERG H5 file for time and moves it into a xarray data array. This
+        """Retrives IMERG H5 file for time and moves it into an xarray data array. This
         will download all variables / coords for this specific time since OpenDAP isn't
         working.
 
@@ -177,7 +177,7 @@ class IMERG:
         Raises
         ------
         KeyError
-            Un supported variable.
+            Unsupported variable
         """
         logger.debug(f"Fetching IMERG H5 file for: {time}")
         h5_file = self.fs.open(self.get_file_url(time)).name
@@ -223,8 +223,8 @@ class IMERG:
 
         Note
         ----
-        See opendap repository for more information on what files are available:
-        https://gpm1.gesdisc.eosdis.nasa.gov/opendap/GPM_L3/GPM_3IMERGHH.07/
+        See repository for more information on what files are available:
+        https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07/
 
         Parameters
         ----------

--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import shutil
+from datetime import datetime, timedelta
+
+import aiohttp
+import numpy as np
+import requests
+import xarray as xr
+from fsspec.implementations.cached import WholeFileCacheFileSystem
+from fsspec.implementations.http import HTTPFileSystem
+from loguru import logger
+from modulus.distributed.manager import DistributedManager
+from tqdm import tqdm
+
+from earth2studio.data.utils import prep_data_inputs
+from earth2studio.lexicon import IMERGLexicon
+from earth2studio.utils.type import TimeArray, VariableArray
+
+logger.remove()
+logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
+
+LOCAL_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "earth2studio")
+
+
+class IMERG:
+    """The Integrated Multi-satellitE Retrievals (IMERG) for GPM. MERG is a NASA product
+    that estimates the global surface precipitation rates at a high resolution of 0.1
+    degree every half-hour beginning 2000. Provides total, probability and index
+    precipitation fields for the past half hour.
+
+    Note
+    ----
+    This datasource requires users to register for NASA's Earthdata portal:
+    https://urs.earthdata.nasa.gov/. Users must supply their username and password
+    for AuthN when using this data source. Users should be sure "NASA GESDISC DATA
+    ARCHIVE" is an approved application on their profile:
+    https://urs.earthdata.nasa.gov/profile
+
+    Parameters
+    ----------
+    auth : aiohttp.BasicAuth | None
+        BasicAuth object with user's EarthData username and password for basic HTTP
+        authentication. If none is provide, one will be constructed using the
+        `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables, by default
+        None
+    cache : bool, optional
+        Cache data source on local memory, by default True
+    verbose : bool, optional
+        Print download progress, by default True
+
+    Warning
+    -------
+    This is a remote data source and can potentially download a large amount of data
+    to your local machine for large requests.
+
+    Note
+    ----
+    Additional information on the data repository can be referenced here:
+
+    - https://disc.gsfc.nasa.gov/datasets/GPM_3IMERGHH_07/summary
+    - https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07
+    """
+
+    # PYData doesnt work: https://github.com/pydap/pydap/issues/188
+
+    IMERG_LAT = np.linspace(-89.95, 89.95, 1800)
+    IMERG_LON = np.linspace(0, 359.9, 3600)
+
+    def __init__(
+        self, auth: aiohttp.BasicAuth | None, cache: bool = True, verbose: bool = True
+    ):
+        self._cache = cache
+        self._verbose = verbose
+
+        cache_options: dict[str, str | int] = {}
+        cache_options["cache_storage"] = self.cache
+        cache_options["expiry_time"] = 31622400
+
+        if auth is None:
+            auth = aiohttp.BasicAuth(
+                os.environ["EARTHDATA_USERNAME"], os.environ["EARTHDATA_PASSWORD"]
+            )
+        self.fs = HTTPFileSystem(block_size=2**20, client_kwargs={"auth": auth})
+        if cache:
+            self.fs = WholeFileCacheFileSystem(fs=self.fs, **cache_options)
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve IMERG data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the IMERG lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            IMERG data array
+        """
+        time, variable = prep_data_inputs(time, variable)
+
+        # Create cache dir if doesnt exist
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        # Make sure input time is valid
+        self._validate_time(time)
+
+        # Fetch index file for requested time
+        data_arrays = []
+        for t0 in time:  # TODO: Tqdm
+            data_array = self.fetch_imerg_dataarray(t0, variable)
+            data_arrays.append(data_array)
+
+        # Delete cache if needed
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        return xr.concat(data_arrays, dim="time")
+
+    def fetch_imerg_dataarray(
+        self,
+        time: datetime,
+        variables: list[str],
+    ) -> xr.DataArray:
+        """Retrives IMERG H5 file for time and moves it into a xarray data array. This
+        will download all variables / coords for this specific time since OpenDAP isn't
+        working.
+
+        Parameters
+        ----------
+        time : datetime
+            Date time to fetch
+        variables : list[str]
+            list of atmosphric variables to fetch. Must be supported in IMERG lexicon
+
+        Returns
+        -------
+        xr.DataArray
+            IMERG data array for given date time
+
+        Raises
+        ------
+        KeyError
+            Un supported variable.
+        """
+        logger.debug(f"Fetching IMERG H5 file for: {time}")
+        h5_file = self.fs.open(self.get_file_url(time)).name
+
+        # Roll raw data from [-180, 180] to  [0, 360]
+        raw_ds = xr.open_dataset(h5_file, group="Grid").roll(
+            longitude=-len(self.IMERG_LON) // 2
+        )
+
+        imergda = xr.DataArray(
+            data=np.empty(
+                (1, len(variables), len(self.IMERG_LAT), len(self.IMERG_LON))
+            ),
+            dims=["time", "variable", "lat", "lon"],
+            coords={
+                "time": [time],
+                "variable": variables,
+                "lat": self.IMERG_LAT,
+                "lon": self.IMERG_LON,
+            },
+        )
+
+        for i, variable in enumerate(variables):
+            # Convert from Earth2Studio variable ID to IMERG id and modifier
+            try:
+                imerg_name, modifier = IMERGLexicon[variable]
+            except KeyError:
+                logger.warning(
+                    f"variable id {variable} not found in IMERG lexicon, good luck"
+                )
+                imerg_name = variable
+
+                def modifier(x: np.array) -> np.array:
+                    """Modify data (if necessary)."""
+                    return x
+
+            imergda[0, i] = modifier(raw_ds[imerg_name].isel(time=0).values.T)
+
+        return imergda
+
+    @classmethod
+    def get_file_url(cls, time: datetime) -> str:
+        """Returns the IMERG H5 file for a requested date
+
+        Note
+        ----
+        See opendap repository for more information on what files are available:
+        https://gpm1.gesdisc.eosdis.nasa.gov/opendap/GPM_L3/GPM_3IMERGHH.07/
+
+        Parameters
+        ----------
+        time : datetime
+            Date time of data to get
+
+        Returns
+        -------
+        str
+            Data file url
+        """
+        dataset_url = "https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07"
+
+        start_time = time - timedelta(minutes=30)
+        end_time = time - timedelta(seconds=1)
+
+        date_str = start_time.strftime("%Y%m%d")
+        start_str = start_time.strftime("%H%M%S")
+        end_str = end_time.strftime("%H%M%S")
+        min_idx = 60 * start_time.hour + start_time.minute
+
+        year = start_time.year
+        yrday = start_time.timetuple().tm_yday
+
+        file_name = f"3B-HHR.MS.MRG.3IMERG.{date_str}-S{start_str}-E{end_str}.{min_idx:04d}.V07B.HDF5"
+        return f"{dataset_url}/{year}/{yrday:03d}/{file_name}"
+
+    @classmethod
+    def _validate_time(cls, times: list[datetime]) -> None:
+        """Verify if date times are valid for IMERG based on offline knowledge
+
+        Parameters
+        ----------
+        times : list[datetime]
+            list of date times to fetch data
+        """
+        for time in times:
+            if not (time - datetime(1900, 1, 1)).total_seconds() % 1800 == 0:
+                raise ValueError(
+                    f"Requested date time {time} needs to be 30 minute interval for IMERG"
+                )
+
+            if time < datetime(year=2000, month=6, day=1, minute=30):
+                raise ValueError(
+                    f"Requested date time {time} needs to be after June 1st, 2000 for IMERG"
+                )
+
+    @property
+    def cache(self) -> str:
+        """Return appropriate cache location."""
+        cache_location = os.path.join(LOCAL_CACHE, "imerg")
+        if not self._cache:
+            cache_location = os.path.join(
+                cache_location, f"tmp_{DistributedManager().rank}"
+            )
+        return cache_location
+
+    @classmethod
+    def available(
+        cls,
+        time: datetime | np.datetime64,
+    ) -> bool:
+        """Checks if given date time is avaliable in IMERG
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date time to access
+
+        Returns
+        -------
+        bool
+            If date time is avaiable
+        """
+        if isinstance(time, np.datetime64):  # np.datetime64 -> datetime
+            _unix = np.datetime64(0, "s")
+            _ds = np.timedelta64(1, "s")
+            time = datetime.utcfromtimestamp((time - _unix) / _ds)
+
+        # Offline checks
+        try:
+            cls._validate_time([time])
+        except ValueError:
+            return False
+
+        response = requests.get(cls.get_file_url(time), timeout=5)
+        return response.status_code < 404

--- a/earth2studio/lexicon/__init__.py
+++ b/earth2studio/lexicon/__init__.py
@@ -19,4 +19,5 @@ from .cds import CDSLexicon
 from .gfs import GFSLexicon
 from .hrrr import HRRRLexicon
 from .ifs import IFSLexicon
+from .imerg import IMERGLexicon
 from .wb2 import WB2Lexicon

--- a/earth2studio/lexicon/base.py
+++ b/earth2studio/lexicon/base.py
@@ -35,6 +35,8 @@ E2STUDIO_VOCAB = {
     "msl": "mean sea level pressure",
     "tcwv": "total column water vapor",
     "tp": "total precipitation",
+    "tpp": "total precipitation probability",
+    "tpi": "total precipitation index",
     "tp06": "total precipitation accumulated over past 6 hours",
     "fg10m": "maximum 10 m wind gust since previous post-processing",
     "lsm": "land-sea mask",

--- a/earth2studio/lexicon/imerg.py
+++ b/earth2studio/lexicon/imerg.py
@@ -14,15 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .arco import ARCO
-from .base import DataSource
-from .cds import CDS
-from .gfs import GFS
-from .hrrr import HRRR
-from .ifs import IFS
-from .imerg import IMERG
-from .rand import Random
-from .rx import CosineSolarZenith, LandSeaMask, SurfaceGeoPotential
-from .utils import datasource_to_file, fetch_data, prep_data_array
-from .wb2 import WB2ERA5, WB2Climatology, WB2ERA5_32x64, WB2ERA5_121x240
-from .xr import DataArrayFile, DataSetFile
+from collections.abc import Callable
+
+import numpy as np
+
+from .base import LexiconType
+
+
+class IMERGLexicon(metaclass=LexiconType):
+    """IMERG Lexicon"""
+
+    VOCAB = {
+        "tp": "precipitation",
+        "tpp": "probabilityLiquidPrecipitation",
+        "tpi": "precipitationQualityIndex",
+    }
+
+    @classmethod
+    def get_item(cls, val: str) -> tuple[str, Callable]:
+        """Return name in IMERG vocabulary."""
+        imerg_key = cls.VOCAB[val]
+
+        def mod(x: np.array) -> np.array:
+            """Modify name (if necessary)."""
+            return x
+
+        return imerg_key, mod

--- a/earth2studio/models/auto.py
+++ b/earth2studio/models/auto.py
@@ -273,6 +273,8 @@ class Package:
         str
             File path inside cache
         """
+        # WARNING: THIS CAN FAIL IF FILE DOES NOT HAVE NAME ATTRIB. BUFFERED FILE TYPES
+        # ARE NOT SUPPORTED HERE. NEED TO LOOK INTO THIS MORE.
         local_file_path = ""
         with self.open(file_path) as file:
             local_file_path = file.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,14 +87,15 @@ all = [
     "tensorly-torch"
 ]
 dev = [
+    "black==22.10.0",
+    "coverage>=7.2.0",
+    "interrogate==1.5.0",
     "pre-commit",
     "pytest>=6.0.0",
     "pytest-timeout>=2.0.1",
     "pytest-skip-slow>=0.0.5",
     "pyyaml>=6.0",
-    "black==22.10.0",
-    "interrogate==1.5.0",
-    "coverage>=7.2.0",
+    "types-requests",
     "ruff==0.1.5",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,4 +211,5 @@ check_untyped_defs = true
 implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-follow_imports = 'skip' # TODO: Should eventually shut off
+ignore_missing_imports = true # Don't look at imports
+follow_imports = 'skip'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,5 +211,4 @@ check_untyped_defs = true
 implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-ignore_missing_imports = true # Don't look at imports
 follow_imports = 'skip'

--- a/test/data/test_imerg.py
+++ b/test/data/test_imerg.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import pathlib
+import shutil
+
+import numpy as np
+import pytest
+
+from earth2studio.data import IMERG
+
+
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize(
+    "time",
+    [
+        datetime.datetime(year=2002, month=10, day=1),
+        [
+            datetime.datetime(year=2006, month=8, day=8, hour=4, minute=30),
+            datetime.datetime(year=2016, month=4, day=20, hour=20),
+        ],
+    ],
+)
+@pytest.mark.parametrize("variable", ["tp", ["tpi"]])
+def test_imerg_fetch(time, variable):
+
+    ds = IMERG(cache=False)
+    data = ds(time, variable)
+
+    shape = data.shape
+
+    if isinstance(variable, str):
+        variable = [variable]
+
+    if isinstance(time, datetime.datetime):
+        time = [time]
+
+    assert shape[0] == len(time)
+    assert shape[1] == len(variable)
+    assert shape[2] == 1800
+    assert shape[3] == 3600
+    assert not np.isnan(data.values).any()
+    assert IMERG.available(time[0])
+    assert np.array_equal(data.coords["variable"].values, np.array(variable))
+
+
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize(
+    "time",
+    [
+        np.array([np.datetime64("2024-01-01T16:00")]),
+    ],
+)
+@pytest.mark.parametrize("variable", [["tp", "tpp"]])
+@pytest.mark.parametrize("cache", [True, False])
+def test_imerge_cache(time, variable, cache):
+
+    ds = IMERG(cache=cache)
+    data = ds(time, variable)
+    shape = data.shape
+
+    assert shape[0] == 1
+    assert shape[1] == 2
+    assert shape[2] == 1800
+    assert shape[3] == 3600
+    assert not np.isnan(data.values).any()
+    assert IMERG.available(time[0])
+    # Cahce should be present
+    assert pathlib.Path(ds.cache).is_dir() == cache
+
+    # Load from cach or refetch
+    data = ds(time, variable[0])
+    shape = data.shape
+
+    assert shape[0] == 1
+    assert shape[1] == 1
+    assert shape[2] == 1800
+    assert shape[3] == 3600
+    assert not np.isnan(data.values).any()
+    assert IMERG.available(time[0])
+
+    try:
+        shutil.rmtree(ds.cache)
+    except FileNotFoundError:
+        pass
+
+
+@pytest.mark.timeout(15)
+@pytest.mark.parametrize(
+    "time",
+    [
+        datetime.datetime(year=2020, month=2, day=1, hour=12, minute=2),
+        datetime.datetime(year=2000, month=6, day=1),
+        datetime.datetime(year=2050, month=1, day=1),
+    ],
+)
+@pytest.mark.parametrize("variable", ["tp"])
+def test_imerg_available(time, variable):
+    assert not IMERG.available(time)
+    with pytest.raises((ValueError, FileNotFoundError)):
+        ds = IMERG()
+        ds(time, variable)
+
+
+if __name__ == "__main__":
+    from earth2studio.data import WB2ERA5
+
+    date = datetime.datetime(year=2002, month=10, day=1)
+
+    wbds = WB2ERA5(cache=False)
+    imergds = IMERG(cache=False)
+
+    wb_data = wbds(time=date, variable=["tp06"])
+    im_data = imergds(time=date, variable=["tp"])
+
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
+
+    fig, ax = plt.subplots(1, 2)
+
+    ax[0].imshow(wb_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
+    ax[0].set_title("ERA5")
+    ax[1].imshow(im_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
+    ax[1].set_title("IMERG")
+
+    plt.savefig("test.png")

--- a/test/data/test_imerg.py
+++ b/test/data/test_imerg.py
@@ -118,27 +118,3 @@ def test_imerg_available(time, variable):
     with pytest.raises((ValueError, FileNotFoundError)):
         ds = IMERG()
         ds(time, variable)
-
-
-if __name__ == "__main__":
-    from earth2studio.data import WB2ERA5
-
-    date = datetime.datetime(year=2002, month=10, day=1)
-
-    wbds = WB2ERA5(cache=False)
-    imergds = IMERG(cache=False)
-
-    wb_data = wbds(time=date, variable=["tp06"])
-    im_data = imergds(time=date, variable=["tp"])
-
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import LogNorm
-
-    fig, ax = plt.subplots(1, 2)
-
-    ax[0].imshow(wb_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
-    ax[0].set_title("ERA5")
-    ax[1].imshow(im_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
-    ax[1].set_title("IMERG")
-
-    plt.savefig("test.png")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adding IMERG data source, the first data source using NASA's earth data portal. Validated output / transforms by comparing WB2 and IMERG at specific time. Both have the same larger structures indicating transforms are correct.

```python
    from earth2studio.data import WB2ERA5

    date = datetime.datetime(year=2002, month=10, day=1)

    wbds = WB2ERA5(cache=False)
    imergds = IMERG(cache=False)

    wb_data = wbds(time=date, variable=["tp06"])
    im_data = imergds(time=date, variable=["tp"])

    import matplotlib.pyplot as plt
    from matplotlib.colors import LogNorm

    fig, ax = plt.subplots(1, 2)

    ax[0].imshow(wb_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
    ax[0].set_title("ERA5")
    ax[1].imshow(im_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=1))
    ax[1].set_title("IMERG")

    plt.savefig("test.png")
```

![test](https://github.com/NVIDIA/earth2studio/assets/5533524/e2c4437c-9e00-4571-b0f3-69268790b80a)


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
