### PR TITLE
Fixing Zarr access to dimension names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ docs-full:
 	rm -rf docs/modules/backreferences
 	$(MAKE) -C docs clean
 	rm -rf examples/outputs
-	PLOT_GALLERY=True RUN_STALE_EXAMPLES=True $(MAKE) -C docs html
+	PLOT_GALLERY=True RUN_STALE_EXAMPLES=True $(MAKE) -j 8 -C docs html
 
 .PHONY: docs-dev
 docs-dev:
 	rm -rf examples/outputs
-	PLOT_GALLERY=True RUN_STALE_EXAMPLES=True FILENAME_PATTERN=$(FILENAME) $(MAKE) -C docs html
+	PLOT_GALLERY=True RUN_STALE_EXAMPLES=True FILENAME_PATTERN=$(FILENAME) $(MAKE) -j 4 -C docs html

--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -92,7 +92,7 @@ class ZarrBackend:
         for array in self.root:
             if zarr_major_version >= 3:
                 # https://github.com/pydata/xarray/pull/9669
-                dims = self.root[array].dimension_names
+                dims = self.root[array].metadata.dimension_names
             else:
                 dims = self.root[array].attrs["_ARRAY_DIMENSIONS"]
             for dim in dims:
@@ -103,7 +103,7 @@ class ZarrBackend:
             if array not in self.coords:
                 if zarr_major_version >= 3:
                     # https://github.com/pydata/xarray/pull/9669
-                    dims = self.root[array].dimension_names
+                    dims = self.root[array].metadata.dimension_names
                 else:
                     dims = self.root[array].attrs["_ARRAY_DIMENSIONS"]
             for c, d in zip(self.root[array].chunks, dims):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

- Fixing Zarr IO when accessing dimension names
- Adding Zarr 3.0 support for pytest
- Updating doc build to be multicore hopefully

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
