### PR TITLE
Updating IMERG total precip data to meters

### DIFF
--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -42,8 +42,8 @@ LOCAL_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "earth2studio")
 class IMERG:
     """The Integrated Multi-satellitE Retrievals (IMERG) for GPM. MERG is a NASA product
     that estimates the global surface precipitation rates at a high resolution of 0.1
-    degree every half-hour beginning in 2000. Provides total, probability and index
-    precipitation fields for the past half hour.
+    degree every half-hour beginning in 2000. Provides total (m/hr), probability and
+    index precipitation fields for the past half hour.
 
     Note
     ----

--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -40,10 +40,10 @@ LOCAL_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "earth2studio")
 
 
 class IMERG:
-    """The Integrated Multi-satellitE Retrievals (IMERG) for GPM. MERG is a NASA product
-    that estimates the global surface precipitation rates at a high resolution of 0.1
-    degree every half-hour beginning in 2000. Provides total (m/hr), probability and
-    index precipitation fields for the past half hour.
+    """The Integrated Multi-satellitE Retrievals (IMERG) for GPM. IMERG is a NASA
+    product that estimates the global surface precipitation rates at a high resolution
+    of 0.1 degree every half-hour beginning in 2000. Provides total (m/hr), probability
+    and index precipitation fields for the past half hour.
 
     Note
     ----

--- a/earth2studio/lexicon/base.py
+++ b/earth2studio/lexicon/base.py
@@ -34,7 +34,7 @@ E2STUDIO_VOCAB = {
     "sp": "surface pressure",
     "msl": "mean sea level pressure",
     "tcwv": "total column water vapor",
-    "tp": "total precipitation",
+    "tp": "total precipitation in meters",
     "tpp": "total precipitation probability",
     "tpi": "total precipitation index",
     "tp06": "total precipitation accumulated over past 6 hours",

--- a/earth2studio/lexicon/imerg.py
+++ b/earth2studio/lexicon/imerg.py
@@ -34,9 +34,17 @@ class IMERGLexicon(metaclass=LexiconType):
     def get_item(cls, val: str) -> tuple[str, Callable]:
         """Return name in IMERG vocabulary."""
         imerg_key = cls.VOCAB[val]
+        if val == "tp":
+            # IMERG is mm/hr by default, convert to meters to match ECMWF
+            # https://arthurhou.pps.eosdis.nasa.gov/Documents/IMERG_TechnicalDocumentation_final.pdf
+            def mod(x: np.array) -> np.array:
+                """Modify data value (if necessary)."""
+                return x / 1000.0
 
-        def mod(x: np.array) -> np.array:
-            """Modify name (if necessary)."""
-            return x
+        else:
+
+            def mod(x: np.array) -> np.array:
+                """Modify name (if necessary)."""
+                return x
 
         return imerg_key, mod


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

IMERG provides total precip in mm, add modifier in lexicon to move to m.
https://arthurhou.pps.eosdis.nasa.gov/Documents/IMERG_TechnicalDocumentation_final.pdf

```python
import datetime
from earth2studio.data import IMERG, ARCO

date = datetime.datetime(year=2002, month=10, day=1)

wbds = ARCO(cache=False)
imergds = IMERG(cache=False)

wb_data = wbds(time=date, variable=["tp"])
im_data = imergds(time=date, variable=["tp"])

import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm

fig, ax = plt.subplots(1, 2)

ax[0].imshow(wb_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=0.1))
ax[0].set_title("ERA5 tp")
ax[1].imshow(im_data.values[0, 0] + 0.001, norm=LogNorm(vmin=0.0001, vmax=0.1))
ax[1].set_title("IMERG tp")

plt.savefig("test.png")
```

![test](https://github.com/NVIDIA/earth2studio/assets/5533524/3e54a51e-2535-4bb8-a21a-737b99d3ac6b)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
