### PR TITLE
NGC Public Model Download Bug Fix

### DIFF
--- a/test/models/test_auto_models.py
+++ b/test/models/test_auto_models.py
@@ -199,14 +199,14 @@ def test_ngc_filesystem():
         fs._parse_ngc_uri("models/a/b/c@1.0/file")
 
     url = fs._get_ngc_model_url("name", "1.0", authenticated_api=False)
-    assert url == "https://api.ngc.nvidia.com/v2/models/name/versions/1.0/files"
+    assert url == "https://api.ngc.nvidia.com/v2/models/name/1.0/files"
 
     url = fs._get_ngc_model_url(
         "name", "1.0", "org", "team", "file.txt", authenticated_api=False
     )
     assert (
         url
-        == "https://api.ngc.nvidia.com/v2/models/org/team/name/versions/1.0/files?path=file.txt"
+        == "https://api.ngc.nvidia.com/v2/models/org/org/team/team/name/1.0/files?path=file.txt"
     )
 
     url = fs._get_ngc_model_url(
@@ -214,7 +214,7 @@ def test_ngc_filesystem():
     )
     assert (
         url
-        == "https://api.ngc.nvidia.com/v2/models/org/name/versions/1.0/files?path=file.txt"
+        == "https://api.ngc.nvidia.com/v2/models/org/org/name/1.0/files?path=file.txt"
     )
 
     url = fs._get_ngc_model_url("name", "1.0", authenticated_api=True)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixing bug that occurs when calling the newer NGC apis where it returns seperate short term download URLs similar to the private api. This passed originally because I had a bug in the ngc model file system that would not request specific files for public models, rather the whole repo. This has been fixed

Closes: https://github.com/NVIDIA/earth2studio/issues/217

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
