### PR TITLE
Remove non-blocking IO writes

### DIFF
--- a/earth2studio/io/kv.py
+++ b/earth2studio/io/kv.py
@@ -169,7 +169,7 @@ class KVBackend:
                             for dim, value in coords.items()
                         ]
                     )
-                ] = xi.to(self.device, non_blocking=True)
+                ] = xi.to(self.device)
 
     def to_xarray(self, **xr_kwargs: Any) -> xarray.Dataset:
         """

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -245,7 +245,7 @@ class NetCDF4Backend:
                             for dim, value in coords.items()
                         ]
                     )
-                ] = xi.to("cpu", non_blocking=True).numpy()
+                ] = xi.to("cpu").numpy()
 
     def read(
         self, coords: CoordSystem, array_name: str, device: torch.device = "cpu"

--- a/earth2studio/io/xarray.py
+++ b/earth2studio/io/xarray.py
@@ -169,7 +169,7 @@ class XarrayBackend:
                             for dim, value in coords.items()
                         ]
                     )
-                ] = xi.to("cpu", non_blocking=True).numpy()
+                ] = xi.to("cpu").numpy()
 
     def read(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
This PR removes `non_blocking=True` from `.to()` statements that were causing hard-to-trace IO issues.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
