### PR TITLE
Add tensor noise amplitude parameters for perturbation methods

### DIFF
--- a/earth2studio/models/dx/identity.py
+++ b/earth2studio/models/dx/identity.py
@@ -58,7 +58,6 @@ class Identity(torch.nn.Module):
         CoordSystem
             Coordinate system dictionary
         """
-
         return input_coords.copy()
 
     @torch.inference_mode()

--- a/earth2studio/perturbation/brown.py
+++ b/earth2studio/perturbation/brown.py
@@ -25,13 +25,16 @@ class Brown:
 
     Parameters
     ----------
-    noise_amplitude : float, optional
-        Noise amplitude, by default 0.05
+    noise_amplitude : float | Tensor, optional
+        Noise amplitude, by default 0.05. If a tensor,
+        this must be broadcastable with the input data.
     reddening : int, optional
         Reddening in Fourier space, by default 2
     """
 
-    def __init__(self, noise_amplitude: float = 0.05, reddening: int = 2):
+    def __init__(
+        self, noise_amplitude: float | torch.Tensor = 0.05, reddening: int = 2
+    ):
         self.reddening = reddening
         self.noise_amplitude = noise_amplitude
 

--- a/earth2studio/perturbation/brown.py
+++ b/earth2studio/perturbation/brown.py
@@ -36,7 +36,11 @@ class Brown:
         self, noise_amplitude: float | torch.Tensor = 0.05, reddening: int = 2
     ):
         self.reddening = reddening
-        self.noise_amplitude = noise_amplitude
+        self.noise_amplitude = (
+            noise_amplitude
+            if isinstance(noise_amplitude, torch.Tensor)
+            else torch.Tensor([noise_amplitude])
+        )
 
     @torch.inference_mode()
     def __call__(
@@ -65,8 +69,8 @@ class Brown:
         handshake_dim(coords, required_dim="lon", required_index=-1)
 
         noise = self._generate_noise_correlated(tuple(shape), device=x.device)
-
-        return x + self.noise_amplitude * noise, coords
+        noise_amplitude = self.noise_amplitude.to(x.device)
+        return x + noise_amplitude * noise, coords
 
     def _generate_noise_correlated(
         self, shape: tuple[int, ...], device: torch.device

--- a/earth2studio/perturbation/bv.py
+++ b/earth2studio/perturbation/bv.py
@@ -33,8 +33,9 @@ class BredVector:
     model : Callable[[torch.Tensor], torch.Tensor]
         Dynamical model, typically this is the prognostic AI model.
         TODO: Update to prognostic looper
-    noise_amplitude : float, optional
-        Noise amplitude, by default 0.05
+    noise_amplitude : float | Tensor, optional
+        Noise amplitude, by default 0.05. If a tensor,
+        this must be broadcastable with the input data.
     integration_steps : int, optional
         Number of integration steps to use in forward call, by default 20
     ensemble_perturb : bool, optional
@@ -56,7 +57,7 @@ class BredVector:
             [torch.Tensor, CoordSystem],
             tuple[torch.Tensor, CoordSystem],
         ],
-        noise_amplitude: float = 0.05,
+        noise_amplitude: float | torch.Tensor = 0.05,
         integration_steps: int = 20,
         ensemble_perturb: bool = False,
         seeding_perturbation_method: Perturbation = Brown(),

--- a/earth2studio/perturbation/gaussian.py
+++ b/earth2studio/perturbation/gaussian.py
@@ -30,7 +30,11 @@ class Gaussian:
     """
 
     def __init__(self, noise_amplitude: float | torch.Tensor = 0.05):
-        self.noise_amplitude = noise_amplitude
+        self.noise_amplitude = (
+            noise_amplitude
+            if isinstance(noise_amplitude, torch.Tensor)
+            else torch.Tensor([noise_amplitude])
+        )
 
     @torch.inference_mode()
     def __call__(
@@ -52,4 +56,5 @@ class Gaussian:
         tuple[torch.Tensor, CoordSystem]:
             Output tensor and respective coordinate system dictionary
         """
-        return x + self.noise_amplitude * torch.randn_like(x), coords
+        noise_amplitude = self.noise_amplitude.to(x.device)
+        return x + noise_amplitude * torch.randn_like(x), coords

--- a/earth2studio/perturbation/gaussian.py
+++ b/earth2studio/perturbation/gaussian.py
@@ -24,11 +24,12 @@ class Gaussian:
 
     Parameters
     ----------
-    noise_amplitude : float, optional
-        Noise amplitude, by default 0.05
+    noise_amplitude : float | Tensor, optional
+        Noise amplitude, by default 0.05. If a tensor,
+        this must be broadcastable with the input data.
     """
 
-    def __init__(self, noise_amplitude: float = 0.05):
+    def __init__(self, noise_amplitude: float | torch.Tensor = 0.05):
         self.noise_amplitude = noise_amplitude
 
     @torch.inference_mode()

--- a/earth2studio/perturbation/spherical.py
+++ b/earth2studio/perturbation/spherical.py
@@ -51,7 +51,11 @@ class SphericalGaussian:
         tau: float = 3.0,
         sigma: float | None = None,
     ):
-        self.noise_amplitude = noise_amplitude
+        self.noise_amplitude = (
+            noise_amplitude
+            if isinstance(noise_amplitude, torch.Tensor)
+            else torch.Tensor([noise_amplitude])
+        )
         self.alpha = alpha
         self.tau = tau
         self.sigma = sigma
@@ -107,7 +111,8 @@ class SphericalGaussian:
         else:
             noise = sample_noise
 
-        return x + self.noise_amplitude * noise, coords
+        noise_amplitude = self.noise_amplitude.to(x.device)
+        return x + noise_amplitude * noise, coords
 
 
 class GaussianRandomFieldS2(torch.nn.Module):

--- a/earth2studio/perturbation/spherical.py
+++ b/earth2studio/perturbation/spherical.py
@@ -33,8 +33,9 @@ class SphericalGaussian:
 
     Parameters
     ----------
-    noise_amplitude : float, optional
-        Noise amplitude, by default 0.05
+    noise_amplitude : float | Tensor, optional
+        Noise amplitude, by default 0.05. If a tensor,
+        this must be broadcastable with the input data.
     alpha : float, optional
         Regularity parameter. Larger means smoother, by default 2.0
     tau : float, optional
@@ -45,7 +46,7 @@ class SphericalGaussian:
 
     def __init__(
         self,
-        noise_amplitude: float = 0.05,
+        noise_amplitude: float | torch.Tensor = 0.05,
         alpha: float = 2.0,
         tau: float = 3.0,
         sigma: float | None = None,

--- a/test/perturbation/test_brown.py
+++ b/test/perturbation/test_brown.py
@@ -37,7 +37,7 @@ from earth2studio.perturbation import Brown
 )
 @pytest.mark.parametrize(
     "amplitude,reddening",
-    [[1.0, 2], [0.05, 3]],
+    [[1.0, 2], [0.05, 3], ["tensor", 2]],
 )
 @pytest.mark.parametrize(
     "device",
@@ -55,6 +55,10 @@ def test_brown(x, coords, amplitude, reddening, device):
 
     x = x.to(device)
 
+    if amplitude == "tensor":
+        amplitude = torch.randn(
+            [x.shape[list(coords).index("variable")], 1, 1], device=device
+        )
     prtb = Brown(amplitude, reddening)
     xout, coords = prtb(x, coords)
     dx = xout - x

--- a/test/perturbation/test_bv.py
+++ b/test/perturbation/test_bv.py
@@ -52,7 +52,7 @@ def model():
 )
 @pytest.mark.parametrize(
     "amplitude,steps,ensemble",
-    [[1.0, 5, False], [1.0, 3, True]],
+    [[1.0, 5, False], [1.0, 3, True], ["tensor", 2, True]],
 )
 @pytest.mark.parametrize(
     "seeding_perturbation_method",
@@ -77,6 +77,11 @@ def test_bred_vec(
     model = model.to(device)
     model.index = 0
     x = x.to(device)
+
+    if amplitude == "tensor":
+        amplitude = torch.randn(
+            [x.shape[list(coords).index("variable")], 1, 1], device=device
+        )
 
     prtb = BredVector(model, amplitude, steps, ensemble, seeding_perturbation_method)
     xout, coords = prtb(x, coords)

--- a/test/perturbation/test_spherical_gaussian.py
+++ b/test/perturbation/test_spherical_gaussian.py
@@ -27,14 +27,17 @@ from earth2studio.perturbation import SphericalGaussian
     [
         [
             torch.randn(1, 2, 16, 32),
-            OrderedDict([("a", []), ("b", []), ("lat", []), ("lon", [])]),
+            OrderedDict([("a", []), ("variable", []), ("lat", []), ("lon", [])]),
         ],
-        [torch.randn(2, 17, 32), OrderedDict([("a", []), ("lat", []), ("lon", [])])],
+        [
+            torch.randn(2, 17, 32),
+            OrderedDict([("variable", []), ("lat", []), ("lon", [])]),
+        ],
     ],
 )
 @pytest.mark.parametrize(
     "amplitude,alpha,tau,sigma",
-    [[1.0, 2.0, 3.0, None], [0.05, 1.0, 10.0, 2.0]],
+    [[1.0, 2.0, 3.0, None], [0.05, 1.0, 10.0, 2.0], ["tensor", 1.0, 10.0, 2.0]],
 )
 @pytest.mark.parametrize(
     "device",
@@ -51,7 +54,10 @@ from earth2studio.perturbation import SphericalGaussian
 def test_spherical_gaussian(x, coords, amplitude, alpha, tau, sigma, device):
 
     x = x.to(device)
-
+    if amplitude == "tensor":
+        amplitude = torch.randn(
+            [x.shape[list(coords).index("variable")], 1, 1], device=device
+        )
     prtb = SphericalGaussian(amplitude, alpha, tau, sigma)
     xout, coords = prtb(x, coords)
     dx = xout - x


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
This is a backward compatible PR that adds the ability to pass broadcastable tensors as noise amplitudes in relevant perturbation methods.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
