### PR TITLE
Making Asyncio ARCO runnable in notebook

### DIFF
--- a/earth2studio/data/arco.py
+++ b/earth2studio/data/arco.py
@@ -249,6 +249,8 @@ class ARCO:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "arco")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/arco.py
+++ b/earth2studio/data/arco.py
@@ -18,6 +18,7 @@ import asyncio
 import os
 import pathlib
 import shutil
+import threading
 from datetime import datetime
 
 import fsspec
@@ -119,9 +120,23 @@ class ARCO:
         # Make sure input time is valid
         self._validate_time(time)
 
-        xr_array = asyncio.run(
-            asyncio.wait_for(self.create_data_array(time, variable), self.async_timeout)
-        )
+        # This makes this function safe in existing async io loops
+        # I.e. runnable in Jupyter notebooks
+        xr_array = None
+
+        def thread_func() -> None:
+            """Function to call in seperate thread"""
+            nonlocal xr_array
+            loop = asyncio.new_event_loop()
+            xr_array = loop.run_until_complete(
+                asyncio.wait_for(
+                    self.create_data_array(time, variable), timeout=self.async_timeout
+                )
+            )
+
+        thread = threading.Thread(target=thread_func)
+        thread.start()
+        thread.join()
 
         # Delete cache if needed
         if not self._cache:

--- a/earth2studio/data/cds.py
+++ b/earth2studio/data/cds.py
@@ -322,6 +322,8 @@ class CDS:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "cds")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -341,6 +341,8 @@ class GFS:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "gfs")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -188,6 +188,8 @@ class HRRR:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "hrrr")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/ifs.py
+++ b/earth2studio/data/ifs.py
@@ -234,6 +234,8 @@ class IFS:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "ifs")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/imerg.py
+++ b/earth2studio/data/imerg.py
@@ -273,6 +273,8 @@ class IMERG:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "imerg")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -193,6 +193,8 @@ class _WB2Base:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "wb2era5")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )
@@ -565,6 +567,8 @@ class WB2Climatology:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "wb2")
         if not self._cache:
+            if not DistributedManager.is_initialized():
+                DistributedManager.initialize()
             cache_location = os.path.join(
                 cache_location, f"tmp_{DistributedManager().rank}"
             )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Jupyter notebooks have a asyncio loop running by default which makes calling a async function from a sync function difficult. Namely blocking asyncio calls such as, `run_until_complete` or `run_until_complete` cannot be used. To get around this the data source creates a new thread for the call to run its own asyncio loop on.

Closes: https://github.com/NVIDIA/earth2studio/issues/103

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
