### PR TITLE
add local option to WB2 climatology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored ARCO datasource to use asyncio
 - Updated NetCDF4 and Zarr IO to take kwargs for root storage objects allowing better
   control over storage behavior. Breaking changes to NetCDF4 init API.
+- Changed the `da` property to DataSetFile and DataArrayFile to no longer be a property
+  and moved xr_args to object instantiator.
 
 ### Deprecated
 

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -409,9 +409,6 @@ class WB2Climatology:
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
-    local : bool, optional
-        Assumes the path provided in `climatology_zarr_store` is a location
-        to a local zarr store.
 
     Warning
     -------

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -392,7 +392,7 @@ class WB2Climatology:
     Parameters
     ----------
     climatology_zarr_store : ClimatologyZarrStore, optional
-        Sopres within `gs://weatherbench2/datasets/era5-hourly-climatology/` to select
+        Stores within `gs://weatherbench2/datasets/era5-hourly-climatology/` to select
         As of 05/03/2024 this is the following list of available files:
 
         - 1990-2017_6h_1440x721.zarr
@@ -431,33 +431,27 @@ class WB2Climatology:
         climatology_zarr_store: ClimatologyZarrStore = "1990-2017_6h_1440x721.zarr",
         cache: bool = True,
         verbose: bool = True,
-        local: bool = False,
     ):
 
         self._cache = cache
         self._verbose = verbose
 
-        if local:
-            fs = fsspec.implementations.local.LocalFileSystem()
-            path = f"{climatology_zarr_store}"
-        else:
-            fs = gcsfs.GCSFileSystem(
-                cache_timeout=-1,
-                token="anon",  # noqa: S106 # nosec B106
-                access="read_only",
-                block_size=2**20,
-            )
+        fs = gcsfs.GCSFileSystem(
+            cache_timeout=-1,
+            token="anon",  # noqa: S106 # nosec B106
+            access="read_only",
+            block_size=2**20,
+        )
 
-            if self._cache:
-                cache_options = {
-                    "cache_storage": self.cache,
-                    "expiry_time": 31622400,  # 1 year
-                }
-                fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
+        if self._cache:
+            cache_options = {
+                "cache_storage": self.cache,
+                "expiry_time": 31622400,  # 1 year
+            }
+            fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
 
-            path = f"weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}"
         fs_map = fsspec.FSMap(
-            path,
+            f"weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}",
             fs,
         )
         self.zarr_group = zarr.open(fs_map, mode="r")

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -392,7 +392,7 @@ class WB2Climatology:
     Parameters
     ----------
     climatology_zarr_store : ClimatologyZarrStore, optional
-        Stpres within `gs://weatherbench2/datasets/era5-hourly-climatology/` to select
+        Sopres within `gs://weatherbench2/datasets/era5-hourly-climatology/` to select
         As of 05/03/2024 this is the following list of available files:
 
         - 1990-2017_6h_1440x721.zarr
@@ -409,6 +409,9 @@ class WB2Climatology:
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    local : bool, optional
+        Assumes the path provided in `climatology_zarr_store` is a location
+        to a local zarr store.
 
     Warning
     -------
@@ -428,27 +431,33 @@ class WB2Climatology:
         climatology_zarr_store: ClimatologyZarrStore = "1990-2017_6h_1440x721.zarr",
         cache: bool = True,
         verbose: bool = True,
+        local: bool = False,
     ):
 
         self._cache = cache
         self._verbose = verbose
 
-        fs = gcsfs.GCSFileSystem(
-            cache_timeout=-1,
-            token="anon",  # noqa: S106 # nosec B106
-            access="read_only",
-            block_size=2**20,
-        )
+        if local:
+            fs = fsspec.implementations.local.LocalFileSystem()
+            path = f"{climatology_zarr_store}"
+        else:
+            fs = gcsfs.GCSFileSystem(
+                cache_timeout=-1,
+                token="anon",  # noqa: S106 # nosec B106
+                access="read_only",
+                block_size=2**20,
+            )
 
-        if self._cache:
-            cache_options = {
-                "cache_storage": self.cache,
-                "expiry_time": 31622400,  # 1 year
-            }
-            fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
+            if self._cache:
+                cache_options = {
+                    "cache_storage": self.cache,
+                    "expiry_time": 31622400,  # 1 year
+                }
+                fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
 
+            path = f"weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}"
         fs_map = fsspec.FSMap(
-            f"weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}",
+            path,
             fs,
         )
         self.zarr_group = zarr.open(fs_map, mode="r")

--- a/earth2studio/data/xr.py
+++ b/earth2studio/data/xr.py
@@ -32,13 +32,9 @@ class DataArrayFile:
         Path to xarray data array compatible file.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, **xr_args: Any):
         self.file_path = file_path
-
-    @property
-    def da(self, xr_args: dict[str, Any] = {}) -> xr.DataArray:
-        """Return the appropriate xarray DataArray."""
-        return xr.open_dataarray(self.file_path, **xr_args)
+        self.da = xr.open_dataarray(self.file_path, **xr_args)
 
     def __call__(
         self,
@@ -74,14 +70,9 @@ class DataSetFile:
         Data array name in xarray dataset
     """
 
-    def __init__(self, file_path: str, array_name: str):
+    def __init__(self, file_path: str, array_name: str, **xr_args: Any):
         self.file_path = file_path
-        self.array_name = array_name
-
-    @property
-    def da(self, xr_args: dict[str, Any] = {}) -> xr.DataArray:
-        """Return the appropriate xarray DataArray."""
-        return xr.open_dataset(self.file_path, **xr_args)[self.array_name]
+        self.da = xr.open_dataset(self.file_path, **xr_args)[array_name]
 
     def __call__(
         self,

--- a/test/data/test_xr.py
+++ b/test/data/test_xr.py
@@ -106,7 +106,7 @@ def test_data_array_netcdf(foo_data_array, time, variable):
 def test_data_set_netcdf(foo_data_set, array, time, variable):
     foo_data_set.to_netcdf("test.nc")
     # Load data source and request data array
-    data_source = DataSetFile("test.nc", array_name=array)
+    data_source = DataSetFile("test.nc", array)
     data = data_source(time, variable)
     # Delete nc file
     pathlib.Path("test.nc").unlink(missing_ok=True)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Made it so that local copies of WB2 Climatology can be used with existing WB2 objects.

Changed the structure of `data.xr` objects so that keyword arguments can be passed in the object instantiate method.
 
## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
