### PR TITLE
Log message for timeout error when loading model artefacts

### DIFF
--- a/earth2studio/models/auto/package.py
+++ b/earth2studio/models/auto/package.py
@@ -95,7 +95,13 @@ class CallbackWholeFileCacheFileSystem(WholeFileCacheFileSystem):
                     f2.write(data)  # type: ignore
         else:
             if "callback" in kwargs:  # Patch here
-                self.fs.get_file(path, fn, callback=kwargs["callback"])
+                try:
+                    self.fs.get_file(path, fn, callback=kwargs["callback"])
+                except fsspec.exceptions.FSTimeoutError as exc:
+                    timeout = Package.default_timeout()
+                    m = 'Loading model artefact resulted in timeout. Consider increasing timeout through environment variable "EARTH2STUDIO_PACKAGE_TIMEOUT". Currently it is set to %s seconds.' % timeout
+                    logger.error(m)
+                    raise exc
             else:
                 self.fs.get_file(path, fn)
         self.save_cache()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Added log message with hint to timeout env variable for timeouts that happens during loading model artefacts. It will help new users to solve timeout problems that happen frequently with large models such as SFNO.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
