### PR TITLE
Update numpy array comparisons to use isin

### DIFF
--- a/earth2studio/io/kv.py
+++ b/earth2studio/io/kv.py
@@ -191,7 +191,7 @@ class KVBackend:
                 self.root[name][
                     np.ix_(
                         *[
-                            np.where(np.in1d(self.coords[dim], value))[0]
+                            np.where(np.isin(self.coords[dim], value))[0]
                             for dim, value in adjusted_coords.items()
                         ]
                     )
@@ -262,7 +262,7 @@ class KVBackend:
         x = self.root[array_name][
             np.ix_(
                 *[
-                    np.where(np.in1d(self.coords[dim], value))[0]
+                    np.where(np.isin(self.coords[dim], value))[0]
                     for dim, value in adjusted_coords.items()
                 ]
             )

--- a/earth2studio/io/netcdf4.py
+++ b/earth2studio/io/netcdf4.py
@@ -279,7 +279,7 @@ class NetCDF4Backend:
                 self.root[name][
                     tuple(
                         [
-                            np.where(np.in1d(self.coords[dim], value))[0]
+                            np.where(np.isin(self.coords[dim], value))[0]
                             for dim, value in adjusted_coords.items()
                         ]
                     )
@@ -326,7 +326,7 @@ class NetCDF4Backend:
         x = self.root[array_name][
             tuple(
                 [
-                    np.where(np.in1d(self.coords[dim], value))[0]
+                    np.where(np.isin(self.coords[dim], value))[0]
                     for dim, value in adjusted_coords.items()
                 ]
             )

--- a/earth2studio/io/xarray.py
+++ b/earth2studio/io/xarray.py
@@ -211,7 +211,7 @@ class XarrayBackend:
                 self.root[name][
                     tuple(
                         [
-                            np.where(np.in1d(self.coords[dim], value))[0]
+                            np.where(np.isin(self.coords[dim], value))[0]
                             for dim, value in adjusted_coords.items()
                         ]
                     )
@@ -260,7 +260,7 @@ class XarrayBackend:
         x = self.root[array_name].values[
             np.ix_(
                 *[
-                    np.where(np.in1d(self.coords[dim], value))[0]
+                    np.where(np.isin(self.coords[dim], value))[0]
                     for dim, value in adjusted_coords.items()
                 ]
             )

--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -401,7 +401,7 @@ class ZarrBackend:
         x = self.root[array_name][
             np.ix_(
                 *[
-                    np.where(np.in1d(self.coords[dim], value))[0]
+                    np.where(np.isin(self.coords[dim], value))[0]
                     for dim, value in adjusted_coords.items()
                 ]
             )

--- a/examples/05_ensemble_workflow_extend.py
+++ b/examples/05_ensemble_workflow_extend.py
@@ -105,7 +105,7 @@ class ApplyToVariable:
         # Apply perturbation
         xp, _ = self.pm(x, coords)
         # Add perturbed slice back into original tensor
-        ind = np.in1d(coords["variable"], self.variable)
+        ind = np.isin(coords["variable"], self.variable)
         x[..., ind, :, :] = xp[..., ind, :, :]
         return x, coords
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
This small PR migrates `np.in1d` to `np.isin` in order to resolve the deprecation warnings:
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
