### PR TITLE
HRRR Async Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hemispheric centred bred vector perturbation now supports single/odd batch sizes
 - Refactored NCAR ERA5 source to have async structure
 - Refactored GFS and GFS_FX to have async structure
+- Refactored HRRR and HRRR_FX to have async structure
 - Expanded the data source protocol to also include async fetch functions for async
   data sources
 

--- a/earth2studio/data/base.py
+++ b/earth2studio/data/base.py
@@ -116,7 +116,7 @@ class ForecastSource(Protocol):
         lead_time: timedelta | list[timedelta] | LeadTimeArray,
         variable: str | list[str] | VariableArray,
     ) -> xr.DataArray:
-        """Async function to get data. Async data sources support.
+        """Async function to get data. Async forecast sources support this.
 
         Parameters
         ----------

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -387,7 +387,6 @@ class GFS:
             Dictionary of GFS vairables (byte offset, byte length)
         """
         # Grab index file
-        # TODO: Change remote file to be more proper fetch
         index_file = await self._fetch_remote_file(index_uri)
         with open(index_file) as file:
             index_lines = [line.rstrip() for line in file]

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -235,6 +235,12 @@ class GFS:
         if not self._cache:
             shutil.rmtree(self.cache)
 
+        # Close aiohttp client if s3fs
+        # https://github.com/fsspec/s3fs/issues/943
+        # https://github.com/zarr-developers/zarr-python/issues/2901
+        if isinstance(self.fs, s3fs.S3FileSystem):
+            s3fs.S3FileSystem.close_session(asyncio.get_event_loop(), self.fs.s3)
+
         return xr_array.isel(lead_time=0)
 
     async def _create_tasks(

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -349,7 +349,7 @@ class GFS:
         xr.DataArray
             FS data array for given time and lead time
         """
-        logger.debug(f"Fetching GRS grib file: {grib_uri} {byte_offset}-{byte_length}")
+        logger.debug(f"Fetching GFS grib file: {grib_uri} {byte_offset}-{byte_length}")
         # Download the grib file to cache
         grib_file = await self._fetch_remote_file(
             grib_uri,

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -14,32 +14,538 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import concurrent.futures
+import functools
+import hashlib
 import os
 import pathlib
 import shutil
 import warnings
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
+import gcsfs
+import nest_asyncio
 import numpy as np
 import s3fs
 import xarray as xr
 from fsspec.implementations.cached import WholeFileCacheFileSystem
+from fsspec.implementations.ftp import FTPFileSystem
 from loguru import logger
-from tqdm import tqdm
+from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     datasource_cache_root,
     prep_data_inputs,
     prep_forecast_inputs,
 )
-from earth2studio.lexicon import HRRRFXLexicon, HRRRLexicon
+from earth2studio.lexicon.hrrr import HRRRFXLexicon, HRRRLexicon, HRRRLexiconNew
 from earth2studio.utils.imports import check_extra_imports
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
 
 logger.remove()
 logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
+
+
+@dataclass
+class HRRRAsyncTask:
+    """Small helper struct for Async tasks"""
+
+    data_array_indices: tuple[int, int, int]
+    hrrr_file_uri: str
+    hrrr_byte_offset: int
+    hrrr_byte_length: int
+    hrrr_modifier: Callable
+
+
+# No more herbie, we can be faster
+class HRRRNew:
+    """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
+    weather analysis data developed by NOAA (used to initialize the HRRR forecast
+    model). This data source is provided on a Lambert conformal 3km grid at 1-hour
+    intervals. The spatial dimensionality of HRRR data is [1059, 1799].
+
+    Parameters
+    ----------
+    source : str, optional
+        Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
+    max_workers : int, optional
+        Maximum number of concurrent downloads, potentially not thread safe with Herbie,
+        by default 1
+    cache : bool, optional
+        Cache data source on local memory, by default True
+    verbose : bool, optional
+        Print download progress, by default True
+
+    Warning
+    -------
+    This is a remote data source and can potentially download a large amount of data
+    to your local machine for large requests.
+
+    Note
+    ----
+    Additional information on the data repository can be referenced here:
+
+    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
+    - https://rapidrefresh.noaa.gov/hrrr/
+    - https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
+    - https://hrrrzarr.s3.amazonaws.com/index.html
+    - https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+    """
+
+    HRRR_BUCKET_NAME = "noaa-hrrr-bdp-pds"
+    MAX_BYTE_SIZE = 5000000
+
+    HRRR_X = np.arange(1799)
+    HRRR_Y = np.arange(1059)
+
+    def __init__(
+        self,
+        source: str = "aws",
+        cache: bool = True,
+        verbose: bool = True,
+        async_timeout: int = 600,
+    ):
+        self._cache = cache
+        self._verbose = verbose
+
+        # Silence cfgrib warning, TODO Remove this
+        warnings.simplefilter(action="ignore", category=FutureWarning)
+
+        if source == "aws":
+            self.uri_prefix = "noaa-hrrr-bdp-pds"
+            self.fs = s3fs.S3FileSystem(anon=True, client_kwargs={}, asynchronous=True)
+
+            # To update look at https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
+            def _range(time: datetime) -> None:
+                if time < datetime(year=2021, month=1, day=1):
+                    raise ValueError(
+                        f"Requested date time {time} needs to be after January 1st, 2021 for GFS on AWS"
+                    )
+
+            self._history_range = _range
+        elif source == "google":
+            self.uri_prefix = "high-resolution-rapid-refresh"
+            self.fs = gcsfs.GCSFileSystem(
+                cache_timeout=-1,
+                token="anon",  # noqa: S106 # nosec B106
+                access="read_only",
+                block_size=8**20,
+            )
+
+            # To update look at https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+            def _range(time: datetime) -> None:
+                if time < datetime(year=2014, month=7, day=30):
+                    raise ValueError(
+                        f"Requested date time {time} needs to be after July 30th, 2014 for HRRR on GCS"
+                    )
+
+            self._history_range = _range
+        elif source == "azure":
+            raise NotImplementedError(
+                "Azure data source not implemented yet, open an issue if needed"
+            )
+        elif source == "nomads":
+            # Could use http location, but using ftp since better for larger data
+            # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
+            self.uri_prefix = "pub/data/nccf/com/hrrr/prod/"
+            self.fs = FTPFileSystem(host="nomads.ncep.noaa.gov")
+
+            def _range(time: datetime) -> None:
+                if time + timedelta(days=2) < datetime.today():
+                    raise ValueError(
+                        f"Requested date time {time} needs to be within past 2 days for HRRR nomads source"
+                    )
+
+            self._history_range = _range
+        else:
+            raise ValueError(f"Invalid HRRR source {source}")
+
+        self.async_timeout = async_timeout
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve HRRR initial data to be used for initial conditions for the given
+        time, variable information, and optional history.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            GFS weather data array
+        """
+        nest_asyncio.apply()  # Patch asyncio to work in notebooks
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If no event loop exists, create one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        xr_array = loop.run_until_complete(
+            asyncio.wait_for(self.fetch(time, variable), timeout=self.async_timeout)
+        )
+
+        return xr_array
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async function to get data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the GFS lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            GFS weather data array
+        """
+        time, variable = prep_data_inputs(time, variable)
+        # Create cache dir if doesnt exist
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        # Make sure input time is valid
+        self._validate_time(time)
+
+        # Note, this could be more memory efficient and avoid pre-allocation of the array
+        # but this is much much cleaner to deal with
+        xr_array = xr.DataArray(
+            data=np.empty(
+                (
+                    len(time),
+                    1,
+                    len(variable),
+                    len(self.HRRR_Y),
+                    len(self.HRRR_X),
+                )
+            ),
+            dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
+            coords={
+                "time": time,
+                "lead_time": [timedelta(hours=0)],
+                "variable": variable,
+                "hrrr_x": self.HRRR_X,
+                "hrrr_y": self.HRRR_Y,
+            },
+        )
+
+        async_tasks = []
+        async_tasks = await self._create_tasks(time, [timedelta(hours=0)], variable)
+        func_map = map(
+            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
+        )
+
+        await tqdm.gather(
+            *func_map, desc="Fetching HRRR data", disable=(not self._verbose)
+        )
+
+        # Delete cache if needed
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        return xr_array.isel(lead_time=0)
+
+    async def _create_tasks(
+        self, time: list[datetime], lead_time: list[timedelta], variable: list[str]
+    ) -> list[HRRRAsyncTask]:
+        """Create download tasks, each corresponding to one grib byte range
+
+        Parameters
+        ----------
+        times : list[datetime]
+            Timestamps to be downloaded (UTC).
+        variables : list[str]
+            List of variables to be downloaded.
+
+        Returns
+        -------
+        list[dict]
+            List of download tasks
+        """
+        tasks: list[HRRRAsyncTask] = []  # group pressure-level variables
+
+        # Start with fetching all index files for each time / lead time
+        # TODO: Update so only needed products (can tell from parsing variables), for
+        # now fetch all index files because its cheap and easier
+        products = ["wrfsfc", "wrfprs", "wrfnat"]
+        args = [
+            self._grib_index_uri(t, lt, p)
+            for t in time
+            for lt in lead_time
+            for p in products
+        ]
+        func_map = map(self._fetch_index, args)
+        results = await tqdm.gather(
+            *func_map, desc="Fetching HRRR index files", disable=True
+        )
+        for i, t in enumerate(time):
+            for j, lt in enumerate(lead_time):
+                # Get index file dictionaries for each possible product
+                index_files = {p: results.pop(0) for p in products}
+                for k, v in enumerate(variable):
+                    try:
+                        hrrr_name, modifier = HRRRLexiconNew[v]  # type: ignore
+                        hrrr_name = hrrr_name.split("::") + [None, None]
+                        product = hrrr_name[0]
+                        variable_name = hrrr_name[1]
+                        level = hrrr_name[2]
+                        forecastvld = hrrr_name[3]
+                        index = hrrr_name[4]
+                        # Create index key to find byte range
+                        hrrr_key = f"{variable_name}::{level}"
+                        if forecastvld:
+                            hrrr_key = f"{hrrr_key}::{forecastvld}"
+                        else:
+                            if lt == 0:
+                                hrrr_key = f"{hrrr_key}::anl"
+                            else:
+                                hrrr_key = f"{hrrr_key}::{lt.seconds // 60} min fcst"
+                        if index and index.isnumeric():
+                            hrrr_key = index
+                    except KeyError as e:
+                        logger.error(
+                            f"variable id {variable} not found in HRRR lexicon"
+                        )
+                        raise e
+
+                    # Get byte range from index
+                    byte_offset = None
+                    byte_length = None
+                    for key, value in index_files[product].items():
+                        if hrrr_key in key:
+                            byte_offset = value[0]
+                            byte_length = value[1]
+                            break
+
+                    if byte_length is None or byte_offset is None:
+                        logger.warning(
+                            f"Variable {v} not found in index file for time {t} at {lt}, values will be unset"
+                        )
+                        raise Exception()
+
+                    tasks.append(
+                        HRRRAsyncTask(
+                            data_array_indices=(i, j, k),
+                            hrrr_file_uri=self._grib_uri(t, lt, product),
+                            hrrr_byte_offset=byte_offset,
+                            hrrr_byte_length=byte_length,
+                            hrrr_modifier=modifier,
+                        )
+                    )
+        return tasks
+
+    async def fetch_wrapper(
+        self,
+        task: HRRRAsyncTask,
+        xr_array: xr.DataArray,
+    ) -> xr.DataArray:
+        """Small wrapper to pack arrays into the DataArray"""
+        out = await self.fetch_array(
+            task.hrrr_file_uri,
+            task.hrrr_byte_offset,
+            task.hrrr_byte_length,
+            task.hrrr_modifier,
+        )
+        xr_array[*task.data_array_indices] = out
+
+    async def fetch_array(
+        self,
+        grib_uri: str,
+        byte_offset: int,
+        byte_length: int,
+        modifier: Callable,
+    ) -> np.ndarray:
+        """Fetch GFS data array. This will first fetch the index file to get byte range
+        of the needed data, fetch the respective grib files and lastly combining grib
+        files into single data array.
+
+        Parameters
+        ----------
+        time : datetime
+            Date time to fetch
+        lead_time : timedelta
+            Forecast lead time to fetch
+        variables : list[str]
+            Variables to fetch
+
+        Returns
+        -------
+        xr.DataArray
+            FS data array for given time and lead time
+        """
+        logger.debug(f"Fetching GRS grib file: {grib_uri} {byte_offset}-{byte_length}")
+        # Download the grib file to cache
+        grib_file = await self._fetch_remote_file(
+            grib_uri,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+        )
+        # Open into xarray data-array
+        da = xr.open_dataarray(
+            grib_file, engine="cfgrib", backend_kwargs={"indexpath": ""}
+        )
+        return modifier(da.values)
+
+    def _validate_time(self, times: list[datetime]) -> None:
+        """Verify if date time is valid for GFS based on offline knowledge
+
+        Parameters
+        ----------
+        times : list[datetime]
+            list of date times to fetch data
+        """
+        for time in times:
+            if not (time - datetime(1900, 1, 1)).total_seconds() % 3600 == 0:
+                raise ValueError(
+                    f"Requested date time {time} needs to be 1 hour interval for HRRR"
+                )
+            # Check history range for given source
+            self._history_range(time)
+
+    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int]]:
+        """Fetch GFS atmospheric index file
+
+        Parameters
+        ----------
+        index_uri : str
+            URI to grib index file to download
+
+        Returns
+        -------
+        dict[str, tuple[int, int]]
+            Dictionary of GFS vairables (byte offset, byte length)
+        """
+        # Grab index file
+        index_file = await self._fetch_remote_file(index_uri)
+        with open(index_file) as file:
+            index_lines = [line.rstrip() for line in file]
+
+        index_table = {}
+        # Note we actually drop the last variable here because its easier (SBT114)
+        # Example of row: "1:0:d=2021111823:REFC:entire atmosphere:795 min fcst:"
+        for i, line in enumerate(index_lines[:-1]):
+            lsplit = line.split(":")
+            if len(lsplit) < 7:
+                continue
+
+            nlsplit = index_lines[i + 1].split(":")
+            byte_length = int(nlsplit[1]) - int(lsplit[1])
+            byte_offset = int(lsplit[1])
+            key = f"{lsplit[0]}::{lsplit[3]}::{lsplit[4]}::{lsplit[5]}"
+            if byte_length > self.MAX_BYTE_SIZE:
+                raise ValueError(
+                    f"Byte length, {byte_length}, of variable {key} larger than safe threshold of {self.MAX_BYTE_SIZE}"
+                )
+
+            index_table[key] = (byte_offset, byte_length)
+
+        # Pop place holder
+        return index_table
+
+    async def _fetch_remote_file(
+        self, path: str, byte_offset: int = 0, byte_length: int | None = None
+    ) -> str:
+        """Fetches remote file into cache"""
+        sha = hashlib.sha256((path + str(byte_offset)).encode())
+        filename = sha.hexdigest()
+        cache_path = os.path.join(self.cache, filename)
+
+        if not pathlib.Path(cache_path).is_file():
+            if self.fs.async_impl:
+                if byte_length:
+                    byte_length = int(byte_offset + byte_length)
+                data = await self.fs._cat_file(path, start=byte_offset, end=byte_length)
+            else:
+                data = await asyncio.to_thread(
+                    self.fs.read_block, path, offset=byte_offset, length=byte_length
+                )
+            with open(cache_path, "wb") as file:
+                await asyncio.to_thread(file.write, data)
+
+        return cache_path
+
+    def _grib_uri(
+        self, time: datetime, lead_time: timedelta, product: str = "wrfsfc"
+    ) -> str:
+        """Generates the URI for HRRR grib files"""
+        lead_hour = int(lead_time.total_seconds() // 3600)
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
+        file_name = os.path.join(
+            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2"
+        )
+        return os.path.join(self.uri_prefix, file_name)
+
+    def _grib_index_uri(
+        self, time: datetime, lead_time: timedelta, product: str
+    ) -> str:
+        """Generates the URI for HRRR index grib files"""
+        # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
+        lead_hour = int(lead_time.total_seconds() // 3600)
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
+        file_name = os.path.join(
+            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2.idx"
+        )
+        return os.path.join(self.uri_prefix, file_name)
+
+    @property
+    def cache(self) -> str:
+        """Return appropriate cache location."""
+        cache_location = os.path.join(datasource_cache_root(), "hrrr")
+        if not self._cache:
+            cache_location = os.path.join(cache_location, "tmp_hrrr")
+        return cache_location
+
+    @classmethod
+    def available(
+        cls,
+        time: datetime | np.datetime64,
+    ) -> bool:
+        """Checks if given date time is avaliable in the HRRR object store. Uses S3
+        store
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date time to access
+
+        Returns
+        -------
+        bool
+            If date time is avaiable
+        """
+        if isinstance(time, np.datetime64):  # np.datetime64 -> datetime
+            _unix = np.datetime64(0, "s")
+            _ds = np.timedelta64(1, "s")
+            time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
+
+        fs = s3fs.S3FileSystem(anon=True)
+        # Object store directory for given time
+        # Just picking the first variable to look for
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/hrrr.t{time.hour:0>2}z.wrfnatf00.grib2.idx"
+        s3_uri = f"s3://{cls.HRRR_BUCKET_NAME}/{file_name}"
+        exists = fs.exists(s3_uri)
+
+        return exists
 
 
 @check_extra_imports("data", ["herbie"])
@@ -153,7 +659,7 @@ class _HRRRBase:
                     lexicon: type[HRRRLexicon] | type[HRRRFXLexicon] = HRRRLexicon
                     if ld.total_seconds() != 0:
                         lexicon = HRRRFXLexicon
-                    hrrr_str, modifier = lexicon[v]
+                    hrrr_str, modifier = lexicon[v]  # type: ignore
                     hrrr_class, hrrr_product, hrrr_level, hrrr_var = hrrr_str.split(
                         "::"
                     )
@@ -281,7 +787,7 @@ class _HRRRBase:
         if isinstance(time, np.datetime64):  # np.datetime64 -> datetime
             _unix = np.datetime64(0, "s")
             _ds = np.timedelta64(1, "s")
-            time = datetime.utcfromtimestamp((time - _unix) / _ds)
+            time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
 
         # Offline checks
         try:

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import asyncio
-import concurrent.futures
 import functools
 import hashlib
 import os
@@ -31,7 +30,6 @@ import nest_asyncio
 import numpy as np
 import s3fs
 import xarray as xr
-from fsspec.implementations.cached import WholeFileCacheFileSystem
 from fsspec.implementations.ftp import FTPFileSystem
 from loguru import logger
 from tqdm.asyncio import tqdm
@@ -41,8 +39,7 @@ from earth2studio.data.utils import (
     prep_data_inputs,
     prep_forecast_inputs,
 )
-from earth2studio.lexicon.hrrr import HRRRFXLexicon, HRRRLexicon, HRRRLexiconNew
-from earth2studio.utils.imports import check_extra_imports
+from earth2studio.lexicon import HRRRFXLexicon, HRRRLexicon
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
 
 logger.remove()
@@ -60,8 +57,7 @@ class HRRRAsyncTask:
     hrrr_modifier: Callable
 
 
-# No more herbie, we can be faster
-class HRRRNew:
+class HRRR:
     """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
     weather analysis data developed by NOAA (used to initialize the HRRR forecast
     model). This data source is provided on a Lambert conformal 3km grid at 1-hour
@@ -120,9 +116,11 @@ class HRRRNew:
 
             # To update look at https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
             def _range(time: datetime) -> None:
-                if time < datetime(year=2021, month=1, day=1):
+                # sfc goes back to 2016 for anl, limit based on pressure
+                # frst starts on on the same date pressure starts
+                if time < datetime(year=2018, month=7, day=12, hour=13):
                     raise ValueError(
-                        f"Requested date time {time} needs to be after January 1st, 2021 for GFS on AWS"
+                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
                     )
 
             self._history_range = _range
@@ -136,10 +134,13 @@ class HRRRNew:
             )
 
             # To update look at https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+            # Needs confirmation
             def _range(time: datetime) -> None:
-                if time < datetime(year=2014, month=7, day=30):
+                # sfc goes back to 2016 for anl, limit based on pressure
+                # frst starts on on the same date pressure starts
+                if time < datetime(year=2018, month=7, day=12, hour=13):
                     raise ValueError(
-                        f"Requested date time {time} needs to be after July 30th, 2014 for HRRR on GCS"
+                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
                     )
 
             self._history_range = _range
@@ -163,6 +164,7 @@ class HRRRNew:
         else:
             raise ValueError(f"Invalid HRRR source {source}")
 
+        self.lexicon = HRRRLexicon
         self.async_timeout = async_timeout
 
     def __call__(
@@ -218,7 +220,7 @@ class HRRRNew:
         Returns
         -------
         xr.DataArray
-            GFS weather data array
+            HRRR weather data array
         """
         time, variable = prep_data_inputs(time, variable)
         # Create cache dir if doesnt exist
@@ -230,7 +232,7 @@ class HRRRNew:
         # Note, this could be more memory efficient and avoid pre-allocation of the array
         # but this is much much cleaner to deal with
         xr_array = xr.DataArray(
-            data=np.empty(
+            data=np.zeros(
                 (
                     len(time),
                     1,
@@ -304,24 +306,32 @@ class HRRRNew:
                 index_files = {p: results.pop(0) for p in products}
                 for k, v in enumerate(variable):
                     try:
-                        hrrr_name, modifier = HRRRLexiconNew[v]  # type: ignore
+                        hrrr_name, modifier = self.lexicon[v]  # type: ignore
                         hrrr_name = hrrr_name.split("::") + [None, None]
                         product = hrrr_name[0]
                         variable_name = hrrr_name[1]
                         level = hrrr_name[2]
                         forecastvld = hrrr_name[3]
                         index = hrrr_name[4]
+
                         # Create index key to find byte range
                         hrrr_key = f"{variable_name}::{level}"
                         if forecastvld:
                             hrrr_key = f"{hrrr_key}::{forecastvld}"
                         else:
-                            if lt == 0:
+                            if lt.total_seconds() == 0:
                                 hrrr_key = f"{hrrr_key}::anl"
                             else:
-                                hrrr_key = f"{hrrr_key}::{lt.seconds // 60} min fcst"
+                                hrrr_key = f"{hrrr_key}::{int(lt.total_seconds() // 3600):d} hour fcst"
                         if index and index.isnumeric():
                             hrrr_key = index
+
+                        # Special cases
+                        # could do this better with templates, but this is single instance
+                        if variable_name == "APCP":
+                            hours = int(lt.total_seconds() // 3600)
+                            hrrr_key = f"{variable_name}::{level}::{hours-1:d}-{hours:d} hour acc fcst"
+
                     except KeyError as e:
                         logger.error(
                             f"variable id {variable} not found in HRRR lexicon"
@@ -341,7 +351,7 @@ class HRRRNew:
                         logger.warning(
                             f"Variable {v} not found in index file for time {t} at {lt}, values will be unset"
                         )
-                        raise Exception()
+                        continue
 
                     tasks.append(
                         HRRRAsyncTask(
@@ -548,471 +558,12 @@ class HRRRNew:
         return exists
 
 
-@check_extra_imports("data", ["herbie"])
-class _HRRRBase:
-
-    HRRR_BUCKET_NAME = "noaa-hrrr-bdp-pds"
-    HRRR_X = np.arange(1799)
-    HRRR_Y = np.arange(1059)
-    MAX_BYTE_SIZE = 5000000
-
-    def __init__(
-        self,
-        cache: bool = True,
-        verbose: bool = True,
-        source: str = "aws",
-        max_workers: int = 1,
-    ):
-        self._cache = cache
-        self._verbose = verbose
-        self._source = source
-        self._max_workers = max_workers
-
-        self.fs = s3fs.S3FileSystem(
-            anon=True,
-            default_block_size=2**20,
-            client_kwargs={},
-        )
-
-        # Doesnt work with read block, only use with index file
-        cache_options = {
-            "cache_storage": self.cache,
-            "expiry_time": 31622400,  # 1 year
-        }
-        self.fsc = WholeFileCacheFileSystem(fs=self.fs, **cache_options)
-
-        # Initialize Herbie client
-        try:
-            from herbie import Herbie
-
-            # Silence cfgrib warning
-            warnings.simplefilter(action="ignore", category=FutureWarning)
-            self.Herbie = Herbie
-        except ImportError:
-            raise ImportError(
-                "Some data dependencies are missing (Herbie). Please install them using 'pip install earth2studio[data]'"
-            )
-
-    def fetch(
-        self,
-        time: list[datetime],
-        lead_time: list[timedelta],
-        variable: list[str],
-    ) -> xr.DataArray:
-        """Function to retrieve HRRR forecast data into a single Xarray data array
-
-        Parameters
-        ----------
-        time : list[datetime]
-            Timestamps to return data for (UTC).
-        lead_time: list[timedelta]
-            List of forecast lead times to fetch
-        variable : str | list[str] | VariableArray
-            String, list of strings or array of strings that refer to variables to
-            return. Must be in the HRRR lexicon.
-
-        Returns
-        -------
-        xr.DataArray
-            HRRR weather data array
-        """
-
-        hrrr_da = xr.DataArray(
-            data=np.empty(
-                (
-                    len(time),
-                    len(lead_time),
-                    len(variable),
-                    len(self.HRRR_Y),
-                    len(self.HRRR_X),
-                )
-            ),
-            dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
-            coords={
-                "time": time,
-                "lead_time": lead_time,
-                "variable": variable,
-                "hrrr_x": self.HRRR_X,
-                "hrrr_y": self.HRRR_Y,
-            },
-        )
-
-        args = [
-            (t, i, ld, j, v, k)
-            for k, v in enumerate(variable)
-            for j, ld in enumerate(lead_time)
-            for i, t in enumerate(time)
-        ]
-        pbar = tqdm(
-            total=len(args), desc="Fetching HRRR data", disable=(not self._verbose)
-        )
-
-        # Use ThreadPoolExecutor to parallelize Herbie calls
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self._max_workers
-        ) as executor:
-            futures = []
-
-            for t, i, ld, j, v, k in args:
-                try:
-                    # Set lexicon based on lead
-                    lexicon: type[HRRRLexicon] | type[HRRRFXLexicon] = HRRRLexicon
-                    if ld.total_seconds() != 0:
-                        lexicon = HRRRFXLexicon
-                    hrrr_str, modifier = lexicon[v]  # type: ignore
-                    hrrr_class, hrrr_product, hrrr_level, hrrr_var = hrrr_str.split(
-                        "::"
-                    )
-                except KeyError as e:
-                    logger.error(f"variable id {v} not found in HRRR lexicon")
-                    raise e
-
-                # Submit the Herbie task to the thread pool
-                future = executor.submit(
-                    self._fetch_herbie_data,
-                    t,
-                    ld,
-                    hrrr_class,
-                    hrrr_level,
-                    hrrr_var,
-                    modifier,
-                    (i, j, k),
-                )
-                futures.append((future, i, j, k))
-
-            # Process completed futures as they finish
-            for future in concurrent.futures.as_completed([f[0] for f in futures]):
-                data, coords, indices = future.result()
-                hrrr_da[tuple(indices)] = data
-
-                # Add lat/lon coordinates if not present
-                if "lat" not in hrrr_da.coords:
-                    hrrr_da.coords["lat"] = coords["lat"]
-                    hrrr_da.coords["lon"] = coords["lon"]
-                pbar.update(1)
-
-        # Delete cache if needed
-        if not self._cache:
-            shutil.rmtree(self.cache)
-
-        return hrrr_da
-
-    def _fetch_herbie_data(
-        self,
-        time: datetime,
-        lead_time: timedelta,
-        hrrr_class: str,
-        hrrr_level: str,
-        hrrr_var: str,
-        modifier: Callable,
-        indices: tuple[int, int, int],
-    ) -> tuple[np.ndarray, dict, tuple[int, int, int]]:
-        """Helper method to fetch data using Herbie"""
-        # Create Herbie object for this timestamp and forecast
-        H = self.Herbie(
-            date=time,
-            model="hrrr",
-            product=hrrr_class,
-            fxx=int(lead_time.total_seconds() // 3600),
-            priority=[self._source],
-            verbose=False,
-            save_dir=self.cache,
-        )
-
-        # Construct search string for the variable
-        if hrrr_level == "surface":
-            search_term = f"{hrrr_var}:surface"
-        else:
-            search_term = f"{hrrr_var}:{hrrr_level}"
-
-        # Read the data using Herbie
-        # Keep grib files cached
-        data = H.xarray(search_term, remove_grib=False)
-        data = list(data.values())[0]
-
-        # Return both the modified data and the coordinates
-        coords = {
-            "lat": (["hrrr_y", "hrrr_x"], data.coords["latitude"].values),
-            "lon": (["hrrr_y", "hrrr_x"], data.coords["longitude"].values),
-        }
-
-        return modifier(data.values), coords, indices
-
-    @classmethod
-    def _validate_time(cls, times: list[datetime]) -> None:
-        """Verify if date time is valid for HRRR
-
-        Parameters
-        ----------
-        times : list[datetime]
-            list of date times to fetch data
-        """
-        for time in times:
-            if not (time - datetime(1900, 1, 1)).total_seconds() % 3600 == 0:
-                raise ValueError(
-                    f"Requested date time {time} needs to be 1 hour interval for HRRR"
-                )
-            # sfc goes back to 2016 for anl, limit based on pressure
-            # frst starts on on the same date pressure starts
-            if time < datetime(year=2018, month=7, day=12, hour=13):
-                raise ValueError(
-                    f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
-                )
-
-    @property
-    def cache(self) -> str:
-        """Return appropriate cache location."""
-        cache_location = os.path.join(datasource_cache_root(), "hrrr")
-        if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_hrrr")
-        return cache_location
-
-    @classmethod
-    def available(
-        cls,
-        time: datetime | np.datetime64,
-    ) -> bool:
-        """Checks if given date time is avaliable in the HRRR store
-
-        Parameters
-        ----------
-        time : datetime | np.datetime64
-            Date time to access
-
-        Returns
-        -------
-        bool
-            If date time is avaiable
-        """
-        if isinstance(time, np.datetime64):  # np.datetime64 -> datetime
-            _unix = np.datetime64(0, "s")
-            _ds = np.timedelta64(1, "s")
-            time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
-
-        # Offline checks
-        try:
-            cls._validate_time([time])
-        except ValueError:
-            return False
-
-        fs = s3fs.S3FileSystem(anon=True)
-
-        # Object store directory for given date
-        date_group = time.strftime("%Y%m%d")
-        forcast_hour = time.strftime("%H")
-        s3_uri = f"{cls.HRRR_BUCKET_NAME}/hrrr.{date_group}/conus/hrrr.t{forcast_hour}z.wrfsfcf00.grib2.idx"
-
-        return fs.exists(s3_uri)
-
-
-# Leaving in here to dream, no natural levels in this data source
-# class _HRRRZarrBase(_HRRRBase):
-#     # Not used but keeping here for now for future reference
-#     HRRR_BUCKET_NAME = "hrrrzarr"
-#     HRRR_X = np.arange(1799)
-#     HRRR_Y = np.arange(1059)
-
-#     def __init__(
-#         self,
-#         lexicon: HRRRLexicon | HRRRFXLexicon,
-#         cache: bool = True,
-#         verbose: bool = True,
-#     ):
-#         self._cache = cache
-#         self._lexicon = lexicon
-#         self._verbose = verbose
-
-#         fs = s3fs.S3FileSystem(
-#             anon=True,
-#             default_block_size=2**20,
-#             client_kwargs={},
-#         )
-
-#         if self._cache:
-#             cache_options = {
-#                 "cache_storage": self.cache,
-#                 "expiry_time": 31622400,  # 1 year
-#             }
-#             fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
-
-#         fs_map = fsspec.FSMap(f"s3://{self.HRRR_BUCKET_NAME}", fs)
-#         self.zarr_group = zarr.open(fs_map, mode="r")
-
-#     async def async_fetch(
-#         self,
-#         time: list[datetime],
-#         lead_time: list[timedelta],
-#         variable: list[str],
-#     ) -> xr.DataArray:
-#         """Async function to retrieve HRRR forecast data into a single Xarray data array
-
-#         Parameters
-#         ----------
-#         time : list[datetime]
-#             Timestamps to return data for (UTC).
-#         lead_time: list[timedelta]
-#             List of forecast lead times to fetch
-#         variable : str | list[str] | VariableArray
-#             String, list of strings or array of strings that refer to variables to
-#             return. Must be in the HRRR lexicon.
-
-#         Returns
-#         -------
-#         xr.DataArray
-#             HRRR weather data array
-#         """
-
-#         hrrr_da = xr.DataArray(
-#             data=np.empty(
-#                 (
-#                     len(time),
-#                     len(lead_time),
-#                     len(variable),
-#                     len(self.HRRR_Y),
-#                     len(self.HRRR_X),
-#                 )
-#             ),
-#             dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
-#             coords={
-#                 "time": time,
-#                 "lead_time": lead_time,
-#                 "variable": variable,
-#                 "hrrr_x": self.HRRR_X,
-#                 "hrrr_y": self.HRRR_Y,
-#                 "lat": (
-#                     ["hrrr_y", "hrrr_x"],
-#                     self.zarr_group["grid"]["HRRR_chunk_index.zarr"]["latitude"][:],
-#                 ),
-#                 "lon": (
-#                     ["hrrr_y", "hrrr_x"],
-#                     self.zarr_group["grid"]["HRRR_chunk_index.zarr"]["longitude"][:]
-#                     + 360,
-#                 ),  # Change to [0,360]
-#             },
-#         )
-#         # Banking on async calls in zarr 3.0
-#         for i, t in enumerate(time):
-#             for j, ld in enumerate(lead_time):
-#                 # Set lexicon based on lead
-#                 lexicon: type[HRRRLexicon] | type[HRRRFXLexicon] = HRRRLexicon
-#                 if ld.total_seconds() != 0:
-#                     lexicon = HRRRFXLexicon
-#                 for k, v in enumerate(variable):
-#                     try:
-#                         hrrr_str, modifier = lexicon[v]
-#                         hrrr_class, hrrr_product, hrrr_level, hrrr_var = hrrr_str.split(
-#                             "::"
-#                         )
-#                     except KeyError as e:
-#                         logger.error(f"variable id {v} not found in HRRR lexicon")
-#                         raise e
-
-#                     date_group = t.strftime("%Y%m%d")
-#                     time_group = t.strftime(f"%Y%m%d_%Hz_{hrrr_product}.zarr")
-
-#                     logger.debug(
-#                         f"Fetching HRRR {hrrr_product} variable {v} at {t.isoformat()}"
-#                     )
-
-#                     data = self.zarr_group[hrrr_class][date_group][time_group][
-#                         hrrr_level
-#                     ][hrrr_var][hrrr_level][hrrr_var]
-#                     if hrrr_product == "fcst":
-#                         # Minus 1 here because index 0 is forecast with leadtime 1hr
-#                         # forecast_period coordinate system tells what the lead times are in hours
-#                         lead_index = int(ld.total_seconds() // 3600) - 1
-#                         data = data[lead_index]
-
-#                     hrrr_da[i, j, k] = modifier(data)
-
-#         # Delete cache if needed
-#         if not self._cache:
-#             shutil.rmtree(self.cache)
-
-#         return hrrr_da
-
-
-class HRRR(_HRRRBase):
-    """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
-    weather analysis data developed by NOAA (used to initialize the HRRR forecast
-    model). This data source is provided on a Lambert conformal 3km grid at 1-hour
-    intervals. The spatial dimensionality of HRRR data is [1059, 1799]. This data source
-    pulls data from the HRRR zarr bucket on S3.
-
-    Parameters
-    ----------
-    source : str, optional
-        Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
-    max_workers : int, optional
-        Maximum number of concurrent downloads, potentially not thread safe with Herbie,
-        by default 1
-    cache : bool, optional
-        Cache data source on local memory, by default True
-    verbose : bool, optional
-        Print download progress, by default True
-
-    Warning
-    -------
-    This is a remote data source and can potentially download a large amount of data
-    to your local machine for large requests.
-
-    Note
-    ----
-    Additional information on the data repository can be referenced here:
-
-    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
-    - https://rapidrefresh.noaa.gov/hrrr/
-    - https://hrrrzarr.s3.amazonaws.com/index.html
-    - https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
-    """
-
-    def __init__(
-        self,
-        source: str = "aws",
-        max_workers: int = 1,
-        cache: bool = True,
-        verbose: bool = True,
-    ):
-        super().__init__(cache, verbose, source, max_workers)
-
-    def __call__(
-        self,
-        time: datetime | list[datetime] | TimeArray,
-        variable: str | list[str] | VariableArray,
-    ) -> xr.DataArray:
-        """Retrieve HRRR initial data to be used for initial conditions for the given
-        time, variable information, and optional history.
-
-        Parameters
-        ----------
-        time : datetime | list[datetime] | TimeArray
-            Timestamps to return data for (UTC).
-        variable : str | list[str] | VariableArray
-            String, list of strings or array of strings that refer to variables to
-            return. Must be in the HRRR lexicon.
-
-        Returns
-        -------
-        xr.DataArray
-            HRRR analysis data array
-        """
-        time, variable = prep_data_inputs(time, variable)
-
-        # Create cache dir if doesnt exist
-        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
-
-        # Make sure input time is valid
-        self._validate_time(time)
-        data_array = self.fetch(time, [timedelta(hours=0)], variable)
-        return data_array.isel(lead_time=0).drop_vars("lead_time")
-
-
-class HRRR_FX(_HRRRBase):
+class HRRR_FX(HRRR):
     """High-Resolution Rapid Refresh (HRRR) forecast source provides a North-American
     weather forecasts with hourly forecast runs developed by NOAA. This forecast source
     has hourly forecast steps up to a lead time of 48 hours. Data is provided on a
     Lambert conformal 3km grid at 1-hour intervals. The spatial dimensionality of HRRR
-    data is [1059, 1799]. This data source pulls data from the HRRR zarr bucket on S3.
+    data is [1059, 1799].
 
     Parameters
     ----------
@@ -1047,13 +598,14 @@ class HRRR_FX(_HRRRBase):
     def __init__(
         self,
         source: str = "aws",
-        max_workers: int = 4,
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
-        super().__init__(cache, verbose, source, max_workers)
+        super().__init__(source, cache, verbose, async_timeout)
+        self.lexicon = HRRRFXLexicon
 
-    def __call__(
+    def __call__(  # type: ignore[override]
         self,
         time: datetime | list[datetime] | TimeArray,
         lead_time: timedelta | list[timedelta] | LeadTimeArray,
@@ -1076,15 +628,91 @@ class HRRR_FX(_HRRRBase):
         xr.DataArray
             HRRR forecast data array
         """
-        time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
+        nest_asyncio.apply()  # Patch asyncio to work in notebooks
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If no event loop exists, create one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
+        xr_array = loop.run_until_complete(
+            asyncio.wait_for(
+                self.fetch(time, lead_time, variable), timeout=self.async_timeout
+            )
+        )
+
+        return xr_array
+
+    async def fetch(  # type: ignore[override]
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async function to get data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR FX lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            HRRR weather data array
+        """
+        time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
         # Create cache dir if doesnt exist
         pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
 
         # Make sure input time is valid
         self._validate_time(time)
         self._validate_leadtime(lead_time)
-        return self.fetch(time, lead_time, variable)
+
+        # Note, this could be more memory efficient and avoid pre-allocation of the array
+        # but this is much much cleaner to deal with, compared to something seen in the
+        # NCAR data source.
+        xr_array = xr.DataArray(
+            data=np.empty(
+                (
+                    len(time),
+                    len(lead_time),
+                    len(variable),
+                    len(self.HRRR_Y),
+                    len(self.HRRR_X),
+                )
+            ),
+            dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
+            coords={
+                "time": time,
+                "lead_time": lead_time,
+                "variable": variable,
+                "hrrr_x": self.HRRR_X,
+                "hrrr_y": self.HRRR_Y,
+            },
+        )
+
+        async_tasks = []
+        async_tasks = await self._create_tasks(time, lead_time, variable)
+        func_map = map(
+            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
+        )
+
+        await tqdm.gather(
+            *func_map, desc="Fetching GFS data", disable=(not self._verbose)
+        )
+
+        # Delete cache if needed
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        return xr_array
 
     @classmethod
     def _validate_leadtime(cls, lead_times: list[timedelta]) -> None:

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -469,7 +469,6 @@ class HRRR:
 
             index_table[key] = (byte_offset, byte_length)
 
-        # Pop place holder
         return index_table
 
     async def _fetch_remote_file(

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -21,7 +21,6 @@ import hashlib
 import os
 import pathlib
 import shutil
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -119,14 +118,6 @@ class HRRR:
         self._cache = cache
         self._verbose = verbose
         self._max_workers = max_workers
-
-        if max_workers is not None:
-            warnings.warn(
-                "The max_workers parameter is deprecated and will be removed in a future version. "
-                "The data source now uses async/await pattern instead of ThreadPoolExecutor.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         if source == "aws":
             self.uri_prefix = "noaa-hrrr-bdp-pds"

--- a/earth2studio/lexicon/hrrr.py
+++ b/earth2studio/lexicon/hrrr.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Callable
-from datetime import datetime, timedelta
 
 import numpy as np
 
@@ -22,126 +21,6 @@ from .base import LexiconType
 
 
 class HRRRLexicon(metaclass=LexiconType):
-    """High-Resolution Rapid Refresh Analysis Lexicon
-    HRRR specified <Product ID>::<Parameter ID>::<Level/ Layer>::
-
-    Note
-    ----
-    Additional resources:
-    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
-    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/hrrr.t00z.wrfsfcf00.grib2.shtml
-    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/hrrr.t00z.wrfsfcf02.grib2.shtml
-    """
-
-    @staticmethod
-    def build_vocab() -> dict[str, str]:
-        """Create HRRR vocab dictionary"""
-        sfc_variables = {
-            "u10m": "sfc::anl::10 m above ground::UGRD",
-            "v10m": "sfc::anl::10 m above ground::VGRD",
-            "u80m": "sfc::anl::80 m above ground::UGRD",
-            "v80m": "sfc::anl::80 m above ground::VGRD",
-            "t2m": "sfc::anl::2 m above ground::TMP",
-            "refc": "sfc::anl::entire atmosphere::REFC",
-            "sp": "sfc::anl::surface::PRES",
-            "mslp": "sfc::anl::mean sea level::MSLMA",
-            "tcwv": "sfc::anl::entire atmosphere::PWAT",
-            "csnow": "sfc::anl::surface::CSNOW",
-            "cicep": "sfc::anl::surface::CICEP",
-            "cfrzr": "sfc::anl::surface::CFRZR",
-            "crain": "sfc::anl::surface::CRAIN",
-        }
-        prs_levels = [
-            50,
-            75,
-            100,
-            125,
-            150,
-            175,
-            200,
-            225,
-            250,
-            275,
-            300,
-            325,
-            350,
-            375,
-            400,
-            425,
-            450,
-            475,
-            500,
-            525,
-            550,
-            575,
-            600,
-            625,
-            650,
-            675,
-            700,
-            725,
-            750,
-            775,
-            800,
-            825,
-            850,
-            875,
-            900,
-            925,
-            950,
-            975,
-            1000,
-        ]
-
-        prs_names = ["UGRD", "VGRD", "HGT", "TMP", "RH", "SPFH", "HGT"]
-        e2s_id = ["u", "v", "z", "t", "r", "q", "Z"]
-        prs_variables = {}
-        for id, variable in zip(e2s_id, prs_names):
-            for level in prs_levels:
-                prs_variables[f"{id}{level:d}"] = f"prs::anl::{level} mb::{variable}"
-
-        hybrid_levels = list(range(1, 51))
-        hybrid_names = ["UGRD", "VGRD", "HGT", "TMP", "SPFH", "PRES", "HGT"]
-        e2s_id = ["u", "v", "z", "t", "q", "p", "Z"]
-        hybrid_variables = {}
-        for id, variable in zip(e2s_id, hybrid_names):
-            for level in hybrid_levels:
-                hybrid_variables[f"{id}{level:d}hl"] = (
-                    f"nat::anl::{level} hybrid level::{variable}"
-                )
-
-        return {**sfc_variables, **prs_variables, **hybrid_variables}
-
-    VOCAB = build_vocab()
-
-    @classmethod
-    def index_regex(cls, val: str, time: datetime, lead_time: timedelta) -> str:
-        """Gets regex to check index file for"""
-        hrrr_key = cls.VOCAB[val]
-        variable = hrrr_key.split("::")[3]
-        level = hrrr_key.split("::")[2]
-        return f"{variable}:{level}"
-
-    @classmethod
-    def get_item(cls, val: str) -> tuple[str, Callable]:
-        """Get item from HRRR vocabulary."""
-        hrrr_key = cls.VOCAB[val]
-        if hrrr_key.split("::")[3] == "HGT" and val.startswith("z"):
-
-            def mod(x: np.array) -> np.array:
-                """Modify data value (if necessary)."""
-                return x * 9.81
-
-        else:
-
-            def mod(x: np.array) -> np.array:
-                """Modify data value (if necessary)."""
-                return x
-
-        return hrrr_key, mod
-
-
-class HRRRLexiconNew(metaclass=LexiconType):
     """High-Resolution Rapid Refresh Analysis Lexicon
     HRRR specified <Product ID>::<Parameter ID>::<Level/ Layer>::<Forcast Valid Range(optional)>::<ID Number (optional, override)>
 
@@ -260,8 +139,15 @@ class HRRRLexiconNew(metaclass=LexiconType):
 
 
 class HRRRFXLexicon(metaclass=LexiconType):
-    """High-Resolution Rapid Refresh Forcast Lexicon
-    HRRR specified <Provider ID>::<Product ID>::<Level/ Layer>::<Parameter ID>
+    """High-Resolution Rapid Refresh Analysis Forecast Lexicon
+    HRRR specified <Product ID>::<Parameter ID>::<Level/ Layer>::<Forcast Valid Range(optional)>::<ID Number (optional, override)>
+    Some variables may not be present for analyis / leadtime 0
+
+    Products include:
+        - wrfsfc
+        - wrfprs
+        - wrfnat
+        - wrfsubh
 
     Note
     ----
@@ -275,35 +161,69 @@ class HRRRFXLexicon(metaclass=LexiconType):
     def build_vocab() -> dict[str, str]:
         """Create HRRR vocab dictionary"""
         sfc_variables = {
-            "u10m": "sfc::fcst::10 m above ground::UGRD",
-            "v10m": "sfc::fcst::10 m above ground::VGRD",
-            "u80m": "sfc::fcst::80 m above ground::UGRD",
-            "v80m": "sfc::fcst::80 m above ground::VGRD",
-            "t2m": "sfc::fcst::2 m above ground::TMP",
-            "refc": "sfc::fcst::entire atmosphere::REFC",
-            "sp": "sfc::fcst::surface::PRES",
-            "mslp": "sfc::anl::mean sea level::MSLMA",
-            "tp": "sfc::fcst::surface::APCP",  # APCP_1hr_acc_fcst in Zarr store
-            "tcwv": "sfc::fcst::entire atmosphere::PWAT",
-            "csnow": "sfc::fcst::surface::CSNOW",
-            "cicep": "sfc::fcst::surface::CICEP",
-            "cfrzr": "sfc::fcst::surface::CFRZR",
-            "crain": "sfc::fcst::surface::CRAIN",
+            "u10m": "wrfsfc::UGRD::10 m above ground",
+            "v10m": "wrfsfc::VGRD::10 m above ground",
+            "u80m": "wrfsfc::UGRD::80 m above ground",
+            "v80m": "wrfsfc::VGRD::80 m above ground",
+            "t2m": "wrfsfc::TMP::2 m above ground",
+            "refc": "wrfsfc::REFC::entire atmosphere",
+            "sp": "wrfsfc::PRES::surface",
+            "mslp": "wrfsfc::MSLMA::mean sea level",
+            "tp": "wrfsfc::APCP::surface::x-x hour acc",  # 1 hour accumulated
+            "tcwv": "wrfsfc::PWAT::entire atmosphere (considered as a single layer)",
+            "csnow": "wrfsfc::CSNOW::surface",
+            "cicep": "wrfsfc::CICEP::surface",
+            "cfrzr": "wrfsfc::CFRZR::surface",
+            "crain": "wrfsfc::CRAIN::surface",
         }
         prs_levels = [
+            50,
+            75,
+            100,
+            125,
+            150,
+            175,
+            200,
+            225,
             250,
+            275,
             300,
+            325,
+            350,
+            375,
+            400,
+            425,
+            450,
+            475,
             500,
+            525,
+            550,
+            575,
+            600,
+            625,
+            650,
+            675,
+            700,
+            725,
+            750,
+            775,
+            800,
+            825,
             850,
+            875,
+            900,
             925,
+            950,
+            975,
             1000,
         ]
-        prs_names = ["UGRD", "VGRD"]
-        e2s_id = ["u", "v"]
+
+        prs_names = ["UGRD", "VGRD", "HGT", "TMP", "RH", "SPFH", "HGT"]
+        e2s_id = ["u", "v", "z", "t", "r", "q", "Z"]
         prs_variables = {}
         for id, variable in zip(e2s_id, prs_names):
             for level in prs_levels:
-                prs_variables[f"{id}{level:d}"] = f"sfc::fcst::{level} mb::{variable}"
+                prs_variables[f"{id}{level:d}"] = f"wrfprs::{variable}::{level} mb"
 
         hybrid_levels = list(range(1, 51))
         hybrid_names = ["UGRD", "VGRD", "HGT", "TMP", "SPFH", "PRES", "HGT"]
@@ -312,7 +232,7 @@ class HRRRFXLexicon(metaclass=LexiconType):
         for id, variable in zip(e2s_id, hybrid_names):
             for level in hybrid_levels:
                 hybrid_variables[f"{id}{level:d}hl"] = (
-                    f"nat::fcst::{level} hybrid level::{variable}"
+                    f"wrfnat::{variable}::{level} hybrid level"
                 )
 
         return {**sfc_variables, **prs_variables, **hybrid_variables}
@@ -320,23 +240,10 @@ class HRRRFXLexicon(metaclass=LexiconType):
     VOCAB = build_vocab()
 
     @classmethod
-    def index_regex(cls, val: str, time: datetime, lead_time: timedelta) -> str:
-        """Gets regex to check index file for"""
-        # Deal with ACPC having two different values (thanks NOAA)
-        hrrr_key = cls.VOCAB[val]
-        if val == "tp":
-            lead_index = int(lead_time.total_seconds() // 3600)
-            return f"APCP:surface:{lead_index-1}-{lead_index} hour acc"
-        else:
-            variable = hrrr_key.split("::")[3]
-            level = hrrr_key.split("::")[2]
-            return f"{variable}:{level}"
-
-    @classmethod
     def get_item(cls, val: str) -> tuple[str, Callable]:
         """Get item from HRRR vocabulary."""
         hrrr_key = cls.VOCAB[val]
-        if hrrr_key.split("::")[3] == "HGT" and val.startswith("z"):
+        if hrrr_key.split("::")[1] == "HGT" and val.startswith("z"):
 
             def mod(x: np.array) -> np.array:
                 """Modify data value (if necessary)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ data = [
     "cdsapi>=0.7.5",
     "eccodes>=2.38.0",
     "ecmwf-opendata>=0.3.3",
-    "herbie-data",
+    "pyproj>=3.7.1",
     "scipy>=1.15.2",
 ]
 perturbation = [

--- a/test/data/test_hrrr.py
+++ b/test/data/test_hrrr.py
@@ -74,7 +74,7 @@ def test_hrrr_fetch(time, variable):
         (datetime(year=2022, month=12, day=25), timedelta(hours=1)),
         (
             datetime(year=2022, month=12, day=25),
-            [timedelta(hours=2), timedelta(hours=3)],
+            [timedelta(hours=0), timedelta(hours=3)],
         ),
         (
             np.array(
@@ -86,7 +86,7 @@ def test_hrrr_fetch(time, variable):
 )
 def test_hrrr_fx_fetch(time, lead_time):
     time = datetime(year=2022, month=12, day=25)
-    variable = "t2m"
+    variable = "tp"
     ds = HRRR_FX(cache=False)
     data = ds(time, lead_time, variable)
     shape = data.shape
@@ -182,7 +182,7 @@ def test_hrrr_cache(time, variable, cache):
         pass
 
 
-def test_hrrr_validate_time():
+def test_hrrr_validate_inputs():
     ds = HRRR(cache=False)
 
     # Test valid time
@@ -198,6 +198,10 @@ def test_hrrr_validate_time():
     old_time = datetime(year=2018, month=7, day=12, hour=12)
     with pytest.raises(ValueError):
         ds._validate_time([old_time])
+
+    # Test invalid variable
+    with pytest.raises(KeyError):
+        ds(datetime(year=2024, month=12, day=25), "invalid variable")
 
 
 @pytest.mark.timeout(15)

--- a/test/lexicon/test_hrrr_lexicon.py
+++ b/test/lexicon/test_hrrr_lexicon.py
@@ -38,7 +38,7 @@ def test_hrrr_lexicon(variable, device):
         assert isinstance(label, str)
         assert input.shape == output.shape
         assert input.device == output.device
-        if label.split("::")[0] == "HGT":
+        if label.split("::")[1] == "HGT" and v.startswith("z"):
             torch.allclose(output, 9.81 * input)
 
 
@@ -60,5 +60,5 @@ def test_hrrrfx_run_deterministic(variable, device):
         assert isinstance(label, str)
         assert input.shape == output.shape
         assert input.device == output.device
-        if label.split("::")[3] == "HGT" and v.startswith("z"):
+        if label.split("::")[1] == "HGT" and v.startswith("z"):
             torch.allclose(output, 9.81 * input)

--- a/test/lexicon/test_hrrr_lexicon.py
+++ b/test/lexicon/test_hrrr_lexicon.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta
-
 import pytest
 import torch
 
@@ -44,23 +42,6 @@ def test_hrrr_lexicon(variable, device):
             torch.allclose(output, 9.81 * input)
 
 
-def test_hrrr_index_regex():
-    time = datetime(2024, 1, 1)
-    lead_time = timedelta(hours=1)
-
-    # Test surface variable
-    regex = HRRRLexicon.index_regex("t2m", time, lead_time)
-    assert regex == "TMP:2 m above ground"
-
-    # Test pressure level variable
-    regex = HRRRLexicon.index_regex("u500", time, lead_time)
-    assert regex == "UGRD:500 mb"
-
-    # Test hybrid level variable
-    regex = HRRRLexicon.index_regex("t20hl", time, lead_time)
-    assert regex == "TMP:20 hybrid level"
-
-
 @pytest.mark.parametrize(
     "variable",
     [
@@ -81,19 +62,3 @@ def test_hrrrfx_run_deterministic(variable, device):
         assert input.device == output.device
         if label.split("::")[3] == "HGT" and v.startswith("z"):
             torch.allclose(output, 9.81 * input)
-
-
-def test_hrrrfx_index_regex():
-    time = datetime(2024, 1, 1)
-    # Test total precipitation with different lead times
-    lead_time = timedelta(hours=1)
-    regex = HRRRFXLexicon.index_regex("tp", time, lead_time)
-    assert regex == "APCP:surface:0-1 hour acc"
-
-    lead_time = timedelta(hours=3)
-    regex = HRRRFXLexicon.index_regex("tp", time, lead_time)
-    assert regex == "APCP:surface:2-3 hour acc"
-
-    # Test regular variable
-    regex = HRRRFXLexicon.index_regex("t2m", time, lead_time)
-    assert regex == "TMP:2 m above ground"

--- a/uv.lock
+++ b/uv.lock
@@ -1367,7 +1367,6 @@ all = [
     { name = "ecmwf-opendata" },
     { name = "einops" },
     { name = "flash-attn" },
-    { name = "herbie-data" },
     { name = "importlib-metadata" },
     { name = "jsbeautifier" },
     { name = "makani", extra = ["all"] },
@@ -1379,6 +1378,7 @@ all = [
     { name = "onnx-weekly", marker = "python_full_version >= '3.13' or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-aurora-fork') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-corrdiff') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-dlwp') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-fcn') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-precip-afno') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-sfno') or (extra == 'extra-12-earth2studio-aurora' and extra == 'extra-12-earth2studio-stormcast')" },
     { name = "onnxruntime-gpu" },
     { name = "pynvml" },
+    { name = "pyproj" },
     { name = "ruamel-yaml" },
     { name = "scikit-image" },
     { name = "scipy" },
@@ -1407,7 +1407,7 @@ data = [
     { name = "cdsapi" },
     { name = "eccodes" },
     { name = "ecmwf-opendata" },
-    { name = "herbie-data" },
+    { name = "pyproj" },
     { name = "scipy" },
 ]
 dlesym = [
@@ -1542,8 +1542,6 @@ requires-dist = [
     { name = "gcsfs" },
     { name = "h5netcdf", specifier = ">=1.0.0" },
     { name = "h5py", specifier = ">=3.2.0" },
-    { name = "herbie-data", marker = "extra == 'all'" },
-    { name = "herbie-data", marker = "extra == 'data'" },
     { name = "huggingface-hub", specifier = ">=0.27.0" },
     { name = "importlib-metadata", marker = "extra == 'all'" },
     { name = "importlib-metadata", marker = "extra == 'dlwp'" },
@@ -1596,6 +1594,8 @@ requires-dist = [
     { name = "onnxruntime-gpu", marker = "extra == 'pangu'", specifier = ">=1.21.0" },
     { name = "pynvml", marker = "extra == 'all'", specifier = ">=12.0.0" },
     { name = "pynvml", marker = "extra == 'sfno'", specifier = ">=12.0.0" },
+    { name = "pyproj", marker = "extra == 'all'", specifier = ">=3.7.1" },
+    { name = "pyproj", marker = "extra == 'data'", specifier = ">=3.7.1" },
     { name = "python-dotenv" },
     { name = "ruamel-yaml", marker = "extra == 'all'", specifier = ">=0.18.10" },
     { name = "ruamel-yaml", marker = "extra == 'sfno'", specifier = ">=0.18.10" },
@@ -2317,25 +2317,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
-]
-
-[[package]]
-name = "herbie-data"
-version = "2025.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgrib" },
-    { name = "eccodes" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "pyproj" },
-    { name = "requests" },
-    { name = "toml" },
-    { name = "xarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/91/cb0e1effccf51daffb615393d114a8110a466c15d41820a1d242294a2481/herbie_data-2025.5.0.tar.gz", hash = "sha256:0629374ae29d0ece5f58c9369219ed95ec262ac0544d6ecb7824e79fdc3a2aef", size = 9418650, upload-time = "2025-05-02T06:02:50.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/47/8f8a5af62c941c5b7e415a8735d5c81f51943b0463b91974e269317e9038/herbie_data-2025.5.0-py3-none-any.whl", hash = "sha256:57eb86b456d626cd057aca42a4b1c3c4bf11a3c10ae0696e47e52891c82b4263", size = 113296, upload-time = "2025-05-02T06:02:48.7Z" },
 ]
 
 [[package]]
@@ -6032,15 +6013,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bc/0c/66b0f9b4a4cb9ffdac7b52b17b37c7d3c4f75623b469e388b0c6d89b4e88/timm-1.0.15.tar.gz", hash = "sha256:756a3bc30c96565f056e608a9b559daed904617eaadb6be536f96874879b1055", size = 2230258, upload-time = "2025-02-23T05:05:55.959Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/d0/179abca8b984b3deefd996f362b612c39da73b60f685921e6cd58b6125b4/timm-1.0.15-py3-none-any.whl", hash = "sha256:5a3dc460c24e322ecc7fd1f3e3eb112423ddee320cb059cc1956fbc9731748ef", size = 2361373, upload-time = "2025-02-23T05:05:53.601Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

round two, this time with HRRR. Similar overhaul as GFS focuses on complete async and interfacing directly with the grib files to get significant speed ups

Sanity check:

```python
from datetime import datetime, timedelta
from earth2studio.data.hrrr import HRRR
from earth2studio.lexicon import HRRRLexicon
import time
import random


start = time.time()

dtime = [datetime(2023,2, 23, 18), datetime(2024,8, 12, 0)]

# Get intersection of variables supported by both lexicons
common_variables = list(set(HRRRLexicon.VOCAB.keys()))
common_variables.sort()

random.seed(0)
variables = random.sample(list(common_variables), len(common_variables))

ds = HRRR(cache=False)
da = ds(time=dtime, variable=variables)
print(f"Time taken: {time.time() - start:.2f} seconds")
da.to_netcdf("hrrr_new.nc", engine="h5netcdf")
```

Checked with:
```python
import xarray as xr
import numpy as np

ds_old = xr.load_dataarray("hrrr_old.nc")
ds_new = xr.load_dataarray("hrrr_new.nc")

print(ds_old.data.shape)
print(ds_new.data.shape)
print(np.sum(ds_old.data- ds_new.data))
```

that gives:

```bash
(earth2studio) (base) local-ngeneva@ipp2-2268:~/earth2studio$ uv run test2.py 
/localhome/local-ngeneva/earth2studio/test2.py:5: FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
  ds_new = xr.load_dataarray("hrrr_new.nc")
(3, 636, 1059, 1799)
(3, 636, 1059, 1799)
0.0
```

New version Time taken: 93.54 seconds
Main branch version Time taken: 2760.56 seconds

Also plotted a few for visual comparison:

![comparison_2](https://github.com/user-attachments/assets/733c34ef-b744-4081-9ec0-1072f36aea3e)

A similar process was done with the forecast source but with a set of two lead times at (timedelta(hours=1), timedelta(hours=3), timedelta(hours=18)) and making sure tp (APCP is included and is the 1 hour accumulated)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
