### PR TITLE
HENS Recipe: Model loading updates

### DIFF
--- a/recipes/hens/src/hens_ensemble.py
+++ b/recipes/hens/src/hens_ensemble.py
@@ -142,7 +142,7 @@ class EnsembleBase:
         cyclone_tracking : DiagnosticModel | None, optional
             Cyclone tracking diagnostic, by default None
         device : torch.device, optional
-            PyTorch device, by default torch.device("cpu")
+            PyTorch device. If None, will select cuda if available, by default None
         """
         self.device = (
             device

--- a/recipes/hens/src/hens_ensemble.py
+++ b/recipes/hens/src/hens_ensemble.py
@@ -92,7 +92,7 @@ class EnsembleBase:
         dx_model_dict: dict[str, DiagnosticModel] = {},
         cyclone_tracking: TCTrackerWuDuan | TCTrackerVitart | None = None,
         batch_size: int | None = None,
-        device: torch.device = torch.device("cpu"),
+        device: torch.device | None = None,
         ensemble_idx_base: int = 0,
         batch_ids_produce: list[int] = [],
         base_seed_string: str = "0",
@@ -129,7 +129,7 @@ class EnsembleBase:
         prognostic: PrognosticModel,
         dx_model_dict: dict[str, DiagnosticModel] = {},
         cyclone_tracking: TCTrackerWuDuan | TCTrackerVitart | None = None,
-        device: torch.device = torch.device("cpu"),
+        device: torch.device | None = None,
     ) -> None:
         """Moves model dictionary to device
 

--- a/recipes/hens/src/hens_utilities.py
+++ b/recipes/hens/src/hens_utilities.py
@@ -746,8 +746,9 @@ def update_model_dict(model_dict: dict, root: str) -> dict:
     if root != model_dict["package"]:
         model_dict["package"] = root
 
-        # move to cpu to free GPU memory TODO find other references and delete properly
-        if model_dict["model"] != None:
+        # move to cpu to free GPU memory
+        # TODO find other references and delete properly
+        if model_dict["model"] is not None:
             model_dict["model"].to("cpu")
 
         if root == "default":

--- a/recipes/hens/src/hens_utilities.py
+++ b/recipes/hens/src/hens_utilities.py
@@ -746,12 +746,17 @@ def update_model_dict(model_dict: dict, root: str) -> dict:
     if root != model_dict["package"]:
         model_dict["package"] = root
 
-    if root == "default":
-        package = model_dict["class"].load_default_package()
-    else:
-        package = Package(root)
+        # move to cpu to free GPU memory TODO find other references and delete properly
+        if model_dict["model"] != None:
+            model_dict["model"].to("cpu")
 
-    model_dict["model"] = model_dict["class"].load_model(package=package)
+        if root == "default":
+            package = model_dict["class"].load_default_package()
+        else:
+            package = Package(root)
+
+        model_dict["model"] = model_dict["class"].load_model(package=package)
+
     return model_dict
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
The default for initialising EnsembleBase was set to cpu and device pass was omitted in hens_run.py, ie the pipeline only ran on the CPU. Fixed this by defaulting device to None.
Updating the model dict always happened, even if no update needed. Fixed this as well, and moved the "old" model to cpu to free GPU memory. delteing it directly would be better, but couldn't track down all other instances that existed, hence the hack. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
