### PR TITLE
Skip interpolation in map_coords when possible

### DIFF
--- a/earth2studio/utils/coords.py
+++ b/earth2studio/utils/coords.py
@@ -218,7 +218,7 @@ def map_coords(
         if np.all(inc == outc):
             # skip interpolation if input and output coords are identical
             continue
-        else:
+        elif (inc.ndim == 1) and (outc.ndim == 1):
             # use a simple slice if output coords are found as a continuous
             # subset of input coords
             try:

--- a/earth2studio/utils/coords.py
+++ b/earth2studio/utils/coords.py
@@ -215,6 +215,24 @@ def map_coords(
         inc = mapped_coords[key]
         dim = list(input_coords).index(key)
 
+        if np.all(inc == outc):
+            # skip interpolation if input and output coords are identical
+            continue
+        else:
+            # use a simple slice if output coords are found as a continuous
+            # subset of input coords
+            try:
+                i0 = list(inc).index(outc[0])
+                i1 = i0 + len(outc)
+                if i1 < len(inc) and (inc[i0:i1] == outc).all():
+                    x_slice = [slice(None)] * len(input_coords)
+                    x_slice[dim] = slice(i0, i1)
+                    x = x[x_slice]
+                    mapped_coords[key] = input_coords[key][i0:i1]
+                    continue
+            except ValueError:  # can be raised by list.index
+                pass
+
         if not np.issubdtype(value.dtype, np.number):
             if not np.all(np.isin(outc, inc)):
                 raise ValueError(f"Error! Some elements of {outc} are not in {inc}.")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Optimizes `map_coords` to skip interpolation whenever the output coordinates are identical to or a continuous subset of the input coordinates.

Tested to work with SFNO and FCN models.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
