### PR TITLE
Adding more vertical levels to the ARCO lexicon

### DIFF
--- a/earth2studio/lexicon/arco.py
+++ b/earth2studio/lexicon/arco.py
@@ -57,6 +57,7 @@ class ARCOLexicon(metaclass=LexiconType):
         "msl": "mean_sea_level_pressure::",
         "tcwv": "total_column_water_vapour::",
         "tp": "total_precipitation::",
+        "z": "geopotential_at_surface::",
     }
     VOCAB.update({f"u{level}" : f"u_component_of_wind::{level}" for level in LEVELS})
     VOCAB.update({f"v{level}" : f"'v_component_of_wind::{level}" for level in LEVELS})

--- a/earth2studio/lexicon/arco.py
+++ b/earth2studio/lexicon/arco.py
@@ -32,9 +32,45 @@ from .base import LexiconType
 # 'type_of_low_vegetation', 'u_component_of_wind', 'v_component_of_wind',
 # 'vertical_velocity']
 
-LEVELS = [   1,    2,    3,    5,    7,   10,   20,   30,   50,   70,  100,  125,  150,  175,
-      200,  225,  250,  300,  350,  400,  450,  500,  550,  600,  650,  700,  750,  775,
-  800,  825,  850,  875,  900,  925,  950,  975, 1000]
+LEVELS = [
+    1,
+    2,
+    3,
+    5,
+    7,
+    10,
+    20,
+    30,
+    50,
+    70,
+    100,
+    125,
+    150,
+    175,
+    200,
+    225,
+    250,
+    300,
+    350,
+    400,
+    450,
+    500,
+    550,
+    600,
+    650,
+    700,
+    750,
+    775,
+    800,
+    825,
+    850,
+    875,
+    900,
+    925,
+    950,
+    975,
+    1000,
+]
 
 
 class ARCOLexicon(metaclass=LexiconType):
@@ -59,11 +95,11 @@ class ARCOLexicon(metaclass=LexiconType):
         "tp": "total_precipitation::",
         "z": "geopotential_at_surface::",
     }
-    VOCAB.update({f"u{level}" : f"u_component_of_wind::{level}" for level in LEVELS})
-    VOCAB.update({f"v{level}" : f"'v_component_of_wind::{level}" for level in LEVELS})
-    VOCAB.update({f"z{level}" : f"geopotential::{level}" for level in LEVELS})
-    VOCAB.update({f"t{level}" : f"temperature::{level}" for level in LEVELS})
-    VOCAB.update({f"q{level}" : f"specific_humidity::{level}" for level in LEVELS})
+    VOCAB.update({f"u{level}": f"u_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"v{level}": f"'v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"z{level}": f"geopotential::{level}" for level in LEVELS})
+    VOCAB.update({f"t{level}": f"temperature::{level}" for level in LEVELS})
+    VOCAB.update({f"q{level}": f"specific_humidity::{level}" for level in LEVELS})
 
     @classmethod
     def get_item(cls, val: str) -> tuple[str, Callable]:

--- a/earth2studio/lexicon/arco.py
+++ b/earth2studio/lexicon/arco.py
@@ -32,6 +32,10 @@ from .base import LexiconType
 # 'type_of_low_vegetation', 'u_component_of_wind', 'v_component_of_wind',
 # 'vertical_velocity']
 
+LEVELS = [   1,    2,    3,    5,    7,   10,   20,   30,   50,   70,  100,  125,  150,  175,
+      200,  225,  250,  300,  350,  400,  450,  500,  550,  600,  650,  700,  750,  775,
+  800,  825,  850,  875,  900,  925,  950,  975, 1000]
+
 
 class ARCOLexicon(metaclass=LexiconType):
     """ARCO Lexicon
@@ -53,72 +57,12 @@ class ARCOLexicon(metaclass=LexiconType):
         "msl": "mean_sea_level_pressure::",
         "tcwv": "total_column_water_vapour::",
         "tp": "total_precipitation::",
-        "u50": "u_component_of_wind::50",
-        "u100": "u_component_of_wind::100",
-        "u150": "u_component_of_wind::150",
-        "u200": "u_component_of_wind::200",
-        "u250": "u_component_of_wind::250",
-        "u300": "u_component_of_wind::300",
-        "u400": "u_component_of_wind::400",
-        "u500": "u_component_of_wind::500",
-        "u600": "u_component_of_wind::600",
-        "u700": "u_component_of_wind::700",
-        "u850": "u_component_of_wind::850",
-        "u925": "u_component_of_wind::925",
-        "u1000": "u_component_of_wind::1000",
-        "v50": "v_component_of_wind::50",
-        "v100": "v_component_of_wind::100",
-        "v150": "v_component_of_wind::150",
-        "v200": "v_component_of_wind::200",
-        "v250": "v_component_of_wind::250",
-        "v300": "v_component_of_wind::300",
-        "v400": "v_component_of_wind::400",
-        "v500": "v_component_of_wind::500",
-        "v600": "v_component_of_wind::600",
-        "v700": "v_component_of_wind::700",
-        "v850": "v_component_of_wind::850",
-        "v925": "v_component_of_wind::925",
-        "v1000": "v_component_of_wind::1000",
-        "z50": "geopotential::50",
-        "z100": "geopotential::100",
-        "z150": "geopotential::150",
-        "z200": "geopotential::200",
-        "z250": "geopotential::250",
-        "z300": "geopotential::300",
-        "z400": "geopotential::400",
-        "z500": "geopotential::500",
-        "z600": "geopotential::600",
-        "z700": "geopotential::700",
-        "z850": "geopotential::850",
-        "z925": "geopotential::925",
-        "z1000": "geopotential::1000",
-        "t50": "temperature::50",
-        "t100": "temperature::100",
-        "t150": "temperature::150",
-        "t200": "temperature::200",
-        "t250": "temperature::250",
-        "t300": "temperature::300",
-        "t400": "temperature::400",
-        "t500": "temperature::500",
-        "t600": "temperature::600",
-        "t700": "temperature::700",
-        "t850": "temperature::850",
-        "t925": "temperature::925",
-        "t1000": "temperature::1000",
-        "q50": "specific_humidity::50",
-        "q100": "specific_humidity::100",
-        "q150": "specific_humidity::150",
-        "q200": "specific_humidity::200",
-        "q250": "specific_humidity::250",
-        "q300": "specific_humidity::300",
-        "q400": "specific_humidity::400",
-        "q500": "specific_humidity::500",
-        "q600": "specific_humidity::600",
-        "q700": "specific_humidity::700",
-        "q850": "specific_humidity::850",
-        "q925": "specific_humidity::925",
-        "q1000": "specific_humidity::1000",
     }
+    VOCAB.update({f"u{level}" : f"u_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"v{level}" : f"'v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"z{level}" : f"geopotential::{level}" for level in LEVELS})
+    VOCAB.update({f"t{level}" : f"temperature::{level}" for level in LEVELS})
+    VOCAB.update({f"q{level}" : f"specific_humidity::{level}" for level in LEVELS})
 
     @classmethod
     def get_item(cls, val: str) -> tuple[str, Callable]:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Including all of the pressure levels <= 1 hPa for z, t, u, v and q variables.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
No new dependencies