### PR TITLE
Add multidimension array IO compatibility

### DIFF
--- a/earth2studio/io/kv.py
+++ b/earth2studio/io/kv.py
@@ -108,9 +108,7 @@ class KVBackend:
                 f"The number of input tensors and array names must be the same but got {len(data)} and {len(array_name)}."
             )
 
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         self.coords = self.coords | adjusted_coords
 
@@ -165,9 +163,7 @@ class KVBackend:
             )
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.coords:
@@ -244,9 +240,7 @@ class KVBackend:
         """
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.coords:

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -23,6 +23,7 @@ import torch
 from cftime import date2num, num2date
 from netCDF4 import Dataset, Variable
 
+from earth2studio.utils.coords import convert_multidim_to_singledim
 from earth2studio.utils.time import timearray_to_datetime
 from earth2studio.utils.type import CoordSystem
 
@@ -177,11 +178,22 @@ class NetCDF4Backend:
                 f"The number of input tensors and array names must be the same but got {len(data)} and {len(array_name)}."
             )
 
-        for c, v in coords.items():
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for c, v in adjusted_coords.items():
             if c not in self.coords:
                 self.add_dimension(c, v.shape, v)
 
-        self.coords = self.coords | coords
+        self.coords = self.coords | adjusted_coords
+
+        # Add multidimensional coords
+        for k in mapping:
+            if k not in self.root.variables:
+                dtype = coords[k].dtype
+                self.root.createVariable(k, dtype, list(mapping[k]))
+                self.root[k][:] = coords[k]
 
         for name, di in zip(array_name, data):
             if name in self.root.variables:
@@ -193,7 +205,7 @@ class NetCDF4Backend:
 
             di = di.cpu().numpy() if di is not None else None
             dtype = di.dtype if di is not None else "float32"
-            self.root.createVariable(name, dtype, list(coords))
+            self.root.createVariable(name, dtype, list(adjusted_coords))
 
             if di is not None:
                 self.root[name][:] = di
@@ -227,13 +239,31 @@ class NetCDF4Backend:
                 f"The number of input tensors and array names must be the same but got {len(x)} and {len(array_name)}."
             )
 
-        for dim in coords:
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
             if dim not in self.coords:
                 raise AssertionError("Coordinate dimension not in NetCDF store.")
 
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root.variables:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in NetCDF4 store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently writing data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
+
         for xi, name in zip(x, array_name):
             if name not in self.root.variables:
-                self.add_array(coords, array_name, data=xi)
+                self.add_array(adjusted_coords, array_name, data=xi)
 
             else:
                 # Get indices as list of arrays and set torch tensor
@@ -241,7 +271,7 @@ class NetCDF4Backend:
                     tuple(
                         [
                             np.where(np.in1d(self.coords[dim], value))[0]
-                            for dim, value in coords.items()
+                            for dim, value in adjusted_coords.items()
                         ]
                     )
                 ] = xi.to("cpu").numpy()
@@ -262,11 +292,35 @@ class NetCDF4Backend:
             device to place the read data from, by default 'cpu'
         """
 
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
+            if dim not in self.coords:
+                raise AssertionError(
+                    f"Coordinate dimension {dim} not in NetCDF4 store."
+                )
+
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root.variables:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in NetCDF4 store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently reading data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
+
         x = self.root[array_name][
             tuple(
                 [
                     np.where(np.in1d(self.coords[dim], value))[0]
-                    for dim, value in coords.items()
+                    for dim, value in adjusted_coords.items()
                 ]
             )
         ]

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -178,9 +178,7 @@ class NetCDF4Backend:
                 f"The number of input tensors and array names must be the same but got {len(data)} and {len(array_name)}."
             )
 
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for c, v in adjusted_coords.items():
             if c not in self.coords:
@@ -240,9 +238,7 @@ class NetCDF4Backend:
             )
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.coords:
@@ -293,9 +289,7 @@ class NetCDF4Backend:
         """
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.coords:

--- a/earth2studio/io/xarray.py
+++ b/earth2studio/io/xarray.py
@@ -22,6 +22,7 @@ import numpy as np
 import torch
 import xarray as xr
 
+from earth2studio.utils.coords import convert_multidim_to_singledim
 from earth2studio.utils.type import CoordSystem
 
 
@@ -40,8 +41,24 @@ class XarrayBackend:
     """
 
     def __init__(self, coords: CoordSystem = OrderedDict({}), **xr_kwargs: Any) -> None:
-        self.root = xr.Dataset(data_vars={}, coords=coords, **xr_kwargs)
-        self.coords = coords
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        data_vars: dict[str, tuple[str, np.ndarray]] = {}
+        if not mapping:
+            self.root = xr.Dataset(
+                data_vars=data_vars, coords=adjusted_coords, **xr_kwargs
+            )
+        else:
+            for k in mapping:
+                data_vars[k] = (mapping[k], coords[k])
+
+            self.root = xr.Dataset(
+                data_vars=data_vars, coords=adjusted_coords, **xr_kwargs
+            )
+
+        self.coords = adjusted_coords
 
     def __contains__(self, item: str) -> bool:
         """Checks if item in xarray Dataset.
@@ -109,18 +126,35 @@ class XarrayBackend:
                 f"The number of input tensors and array names must be the same but got {len(data)} and {len(array_name)}."
             )
 
-        self.coords = self.coords | coords
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        self.coords = self.coords | adjusted_coords
+
+        for k in mapping:
+            if k not in self.root:
+                self.root[k] = xr.DataArray(
+                    data=coords[k],
+                    dims=mapping[k],
+                    coords={adjusted_coords[ki] for ki in mapping[k]},
+                    **xr_kwargs,
+                )
+
         for name, di in zip(array_name, data):
             if name in self.root:
                 raise AssertionError(f"Warning! {name} is already in xarray Dataset.")
 
             if di is not None:
                 self.root[name] = xr.DataArray(
-                    data=di.cpu().numpy(), coords=coords, dims=list(coords), **xr_kwargs
+                    data=di.cpu().numpy(),
+                    coords=adjusted_coords,
+                    dims=list(adjusted_coords),
+                    **xr_kwargs,
                 )
             else:
                 self.root[name] = xr.DataArray(
-                    coords=coords, dims=list(coords), **xr_kwargs
+                    coords=adjusted_coords, dims=list(adjusted_coords), **xr_kwargs
                 )
 
     def write(
@@ -152,13 +186,31 @@ class XarrayBackend:
                 f"The number of input tensors and array names must be the same but got {len(x)} and {len(array_name)}."
             )
 
-        for dim in coords:
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
             if dim not in self.root:
                 raise AssertionError("Coordinate dimension not in xarray dataset.")
 
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in xarray store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently writing data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
+
         for xi, name in zip(x, array_name):
             if name not in self.root:
-                self.add_array(coords, array_name, data=xi)
+                self.add_array(adjusted_coords, array_name, data=xi)
 
             else:
                 # Get indices as list of arrays and set torch tensor
@@ -166,7 +218,7 @@ class XarrayBackend:
                     tuple(
                         [
                             np.where(np.in1d(self.coords[dim], value))[0]
-                            for dim, value in coords.items()
+                            for dim, value in adjusted_coords.items()
                         ]
                     )
                 ] = xi.to("cpu").numpy()
@@ -191,11 +243,33 @@ class XarrayBackend:
             device to place the read data from, by default 'cpu'
         """
 
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
+            if dim not in self.root:
+                raise AssertionError(f"Coordinate dimension {dim} not in xarray store.")
+
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in xarray store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently reading data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
+
         x = self.root[array_name].values[
             np.ix_(
                 *[
                     np.where(np.in1d(self.coords[dim], value))[0]
-                    for dim, value in coords.items()
+                    for dim, value in adjusted_coords.items()
                 ]
             )
         ]

--- a/earth2studio/io/xarray.py
+++ b/earth2studio/io/xarray.py
@@ -41,11 +41,9 @@ class XarrayBackend:
     """
 
     def __init__(self, coords: CoordSystem = OrderedDict({}), **xr_kwargs: Any) -> None:
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
-        data_vars: dict[str, tuple[str, np.ndarray]] = {}
+        data_vars: dict[str, tuple[list[str], np.ndarray]] = {}
         if not mapping:
             self.root = xr.Dataset(
                 data_vars=data_vars, coords=adjusted_coords, **xr_kwargs
@@ -126,9 +124,7 @@ class XarrayBackend:
                 f"The number of input tensors and array names must be the same but got {len(data)} and {len(array_name)}."
             )
 
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         self.coords = self.coords | adjusted_coords
 
@@ -187,9 +183,7 @@ class XarrayBackend:
             )
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.root:
@@ -244,9 +238,7 @@ class XarrayBackend:
         """
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.root:

--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -174,7 +174,7 @@ class ZarrBackend:
                     **kwargs,
                 )
                 self.root[k][:] = values
-                self.root[dim].attrs["_ARRAY_DIMENSIONS"] = mapping[k]
+                self.root[k].attrs["_ARRAY_DIMENSIONS"] = mapping[k]
 
         self.coords = self.coords | adjusted_coords
 

--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -22,6 +22,7 @@ import numpy as np
 import torch
 import zarr
 
+from earth2studio.utils.coords import convert_multidim_to_singledim
 from earth2studio.utils.type import CoordSystem
 
 
@@ -146,7 +147,10 @@ class ZarrBackend:
         if "fill_value" not in kwargs:
             kwargs["fill_value"] = None
 
-        for dim, values in coords.items():
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+        for dim, values in adjusted_coords.items():
             if dim not in self.coords:
                 self.root.create_dataset(
                     dim,
@@ -158,10 +162,26 @@ class ZarrBackend:
                 self.root[dim][:] = values
                 self.root[dim].attrs["_ARRAY_DIMENSIONS"] = [dim]
 
-        self.coords = self.coords | coords
+        # Add any multidim coordinates that were expelled above
+        for k in mapping:
+            if k not in self.root:
+                values = coords[k]
+                self.root.create_dataset(
+                    k,
+                    shape=values.shape,
+                    chunks=values.shape,
+                    dtype=values.dtype,
+                    **kwargs,
+                )
+                self.root[k][:] = values
+                self.root[dim].attrs["_ARRAY_DIMENSIONS"] = mapping[k]
 
-        shape = [len(v) for v in coords.values()]
-        chunks = [self.chunks.get(dim, len(coords[dim])) for dim in coords]
+        self.coords = self.coords | adjusted_coords
+
+        shape = [len(v) for v in adjusted_coords.values()]
+        chunks = [
+            self.chunks.get(dim, len(adjusted_coords[dim])) for dim in adjusted_coords
+        ]
 
         for name, di in zip(array_name, data):
             if name in self.root and not kwargs.get("overwrite", False):
@@ -178,7 +198,7 @@ class ZarrBackend:
             if di is not None:
                 self.root[name][:] = di
 
-            self.root[name].attrs["_ARRAY_DIMENSIONS"] = list(coords)
+            self.root[name].attrs["_ARRAY_DIMENSIONS"] = list(adjusted_coords)
 
     def write(
         self,
@@ -209,13 +229,31 @@ class ZarrBackend:
                 f"The number of input tensors and array names must be the same but got {len(x)} and {len(array_name)}."
             )
 
-        for dim in coords:
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
             if dim not in self.root:
-                raise AssertionError("Coordinate dimension not in zarr store.")
+                raise AssertionError(f"Coordinate dimension {dim} not in zarr store.")
+
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in zarr store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently writing data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
 
         for xi, name in zip(x, array_name):
             if name not in self.root:
-                self.add_array(coords, array_name, data=xi)
+                self.add_array(adjusted_coords, array_name, data=xi)
 
             else:
                 # Get indices as list of arrays and set torch tensor
@@ -223,7 +261,7 @@ class ZarrBackend:
                     np.ix_(
                         *[
                             np.where(np.in1d(self.coords[dim], value))[0]
-                            for dim, value in coords.items()
+                            for dim, value in adjusted_coords.items()
                         ]
                     )
                 ] = xi.to("cpu", non_blocking=False).numpy()
@@ -244,11 +282,33 @@ class ZarrBackend:
             device to place the read data from, by default 'cpu'
         """
 
+        # Reduce complex coordinates, if any multidimension coordinates exist
+        adjusted_coords, mapping = convert_multidim_to_singledim(
+            coords, return_mapping=True
+        )
+
+        for dim in adjusted_coords:
+            if dim not in self.root:
+                raise AssertionError(f"Coordinate dimension {dim} not in zarr store.")
+
+        # Check to see if multidimensions are passed in full, otherwise error
+        for key in mapping:
+            if key not in self.root:
+                raise AssertionError(
+                    f"Multidimension coordinate {key} not in zarr store."
+                )
+
+            if coords[key].shape != self.root[key].shape:
+                raise AssertionError(
+                    "Currently reading data with multidimension arrays is only supported when"
+                    + "the multidimension coordinates are passed in full."
+                )
+
         x = self.root[array_name][
             np.ix_(
                 *[
                     np.where(np.in1d(self.coords[dim], value))[0]
-                    for dim, value in coords.items()
+                    for dim, value in adjusted_coords.items()
                 ]
             )
         ]

--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -147,9 +147,8 @@ class ZarrBackend:
         if "fill_value" not in kwargs:
             kwargs["fill_value"] = None
 
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
+
         for dim, values in adjusted_coords.items():
             if dim not in self.coords:
                 self.root.create_dataset(
@@ -230,9 +229,7 @@ class ZarrBackend:
             )
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.root:
@@ -283,9 +280,7 @@ class ZarrBackend:
         """
 
         # Reduce complex coordinates, if any multidimension coordinates exist
-        adjusted_coords, mapping = convert_multidim_to_singledim(
-            coords, return_mapping=True
-        )
+        adjusted_coords, mapping = convert_multidim_to_singledim(coords)
 
         for dim in adjusted_coords:
             if dim not in self.root:

--- a/earth2studio/utils/__init__.py
+++ b/earth2studio/utils/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from .coords import (
+    convert_multidim_to_singledim,
     handshake_coords,
     handshake_dim,
     handshake_size,

--- a/earth2studio/utils/coords.py
+++ b/earth2studio/utils/coords.py
@@ -343,7 +343,7 @@ def split_coords(
 
 def convert_multidim_to_singledim(
     coords: CoordSystem, return_mapping: bool = False
-) -> CoordSystem:
+) -> tuple[CoordSystem, dict[str, list[str]]]:
     """Converts a set of coordinates from a complex coordinate system, which has some
     coordinates with multidimensional arrays, into a simple coordinate system
     containing only one-dimensional arrays.
@@ -367,7 +367,7 @@ def convert_multidim_to_singledim(
     LON, LAT = np.meshgrid(lat, lon)
     c = CoordSystem({"lat": LAT, "lon": LON})
 
-    c1 = convert_multidim_to_singledim(c)
+    c1, m = convert_multidim_to_singledim(c)
     ```
 
     `c1` has 2 keys - `x1` and `x2`, with shapes `(10,)` and `(20,)` respectively.
@@ -376,15 +376,14 @@ def convert_multidim_to_singledim(
     ----------
     coords : CoordSystem
         CoordSystem to convert.
-    return_mapping : bool, optional
-        Whether to return the mapping between the multidimensional entries and their
-        reduced entries in the converted coordinate system.
-        By default false.
 
     Returns
     -------
     CoordSystem
         Converted coordinate system where each coordinate is 1-dimensional.
+    dict[str, list[str]]
+        Mapping of multidimensional coordinates to a list of their 1-dimensional
+        enumerations.
     """
 
     adjusted_coords = {}
@@ -392,7 +391,6 @@ def convert_multidim_to_singledim(
 
     items = list(coords.items())
     i = 0
-    dim_number = 0
     while i < len(items):
         item = items[i]
         k, v = item
@@ -421,11 +419,7 @@ def convert_multidim_to_singledim(
                 adjusted_coords["i" + k1] = np.arange(s[j])
                 mapping[k].append("i" + k1)
                 mapping[k1] = mapping[k]
-                dim_number += 1
 
             i += j + 1
 
-    if return_mapping:
-        return CoordSystem(adjusted_coords), mapping
-    else:
-        return CoordSystem(adjusted_coords)
+    return CoordSystem(adjusted_coords), mapping

--- a/earth2studio/utils/coords.py
+++ b/earth2studio/utils/coords.py
@@ -339,3 +339,80 @@ def split_coords(
     values = reduced_coords.pop(dim)
     xs = [xi.squeeze(dim_index) for xi in x.split(1, dim=dim_index)]
     return xs, reduced_coords, values
+
+
+def convert_multidim_to_singledim(coords: CoordSystem) -> CoordSystem:
+    """Converts a set of coordinates from a complex coordinate system, which has some
+    coordinates with multidimensional arrays, into a simple coordinate system
+    containing only one-dimensional arrays.
+
+    This conversion is done by creating individual indexes that are enumerations of
+    the complex coordinate.
+
+    Assumptions
+    -----------
+    This code assumes that if a coordinate entry is n-dimensional, then the following
+    (n-1) coordinate entries in the ordered dictionary have the same shape and represent
+    the same multidimensional grid.
+
+    Example
+    -------
+
+    Suppose we have lat/lon coordinates represented by 2-dimensional grids.
+    ```python
+    lat = np.linspace(0, 1, 10)
+    lon = np.linspace(0, 1, 20)
+    LON, LAT = np.meshgrid(lat, lon)
+    c = CoordSystem({"lat": LAT, "lon": LON})
+
+    c1 = convert_multidim_to_singledim(c)
+    ```
+
+    `c1` has 2 keys - `x1` and `x2`, with shapes `(10,)` and `(20,)` respectively.
+
+    Parameters
+    ----------
+    coords : CoordSystem
+        CoordSystem to convert.
+
+    Returns
+    -------
+    CoordSystem
+        Converted coordinate system where each coordinate is 1-dimensional.
+    """
+
+    adjusted_coords = {}
+
+    items = list(coords.items())
+    i = 0
+    dim_number = 0
+    while i < len(items):
+        item = items[i]
+        k, v = item
+        ndim = v.ndim
+        if v.ndim < 2:
+            adjusted_coords[k] = v
+            i += 1
+        else:
+            s = v.shape
+
+            for j in range(ndim):
+                if i + j > len(items) - 1:
+                    raise ValueError(
+                        "Assumed that if an n-dimensional coordinate exists, "
+                        "then there will be exactly n coordinates with the same shape."
+                    )
+
+                _, v1 = items[i + j]
+                if v1.shape != s:
+                    raise ValueError(
+                        "Assumed that if an n-dimensional coordinate exists, "
+                        "then there will be exactly n coordinates with the same shape."
+                    )
+
+                adjusted_coords["x" + str(dim_number)] = np.arange(s[j])
+                dim_number += 1
+
+            i += j + 1
+
+    return CoordSystem(adjusted_coords)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "ngcsdk>=3.48.0,<3.55.0",
     "numpy>=1.24.0",
     "nvidia-modulus@git+https://github.com/NVIDIA/modulus.git",
+    "omegaconf",
     "python-dotenv",
     "s3fs>=2023.5.0",
     "setuptools>=67.6.0",

--- a/test/io/test_kv.py
+++ b/test/io/test_kv.py
@@ -22,7 +22,7 @@ import torch
 import xarray as xr
 
 from earth2studio.io import KVBackend
-from earth2studio.utils.coords import split_coords
+from earth2studio.utils.coords import convert_multidim_to_singledim, split_coords
 
 
 @pytest.mark.parametrize(
@@ -229,3 +229,91 @@ def test_kv_exceptions(
     # Try to write with too many array names
     with pytest.raises(ValueError):
         z.write([dummy, dummy], bad_coords, "dummy_1")
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        [np.datetime64("1958-01-31")],
+        [np.datetime64("1971-06-01T06:00:00"), np.datetime64("2021-11-23T12:00:00")],
+    ],
+)
+@pytest.mark.parametrize(
+    "variable",
+    [["t2m"], ["t2m", "tcwv"]],
+)
+@pytest.mark.parametrize("device", ["cpu"])
+def test_kv_fields_multidim(
+    time: list[np.datetime64], variable: list[str], device: str
+) -> None:
+
+    lat = np.linspace(-90, 90, 180)
+    lon = np.linspace(0, 360, 360, endpoint=False)
+    LON, LAT = np.meshgrid(lon, lat)
+
+    total_coords = OrderedDict(
+        {
+            "time": np.asarray(time),
+            "variable": np.asarray(variable),
+            "lat": LAT,
+            "lon": LON,
+        }
+    )
+
+    adjusted_coords = convert_multidim_to_singledim(total_coords)
+
+    # Test Memory Store
+    z = KVBackend(device=device)
+    assert isinstance(z.root, dict)
+
+    array_name = "fields"
+    z.add_array(total_coords, array_name)
+    for dim in adjusted_coords:
+        assert dim in z.coords
+        assert z.coords[dim].shape == adjusted_coords[dim].shape
+
+    # Test __contains__
+    assert array_name in z
+
+    # Test __getitem__
+    shape = tuple([len(dim) for dim in adjusted_coords.values()])
+    assert z[array_name].shape == shape
+
+    # Test __len__
+    assert len(z) == (7)
+
+    # Test __iter__
+    for array in z:
+        assert array in ["fields", "time", "variable", "lat", "lon", "ilat", "ilon"]
+
+    for array in ["fields", "time", "variable", "lat", "lon", "ilat", "ilon"]:
+        assert array in z
+
+    # Test add_array with torch.Tensor
+    z.add_array(
+        total_coords,
+        "dummy_1",
+        data=torch.randn(shape, device=device, dtype=torch.float32),
+    )
+
+    assert "dummy_1" in z
+    assert z["dummy_1"].shape == shape
+
+    # Test writing
+
+    # Test full write
+    x = torch.randn(shape, device=device, dtype=torch.float32)
+    z.write(x, adjusted_coords, array_name)
+
+    xx, _ = z.read(adjusted_coords, array_name, device=device)
+    assert torch.allclose(x, xx)
+
+    # Test separate write
+    z.write(x, total_coords, "fields_1")
+    assert "fields_1" in z
+    assert z["fields_1"].shape == x.shape
+
+    xx, _ = z.read(total_coords, "fields_1", device=device)
+    assert torch.allclose(x, xx)
+    print(list(z.root))
+    print(z.to_xarray())

--- a/test/io/test_kv.py
+++ b/test/io/test_kv.py
@@ -260,7 +260,7 @@ def test_kv_fields_multidim(
         }
     )
 
-    adjusted_coords = convert_multidim_to_singledim(total_coords)
+    adjusted_coords, _ = convert_multidim_to_singledim(total_coords)
 
     # Test Memory Store
     z = KVBackend(device=device)

--- a/test/io/test_netcdf4.py
+++ b/test/io/test_netcdf4.py
@@ -413,7 +413,7 @@ def test_netcdf4_fields_multidim(
         }
     )
 
-    adjusted_coords = convert_multidim_to_singledim(total_coords)
+    adjusted_coords, _ = convert_multidim_to_singledim(total_coords)
 
     # Test Memory Store
     nc = NetCDF4Backend(

--- a/test/io/test_netcdf4.py
+++ b/test/io/test_netcdf4.py
@@ -24,7 +24,7 @@ import pytest
 import torch
 
 from earth2studio.io import NetCDF4Backend
-from earth2studio.utils.coords import split_coords
+from earth2studio.utils.coords import convert_multidim_to_singledim, split_coords
 
 
 @pytest.mark.parametrize(
@@ -366,5 +366,119 @@ def test_netcdf4_exceptions(
     # Try to write with too many array names
     with pytest.raises(ValueError):
         nc.write([dummy, dummy], bad_coords, "dummy_1")
+
+    nc.close()
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        [np.datetime64("1958-01-31T00:00:00")],
+        [np.datetime64("1971-06-01T06:00:00"), np.datetime64("2021-11-23T12:00:00")],
+    ],
+)
+@pytest.mark.parametrize(
+    "lead_time",
+    [
+        np.array([np.timedelta64(0, "h")]),
+        np.array([np.timedelta64(-6, "h"), np.timedelta64(0, "h")]),
+    ],
+)
+@pytest.mark.parametrize(
+    "variable",
+    [
+        ["t2m"],
+        ["t2m", "tcwv"],
+    ],
+)
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_netcdf4_fields_multidim(
+    time: list[np.datetime64],
+    lead_time: list[np.datetime64],
+    variable: list[str],
+    device: str,
+) -> None:
+
+    lat = np.linspace(-90, 90, 180)
+    lon = np.linspace(0, 360, 360, endpoint=False)
+    LON, LAT = np.meshgrid(lon, lat)
+
+    total_coords = OrderedDict(
+        {
+            "time": np.asarray(time),
+            "lead_time": lead_time,
+            "variable": np.asarray(variable),
+            "lat": LAT,
+            "lon": LON,
+        }
+    )
+
+    adjusted_coords = convert_multidim_to_singledim(total_coords)
+
+    # Test Memory Store
+    nc = NetCDF4Backend(
+        "inmemory.nc", backend_kwargs={"mode": "w", "diskless": True, "persist": False}
+    )
+    assert isinstance(nc.root, netCDF4.Dataset)
+
+    # Instantiate
+    array_name = "fields"
+    nc.add_array(total_coords, array_name)
+
+    # Check instantiation
+    for dim in adjusted_coords:
+        assert dim in nc
+        assert dim in nc.coords
+        assert nc[dim].shape == adjusted_coords[dim].shape
+
+    # Test __contains__
+    assert array_name in nc
+
+    # Test __getitem__
+    shape = tuple([len(dim) for dim in adjusted_coords.values()])
+    assert nc[array_name].shape == shape
+
+    # Test __len__
+    assert len(nc) == 8
+
+    # Test __iter__
+    for array in nc:
+        assert array in [
+            "fields",
+            "time",
+            "lead_time",
+            "variable",
+            "ilat",
+            "ilon",
+            "lat",
+            "lon",
+        ]
+
+    # Test add_array with torch.Tensor
+    nc.add_array(
+        total_coords,
+        "dummy_1",
+        data=torch.randn(shape, device=device, dtype=torch.float32),
+    )
+
+    assert "dummy_1" in nc
+    assert nc["dummy_1"].shape == shape
+
+    # Test writing
+
+    # Test full write
+    x = torch.randn(shape, device=device, dtype=torch.float32)
+    nc.write(x, adjusted_coords, array_name)
+
+    xx, _ = nc.read(adjusted_coords, array_name, device=device)
+    assert torch.allclose(x, xx)
+
+    # Test separate write
+    nc.write(x, total_coords, "fields_1")
+    assert "fields_1" in nc
+    assert nc["fields_1"].shape == x.shape
+
+    xx, _ = nc.read(total_coords, "fields_1", device=device)
+    assert torch.allclose(x, xx)
 
     nc.close()

--- a/test/io/test_xarray.py
+++ b/test/io/test_xarray.py
@@ -22,7 +22,7 @@ import torch
 import xarray as xr
 
 from earth2studio.io import XarrayBackend
-from earth2studio.utils.coords import split_coords
+from earth2studio.utils.coords import convert_multidim_to_singledim, split_coords
 
 
 @pytest.mark.parametrize(
@@ -223,3 +223,88 @@ def test_xarray_exceptions(
     # Try to write with too many array names
     with pytest.raises(ValueError):
         z.write([dummy, dummy], bad_coords, "dummy_1")
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        [np.datetime64("1958-01-31")],
+        [np.datetime64("1971-06-01T06:00:00"), np.datetime64("2021-11-23T12:00:00")],
+    ],
+)
+@pytest.mark.parametrize(
+    "variable",
+    [["t2m"], ["t2m", "tcwv"]],
+)
+@pytest.mark.parametrize("device", ["cpu"])
+def test_xarray_fields_multidim(
+    time: list[np.datetime64], variable: list[str], device: str
+) -> None:
+
+    lat = np.linspace(-90, 90, 180)
+    lon = np.linspace(0, 360, 360, endpoint=False)
+    LON, LAT = np.meshgrid(lon, lat)
+
+    total_coords = OrderedDict(
+        {
+            "time": np.asarray(time),
+            "variable": np.asarray(variable),
+            "lat": LAT,
+            "lon": LON,
+        }
+    )
+
+    adjusted_coords = convert_multidim_to_singledim(total_coords)
+
+    # Test Memory Store
+    z = XarrayBackend(total_coords)
+    assert isinstance(z.root, xr.Dataset)
+
+    array_name = "fields"
+    z.add_array(total_coords, array_name)
+    for dim in adjusted_coords:
+        assert dim in z.coords
+        assert z.coords[dim].shape == adjusted_coords[dim].shape
+
+    # Test __contains__
+    assert array_name in z
+    assert "lat" in z
+    assert "lon" in z
+
+    # Test __getitem__
+    shape = tuple([len(dim) for dim in adjusted_coords.values()])
+    assert z[array_name].shape == shape
+
+    # Test __len__
+    assert len(z) == 7
+
+    # Test __iter__
+    for array in z:
+        assert array in ["fields", "time", "variable", "lat", "lon", "ilat", "ilon"]
+
+    # Test add_array with torch.Tensor
+    z.add_array(
+        total_coords,
+        "dummy_1",
+        data=torch.randn(shape, device=device, dtype=torch.float32),
+    )
+
+    assert "dummy_1" in z
+    assert z["dummy_1"].shape == shape
+
+    # Test writing
+
+    # Test full write
+    x = torch.randn(shape, device=device, dtype=torch.float32)
+    z.write(x, adjusted_coords, array_name)
+
+    xx, _ = z.read(adjusted_coords, array_name, device=device)
+    assert torch.allclose(x, xx)
+
+    # Test separate write
+    z.write(x, total_coords, "fields_1")
+    assert "fields_1" in z
+    assert z["fields_1"].shape == x.shape
+
+    xx, _ = z.read(total_coords, "fields_1", device=device)
+    assert torch.allclose(x, xx)

--- a/test/io/test_xarray.py
+++ b/test/io/test_xarray.py
@@ -254,7 +254,7 @@ def test_xarray_fields_multidim(
         }
     )
 
-    adjusted_coords = convert_multidim_to_singledim(total_coords)
+    adjusted_coords, _ = convert_multidim_to_singledim(total_coords)
 
     # Test Memory Store
     z = XarrayBackend(total_coords)

--- a/test/io/test_zarr.py
+++ b/test/io/test_zarr.py
@@ -413,7 +413,7 @@ def test_zarr_field_multidim(
         }
     )
 
-    adjusted_coords = convert_multidim_to_singledim(total_coords)
+    adjusted_coords, _ = convert_multidim_to_singledim(total_coords)
     chunks = OrderedDict({"time": 1, "variable": 1})
 
     # Test Memory Store

--- a/test/io/test_zarr.py
+++ b/test/io/test_zarr.py
@@ -492,6 +492,15 @@ def test_zarr_field_multidim(
 
     # Test full write
     x = torch.randn(shape, device=device, dtype=torch.float32)
+    z.write(x, adjusted_coords, array_name)
+
+    xx, _ = z.read(adjusted_coords, array_name, device=device)
+    assert torch.allclose(x, xx)
+
+    # Test separate write
     z.write(x, total_coords, "fields_1")
     assert "fields_1" in z
     assert z["fields_1"].shape == x.shape
+
+    xx, _ = z.read(total_coords, "fields_1", device=device)
+    assert torch.allclose(x, xx)

--- a/test/utils/test_coords.py
+++ b/test/utils/test_coords.py
@@ -185,7 +185,7 @@ def test_convert_multidim_to_singledim():
 
     dc = OrderedDict(dict(lat=LAT, lon=LON))
 
-    true_converted = OrderedDict(dict(x0=np.arange(20), x1=np.arange(40)))
+    true_converted = OrderedDict(dict(ilat=np.arange(20), ilon=np.arange(40)))
 
     # Test simple case
     c = dc
@@ -208,12 +208,26 @@ def test_convert_multidim_to_singledim():
 
     # Test with multiple multi-dim coordinates
     dc1 = OrderedDict(dict(lat1=LAT, lon1=LON))
-    true_converted2 = OrderedDict(dict(x2=np.arange(20), x3=np.arange(40)))
+    true_converted2 = OrderedDict(dict(ilat1=np.arange(20), ilon1=np.arange(40)))
     out = convert_multidim_to_singledim(dc | dc1)
     check_coord_equivalence(out, true_converted | true_converted2)
 
     out = convert_multidim_to_singledim(dc | c | dc1)
     check_coord_equivalence(out, true_converted | c | true_converted2)
+
+    # Test with 3 dims
+    ff = np.linspace(0, 1, 5)
+    LON, LAT, ff = np.meshgrid(lon, lat, ff)
+    dc = OrderedDict(dict(lat=LAT, lon=LON, ff=ff))
+    true_converted = OrderedDict(
+        dict(ilat=np.arange(20), ilon=np.arange(40), iff=np.arange(5))
+    )
+    out, mapping = convert_multidim_to_singledim(dc, return_mapping=True)
+    check_coord_equivalence(out, true_converted)
+
+    assert mapping["lat"] == ["ilat", "ilon", "iff"]
+    assert mapping["lon"] == ["ilat", "ilon", "iff"]
+    assert mapping["ff"] == ["ilat", "ilon", "iff"]
 
 
 def test_convert_multidim_to_singledim_error():

--- a/test/utils/test_coords.py
+++ b/test/utils/test_coords.py
@@ -189,7 +189,7 @@ def test_convert_multidim_to_singledim():
 
     # Test simple case
     c = dc
-    out = convert_multidim_to_singledim(c)
+    out, _ = convert_multidim_to_singledim(c)
     check_coord_equivalence(out, true_converted)
 
     # Test with leading coordinates
@@ -199,20 +199,20 @@ def test_convert_multidim_to_singledim():
             "d": np.arange(4),
         }
     )
-    out = convert_multidim_to_singledim(c | dc)
+    out, _ = convert_multidim_to_singledim(c | dc)
     check_coord_equivalence(out, c | true_converted)
 
     # Test with training coordinates
-    out = convert_multidim_to_singledim(dc | c)
+    out, _ = convert_multidim_to_singledim(dc | c)
     check_coord_equivalence(out, true_converted | c)
 
     # Test with multiple multi-dim coordinates
     dc1 = OrderedDict(dict(lat1=LAT, lon1=LON))
     true_converted2 = OrderedDict(dict(ilat1=np.arange(20), ilon1=np.arange(40)))
-    out = convert_multidim_to_singledim(dc | dc1)
+    out, _ = convert_multidim_to_singledim(dc | dc1)
     check_coord_equivalence(out, true_converted | true_converted2)
 
-    out = convert_multidim_to_singledim(dc | c | dc1)
+    out, _ = convert_multidim_to_singledim(dc | c | dc1)
     check_coord_equivalence(out, true_converted | c | true_converted2)
 
     # Test with 3 dims
@@ -222,7 +222,7 @@ def test_convert_multidim_to_singledim():
     true_converted = OrderedDict(
         dict(ilat=np.arange(20), ilon=np.arange(40), iff=np.arange(5))
     )
-    out, mapping = convert_multidim_to_singledim(dc, return_mapping=True)
+    out, mapping = convert_multidim_to_singledim(dc)
     check_coord_equivalence(out, true_converted)
 
     assert mapping["lat"] == ["ilat", "ilon", "iff"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
This PR allows the handling of coordinates that are more than 1-dimensional. A common example are curvilinear coordinates systems where lat/lon grids are 2-dimensional.

With this PR, the IO system, in order to continue being compatible with xarray, will create 1-dimensional enumerations of the multidimensional coordinates and save them as dimensions to the IO backend while the 2-dimensional coordinates will be saved as arrays.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

