### PR TITLE
WB2 Async Zarr updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored NCAR ERA5 source to have async structure
 - Refactored GFS and GFS_FX to have async structure
 - Refactored HRRR and HRRR_FX to have async structure
+- Refactored WB2ERA5 and WB2Climatology for async Zarr 3.0
 - Expanded the data source protocol to also include async fetch functions for async
   data sources
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 .PHONY: install-docker
 install-docker:
 	uv pip install --system --break-system-packages .[all] --group dev
-	uv pip install --system --break-system-packages --force-reinstall --no-deps zarr
+	uv pip install --system --break-system-packages zarr==3.0.7
 
 .PHONY: setup-ci
 setup-ci:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --system --break-system-packages .[all] --group dev
+	uv pip install --upgrade  --system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci
 setup-ci:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --system --break-system-packages --force-reinstall --no-deps zarr
 	uv pip install --system --break-system-packages .[all] --group dev
+	uv pip install --system --break-system-packages --force-reinstall --no-deps zarr
 
 .PHONY: setup-ci
 setup-ci:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --force-reinstall zarr
 	uv pip install ---system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --system --break-system-packages --force-reinstall zarr
+	uv pip install --system --break-system-packages --force-reinstall --no-dependencies zarr
 	uv pip install --system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --system --break-system-packages --force-reinstall --no-dependencies zarr
+	uv pip install --system --break-system-packages --force-reinstall --no-deps zarr
 	uv pip install --system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --force-reinstall zarr
-	uv pip install ---system --break-system-packages .[all] --group dev
+	uv pip install --system --break-system-packages --force-reinstall zarr
+	uv pip install --system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci
 setup-ci:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ install:
 
 .PHONY: install-docker
 install-docker:
-	uv pip install --upgrade  --system --break-system-packages .[all] --group dev
+	uv pip install --force-reinstall zarr
+	uv pip install ---system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci
 setup-ci:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ install:
 
 .PHONY: install-docker
 install-docker:
+	uv pip install --force-reinstall zarr
 	uv pip install ---system --break-system-packages .[all] --group dev
 
 .PHONY: setup-ci

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -63,6 +63,7 @@ class _WB2Base:
             token="anon",  # noqa: S106 # nosec B106
             access="read_only",
             block_size=2**20,
+            asynchronous=True,
         )
 
         if self._cache:

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import functools
+import inspect
 import os
 import pathlib
 import shutil
@@ -21,17 +24,20 @@ from datetime import datetime
 from importlib.metadata import version
 from typing import Literal
 
-import fsspec
 import gcsfs
+import nest_asyncio
 import numpy as np
 import xarray as xr
 import zarr
-from fsspec.implementations.cached import WholeFileCacheFileSystem
 from loguru import logger
-from tqdm import tqdm
+from tqdm.asyncio import tqdm
 
-from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
-from earth2studio.lexicon import WB2Lexicon
+from earth2studio.data.utils import (
+    AsyncCachingFileSystem,
+    datasource_cache_root,
+    prep_data_inputs,
+)
+from earth2studio.lexicon import WB2ClimatetologyLexicon, WB2Lexicon
 from earth2studio.utils.type import TimeArray, VariableArray
 
 
@@ -44,8 +50,10 @@ class _WB2Base:
     def __init__(
         self,
         wb2_zarr_store: str,
+        wb2_product: str = "era5",
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
         self._cache = cache
         self._verbose = verbose
@@ -62,7 +70,7 @@ class _WB2Base:
                 "cache_storage": self.cache,
                 "expiry_time": 31622400,  # 1 year
             }
-            fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
+            fs = AsyncCachingFileSystem(fs=fs, **cache_options, asynchronous=True)
 
         # Check Zarr version and use appropriate method
         try:
@@ -71,25 +79,24 @@ class _WB2Base:
         except Exception:
             # Fallback to older method if version check fails
             zarr_major_version = 2  # Assume older version if we can't determine
+        # Only zarr 3.0 support
+        if zarr_major_version < 3:
+            raise ModuleNotFoundError("Zarr 3.0 and above support only")
 
-        if zarr_major_version >= 3:
-            # Zarr 3.0+ method
-            zstore = zarr.storage.FsspecStore(
-                fs,
-                path=f"/weatherbench2/datasets/era5/{wb2_zarr_store}",
-            )
-            self.zarr_group = zarr.open(zstore, mode="r")
-        else:
-            # Legacy method for Zarr < 3.0
-            fs_map = fsspec.FSMap(f"weatherbench2/datasets/era5/{wb2_zarr_store}", fs)
-            self.zarr_group = zarr.open(fs_map, mode="r")
+        zstore = zarr.storage.FsspecStore(
+            fs,
+            path=f"/weatherbench2/datasets/{wb2_product}/{wb2_zarr_store}",
+        )
+        self.zarr_group = zarr.api.asynchronous.open(store=zstore, mode="r")
+
+        self.async_timeout = async_timeout
 
     def __call__(
         self,
         time: datetime | list[datetime] | TimeArray,
         variable: str | list[str] | VariableArray,
     ) -> xr.DataArray:
-        """Function to get data.
+        """Function to get data
 
         Parameters
         ----------
@@ -97,12 +104,51 @@ class _WB2Base:
             Timestamps to return data for (UTC).
         variable : str | list[str] | VariableArray
             String, list of strings or array of strings that refer to variables to
-            return. Must be in the WB2Lexicon lexicon.
+            return. Must be in the WB2 lexicon.
 
         Returns
         -------
         xr.DataArray
-            ERA5 weather data array from WB2Lexicon
+            ERA5 weather data array from weather bench 2
+        """
+
+        nest_asyncio.apply()  # Patch asyncio to work in notebooks
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If no event loop exists, create one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        xr_array = loop.run_until_complete(
+            asyncio.wait_for(self.fetch(time, variable), timeout=self.async_timeout)
+        )
+
+        # Delete cache if needed
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        return xr_array
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async function to get data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the ARCO lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            ERA5 weather data array from weather bench 2
         """
         time, variable = prep_data_inputs(time, variable)
         # Create cache dir if doesnt exist
@@ -111,99 +157,103 @@ class _WB2Base:
         # Make sure input time is valid
         self._validate_time(time)
 
-        # Fetch index file for requested time
-        data_arrays = []
-        for t0 in time:
-            data_array = self.fetch_wb2_dataarray(t0, variable)
-            data_arrays.append(data_array)
-
-        # Delete cache if needed
-        if not self._cache:
-            shutil.rmtree(self.cache)
-
-        return xr.concat(data_arrays, dim="time")
-
-    def fetch_wb2_dataarray(
-        self,
-        time: datetime,
-        variables: list[str],
-    ) -> xr.DataArray:
-        """Retrives WeatherBench2 data array for given date time by downloading a lat
-        lon array from the Zarr store
-
-        Parameters
-        ----------
-        time : datetime
-            Date time to fetch
-        variables : list[str]
-            list of atmosphric variables to fetch. Must be supported in WeatherBench2 lexicon
-
-        Returns
-        -------
-        xr.DataArray
-            WeatherBench2 data array for given date time
-        """
-        wb2da = xr.DataArray(
+        xr_array = xr.DataArray(
             data=np.empty(
                 (
-                    1,
-                    len(variables),
-                    self.WB2_ERA5_LAT.shape[0],
-                    self.WB2_ERA5_LON.shape[0],
+                    len(time),
+                    len(variable),
+                    len(self.WB2_ERA5_LAT),
+                    len(self.WB2_ERA5_LON),
                 )
             ),
             dims=["time", "variable", "lat", "lon"],
             coords={
-                "time": [time],
-                "variable": variables,
+                "time": time,
+                "variable": variable,
                 "lat": self.WB2_ERA5_LAT,
                 "lon": self.WB2_ERA5_LON,
             },
         )
 
-        # Load levels coordinate system from Zarr store and check
-        level_coords = self.zarr_group["level"][:]
+        args = [
+            (t, i, v, j) for j, v in enumerate(variable) for i, t in enumerate(time)
+        ]
+        func_map = map(functools.partial(self.fetch_wrapper, xr_array=xr_array), args)
+
+        # Before anything wait until the group gets opened
+        if inspect.isawaitable(self.zarr_group):
+            self.zarr_group = await self.zarr_group
+        self.level_coords = await (await self.zarr_group.get("level")).getitem(
+            slice(None)
+        )
+        # Launch all fetch requests
+        await tqdm.gather(
+            *func_map, desc="Fetching WB2 data", disable=(not self._verbose)
+        )
+        return xr_array
+
+    async def fetch_wrapper(
+        self,
+        e: tuple[datetime, int, str, int],
+        xr_array: xr.DataArray,
+    ) -> None:
+        """Small wrapper to pack arrays into the DataArray"""
+        out = await self.fetch_array(e[0], e[2])
+        xr_array[e[1], e[3]] = out
+
+    async def fetch_array(self, time: datetime, variable: str) -> np.ndarray:
+        """Fetches requested array from remote store
+
+        Parameters
+        ----------
+        time : datetime
+            Time to fetch
+        variable : str
+            Variable to fetch
+
+        Returns
+        -------
+        np.ndarray
+            Data
+        """
         # Get time index (vanilla zarr doesnt support date indices)
         time_index = self._get_time_index(time)
+        logger.debug(
+            f"Fetching WB2 zarr array for variable: {variable} at {time.isoformat()}"
+        )
+        try:
+            wb2_name, modifier = WB2Lexicon[variable]  # type: ignore
+        except KeyError as e:
+            logger.error(f"variable id {variable} not found in WB2 lexicon")
+            raise e
 
-        # TODO: Add MP here
-        for i, variable in enumerate(
-            tqdm(
-                variables,
-                desc=f"Fetching WB2 ERA5 for {time}",
-                disable=(not self._verbose),
-            )
-        ):
-            logger.debug(
-                f"Fetching WB2 ERA5 zarr array for variable: {variable} at {time.isoformat()}"
-            )
-            try:
-                wb2_name, modifier = WB2Lexicon[variable]
-            except KeyError as e:
-                logger.error(f"variable id {variable} not found in WB2 lexicon")
-                raise e
+        wb2_name, level = wb2_name.split("::")
 
-            wb2_name, level = wb2_name.split("::")
+        zarr_array = await self.zarr_group.get(wb2_name)
+        if zarr_array is None:
+            print(wb2_name)
+        shape = zarr_array.shape
+        # Static variables
+        if len(shape) == 2:
+            data = await zarr_array.getitem(slice(None))
+            output = modifier(data)
+        # Surface variable
+        elif len(shape) == 3:
+            data = await zarr_array.getitem(time_index)
+            output = modifier(data)
+        # Atmospheric variable
+        else:
+            # Load levels coordinate system from Zarr store and check
+            level_index = np.searchsorted(self.level_coords, int(level))
+            data = await zarr_array.getitem((time_index, level_index))
+            output = modifier(data)
 
-            shape = self.zarr_group[wb2_name].shape
-            # Static variables
-            if len(shape) == 2:
-                data = self.zarr_group[wb2_name][:]
-            # Surface variable
-            elif len(shape) == 3:
-                data = self.zarr_group[wb2_name][time_index]
-            # Atmospheric variable
-            else:
-                level_index = np.where(level_coords == int(level))[0][0]
-                data = self.zarr_group[wb2_name][time_index, level_index]
+        # Some WB2 data Zarr stores are saved [lon, lat] with lat flipped
+        # Namely its the lower resolutions ones with this issue
+        if output.shape[0] > output.shape[1]:
+            output = np.flip(output, axis=-1).T
 
-            # Some WB2 data Zarr stores are saved [lon, lat] with lat flipped
-            # Namely its the lower resolutions ones with this issue
-            if data.shape[0] > data.shape[1]:
-                data = np.flip(data, axis=-1).T
-            wb2da[0, i] = modifier(data)
-
-        return wb2da
+        return output
 
     @property
     def cache(self) -> str:
@@ -272,6 +322,9 @@ class WB2ERA5(_WB2Base):
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
 
     Warning
     -------
@@ -293,11 +346,13 @@ class WB2ERA5(_WB2Base):
         self,
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
         super().__init__(
-            "1959-2023_01_10-wb13-6h-1440x721_with_derived_variables.zarr",
-            cache,
-            verbose,
+            wb2_zarr_store="1959-2023_01_10-wb13-6h-1440x721_with_derived_variables.zarr",
+            cache=cache,
+            verbose=verbose,
+            async_timeout=async_timeout,
         )
 
 
@@ -313,6 +368,9 @@ class WB2ERA5_121x240(_WB2Base):
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
 
     Warning
     -------
@@ -334,11 +392,13 @@ class WB2ERA5_121x240(_WB2Base):
         self,
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
         super().__init__(
-            "1959-2023_01_10-6h-240x121_equiangular_with_poles_conservative.zarr",
-            cache,
-            verbose,
+            wb2_zarr_store="1959-2023_01_10-6h-240x121_equiangular_with_poles_conservative.zarr",
+            cache=cache,
+            verbose=verbose,
+            async_timeout=async_timeout,
         )
 
 
@@ -354,6 +414,9 @@ class WB2ERA5_32x64(_WB2Base):
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
 
     Warning
     -------
@@ -375,9 +438,13 @@ class WB2ERA5_32x64(_WB2Base):
         self,
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
         super().__init__(
-            "1959-2023_01_10-6h-64x32_equiangular_conservative.zarr", cache, verbose
+            "1959-2023_01_10-6h-64x32_equiangular_conservative.zarr",
+            cache=cache,
+            verbose=verbose,
+            async_timeout=async_timeout,
         )
 
 
@@ -393,7 +460,7 @@ ClimatologyZarrStore = Literal[
 ]
 
 
-class WB2Climatology:
+class WB2Climatology(_WB2Base):
     """
     Climatology provided by WeatherBench2,
 
@@ -422,6 +489,9 @@ class WB2Climatology:
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
 
     Warning
     -------
@@ -441,54 +511,22 @@ class WB2Climatology:
         climatology_zarr_store: ClimatologyZarrStore = "1990-2017_6h_1440x721.zarr",
         cache: bool = True,
         verbose: bool = True,
+        async_timeout: int = 600,
     ):
-
-        self._cache = cache
-        self._verbose = verbose
-
-        fs = gcsfs.GCSFileSystem(
-            cache_timeout=-1,
-            token="anon",  # noqa: S106 # nosec B106
-            access="read_only",
-            block_size=2**20,
+        super().__init__(
+            climatology_zarr_store,
+            wb2_product="era5-hourly-climatology",
+            cache=cache,
+            verbose=verbose,
+            async_timeout=async_timeout,
         )
 
-        if self._cache:
-            cache_options = {
-                "cache_storage": self.cache,
-                "expiry_time": 31622400,  # 1 year
-            }
-            fs = WholeFileCacheFileSystem(fs=fs, **cache_options)
-
-        # Check Zarr version and use appropriate method
-        try:
-            zarr_version = version("zarr")
-            zarr_major_version = int(zarr_version.split(".")[0])
-        except Exception:
-            # Fallback to older method if version check fails
-            zarr_major_version = 2  # Assume older version if we can't determine
-
-        if zarr_major_version >= 3:
-            # Zarr 3.0+ method
-            zstore = zarr.storage.FsspecStore(
-                fs,
-                path=f"/weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}",
-            )
-            self.zarr_group = zarr.open(zstore, mode="r")
-        else:
-            # Legacy method for Zarr < 3.0
-            fs_map = fsspec.FSMap(
-                f"weatherbench2/datasets/era5-hourly-climatology/{climatology_zarr_store}",
-                fs,
-            )
-            self.zarr_group = zarr.open(fs_map, mode="r")
-
-    def __call__(
+    async def fetch(
         self,
         time: datetime | list[datetime] | TimeArray,
         variable: str | list[str] | VariableArray,
     ) -> xr.DataArray:
-        """Function to get data.
+        """Async function to get data
 
         Parameters
         ----------
@@ -496,112 +534,106 @@ class WB2Climatology:
             Timestamps to return data for (UTC).
         variable : str | list[str] | VariableArray
             String, list of strings or array of strings that refer to variables to
-            return. Must be in the WeatherBench2 lexicon.
+            return. Must be in the ARCO lexicon.
 
         Returns
         -------
         xr.DataArray
-            climatology data from WeatherBench climatology
+            ERA5 weather data array from weather bench 2
         """
         time, variable = prep_data_inputs(time, variable)
         # Create cache dir if doesnt exist
         pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
 
-        # Fetch index file for requested time
-        data_arrays = []
-        for t0 in time:
-            data_array = self.fetch_wb_dataarray(t0, variable)
-            data_arrays.append(data_array)
+        # Make sure input time is valid
+        self._validate_time(time)
 
-        # Delete cache if needed
-        if not self._cache:
-            shutil.rmtree(self.cache)
+        # Before anything wait until the group gets opened
+        if inspect.isawaitable(self.zarr_group):
+            self.zarr_group = await self.zarr_group
 
-        return xr.concat(data_arrays, dim="time")
+        WB2_CLIMATE_LAT = await (await self.zarr_group.get("latitude")).getitem(
+            slice(None)
+        )
+        WB2_CLIMATE_LON = await (await self.zarr_group.get("longitude")).getitem(
+            slice(None)
+        )
 
-    def fetch_wb_dataarray(
-        self,
-        time: datetime,
-        variables: list[str],
-    ) -> xr.DataArray:
-        """Retrives WeatherBench data array for given date time by downloading a
-        lat lon array from the Zarr store
+        xr_array = xr.DataArray(
+            data=np.empty(
+                (len(time), len(variable), len(WB2_CLIMATE_LAT), len(WB2_CLIMATE_LON))
+            ),
+            dims=["time", "variable", "lat", "lon"],
+            coords={
+                "time": time,
+                "variable": variable,
+                "lat": WB2_CLIMATE_LAT[:],
+                "lon": WB2_CLIMATE_LON[:],
+            },
+        )
+
+        args = [
+            (t, i, v, j) for j, v in enumerate(variable) for i, t in enumerate(time)
+        ]
+        func_map = map(functools.partial(self.fetch_wrapper, xr_array=xr_array), args)
+
+        self.level_coords = await (await self.zarr_group.get("level")).getitem(
+            slice(None)
+        )
+        # Launch all fetch requests
+        await tqdm.gather(
+            *func_map, desc="Fetching WB2 climatology data", disable=(not self._verbose)
+        )
+        return xr_array
+
+    async def fetch_array(self, time: datetime, variable: str) -> np.ndarray:
+        """Fetches requested array from remote store
 
         Parameters
         ----------
         time : datetime
-            Date time to fetch
-        variables : list[str]
-            list of atmosphric variables to fetch.
+            Time to fetch
+        variable : str
+            Variable to fetch
 
         Returns
         -------
-        xr.DataArray
-            WeatherBench data array for given date time
+        np.ndarray
+            Data
         """
-        LAT = self.zarr_group["latitude"][:]
-        LON = self.zarr_group["longitude"][:]
-        wbda = xr.DataArray(
-            data=np.empty((1, len(variables), len(LAT), len(LON))),
-            dims=["time", "variable", "lat", "lon"],
-            coords={
-                "time": [time],
-                "variable": variables,
-                "lat": LAT,
-                "lon": LON,
-            },
-        )
-
-        # Load levels coordinate system from Zarr store and check
-        level_coords = self.zarr_group["level"][:]
         # Get time index (vanilla zarr doesnt support date indices)
-        hour, day_of_year = self._get_time_index(time)
+        hour_index, day_of_year_index = self._get_time_index(time)
+        logger.debug(
+            f"Fetching WB2 climatology zarr array for variable: {variable} at {time.isoformat()}"
+        )
+        try:
+            wb2_name, modifier = WB2ClimatetologyLexicon[variable]  # type: ignore
+        except KeyError as e:
+            logger.error(f"variable id {variable} not found in WB2 lexicon")
+            raise e
 
-        # TODO: Add MP here
-        for i, variable in enumerate(
-            tqdm(
-                variables,
-                desc=f"Fetching WeatherBench Climatology for {time}",
-                disable=(not self._verbose),
+        wb2_name, level = wb2_name.split("::")
+
+        zarr_array = await self.zarr_group.get(wb2_name)
+        shape = zarr_array.shape
+
+        # Surface variable [hour idx (6 hour), day index, lat, lon]
+        if len(shape) == 4:
+            data = await zarr_array.getitem((hour_index, day_of_year_index))
+            output = modifier(data)
+        # Atmospheric variable [hour idx (6 hour), day index, level lat, lon]
+        else:
+            # Load levels coordinate system from Zarr store and check
+            level_index = np.searchsorted(self.level_coords, int(level))
+            data = await zarr_array.getitem(
+                (hour_index, day_of_year_index, level_index)
             )
-        ):
-            logger.debug(
-                f"Fetching WeatherBench Climatology zarr array for variable: {variable} at {time.isoformat()}"
-            )
+            output = modifier(data)
 
-            try:
-                wb2_name, modifier = WB2Lexicon[variable]
-            except KeyError as e:
-                logger.error(
-                    f"variable id {variable} not found in WeatherBench lexicon"
-                )
-                raise e
-
-            wb2_variable, level = wb2_name.split("::")
-
-            if len(level) > 0:
-                wb2_variable, level = wb2_name.split("::")
-                level_index = np.where(level_coords == int(level))[0][0]
-                wbda[0, i] = modifier(
-                    self.zarr_group[wb2_variable][hour, day_of_year, level_index]
-                )
-
-            else:
-                wb2_variable = wb2_name.split("::")[0]
-                wbda[0, i] = modifier(self.zarr_group[wb2_variable][hour, day_of_year])
-
-        return wbda
-
-    @property
-    def cache(self) -> str:
-        """Get the appropriate cache location."""
-        cache_location = os.path.join(datasource_cache_root(), "wb2")
-        if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_wb2")
-        return cache_location
+        return output
 
     @classmethod
-    def _get_time_index(cls, time: datetime) -> tuple[int, int]:
+    def _get_time_index(cls, time: datetime) -> tuple[int, int]:  # type: ignore[override]
         """Little index converter to go from datetime to integer index for hour
         and day of year.
 

--- a/earth2studio/lexicon/__init__.py
+++ b/earth2studio/lexicon/__init__.py
@@ -22,4 +22,4 @@ from .hrrr import HRRRFXLexicon, HRRRLexicon
 from .ifs import IFSLexicon
 from .imerg import IMERGLexicon
 from .ncar import NCAR_ERA5Lexicon
-from .wb2 import WB2Lexicon
+from .wb2 import WB2ClimatetologyLexicon, WB2Lexicon

--- a/earth2studio/lexicon/arco.py
+++ b/earth2studio/lexicon/arco.py
@@ -90,13 +90,15 @@ class ARCOLexicon(metaclass=LexiconType):
         "t2m": "2m_temperature::",
         "d2m": "2m_dewpoint_temperature::",
         "sp": "surface_pressure::",
+        "sst": "sea_surface_temperature::",
         "msl": "mean_sea_level_pressure::",
         "tcwv": "total_column_water_vapour::",
         "tp": "total_precipitation::",
         "z": "geopotential_at_surface::",
     }
     VOCAB.update({f"u{level}": f"u_component_of_wind::{level}" for level in LEVELS})
-    VOCAB.update({f"v{level}": f"'v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"v{level}": f"v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"w{level}": f"vertical_velocity::{level}" for level in LEVELS})
     VOCAB.update({f"z{level}": f"geopotential::{level}" for level in LEVELS})
     VOCAB.update({f"t{level}": f"temperature::{level}" for level in LEVELS})
     VOCAB.update({f"q{level}": f"specific_humidity::{level}" for level in LEVELS})

--- a/earth2studio/lexicon/wb2.py
+++ b/earth2studio/lexicon/wb2.py
@@ -32,13 +32,13 @@ class WB2Lexicon(metaclass=LexiconType):
     Variable named based on ERA5 names, see WB2 docs for resources.
 
     - https://weatherbench2.readthedocs.io/en/latest/data-guide.html
+    - Dew point temperature at 2m seems to be all NaNs
     """
 
     VOCAB = {
         "u10m": "10m_u_component_of_wind::",
         "v10m": "10m_v_component_of_wind::",
         "t2m": "2m_temperature::",
-        "d2m": "2m_dewpoint_temperature::",
         "sp": "surface_pressure::",
         "msl": "mean_sea_level_pressure::",
         "sst": "sea_surface_temperature::",
@@ -88,13 +88,13 @@ class WB2ClimatetologyLexicon(metaclass=LexiconType):
     Variable named based on ERA5 names, see WB2 docs for resources.
 
     - https://weatherbench2.readthedocs.io/en/latest/data-guide.html
+    - Dew point temperature at 2m seems to be all NaNs
     """
 
     VOCAB = {
         "u10m": "10m_u_component_of_wind::",
         "v10m": "10m_v_component_of_wind::",
         "t2m": "2m_temperature::",
-        "d2m": "2m_dewpoint_temperature::",
         "sp": "surface_pressure::",
         "msl": "mean_sea_level_pressure::",
         "sst": "sea_surface_temperature::",

--- a/earth2studio/lexicon/wb2.py
+++ b/earth2studio/lexicon/wb2.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from .base import LexiconType
 
+LEVELS = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
+
 
 class WB2Lexicon(metaclass=LexiconType):
     """WeatherBench Lexicon
@@ -39,105 +41,79 @@ class WB2Lexicon(metaclass=LexiconType):
         "d2m": "2m_dewpoint_temperature::",
         "sp": "surface_pressure::",
         "msl": "mean_sea_level_pressure::",
+        "sst": "sea_surface_temperature::",
+        "tcwv": "total_column_water_vapour::",
+        "tp06": "total_precipitation_6hr::",
+        "tp12": "total_precipitation_12hr::",
+        "tp24": "total_precipitation_24hr::",
+    }
+    VOCAB.update({f"u{level}": f"u_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"v{level}": f"v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"w{level}": f"vertical_velocity::{level}" for level in LEVELS})
+    VOCAB.update({f"z{level}": f"geopotential::{level}" for level in LEVELS})
+    VOCAB.update({f"t{level}": f"temperature::{level}" for level in LEVELS})
+    VOCAB.update({f"q{level}": f"specific_humidity::{level}" for level in LEVELS})
+    VOCAB.update({f"r{level}": f"relative_humidity::{level}" for level in LEVELS})
+
+    @classmethod
+    def get_item(cls, val: str) -> tuple[str, Callable]:
+        """Return name in WeatherBench vocabulary."""
+        wb2_key = cls.VOCAB[val]
+
+        if wb2_key.split("::")[0] == "relative_humidity":
+
+            def mod(x: np.array) -> np.array:
+                """Relative humidty in WeatherBench uses older calculation and does
+                not scale by 100 natively. Not recommended for use, see IFS method for
+                more modern calculation.
+                https://github.com/google-research/weatherbench2/blob/main/weatherbench2/derived_variables.py#L468
+                """
+                return x * 100
+
+        else:
+
+            def mod(x: np.array) -> np.array:
+                """Modify name (if necessary)."""
+                return x
+
+        return wb2_key, mod
+
+
+class WB2ClimatetologyLexicon(metaclass=LexiconType):
+    """WeatherBench Climatology Lexicon
+    WeatherBench specified <Variable ID>::<Pressure Level>
+
+    Note
+    ----
+    Variable named based on ERA5 names, see WB2 docs for resources.
+
+    - https://weatherbench2.readthedocs.io/en/latest/data-guide.html
+    """
+
+    VOCAB = {
+        "u10m": "10m_u_component_of_wind::",
+        "v10m": "10m_v_component_of_wind::",
+        "t2m": "2m_temperature::",
+        "d2m": "2m_dewpoint_temperature::",
+        "sp": "surface_pressure::",
+        "msl": "mean_sea_level_pressure::",
+        "sst": "sea_surface_temperature::",
         "tcwv": "total_column_water_vapour::",
         "tp06": "total_precipitation_6hr::",
         "tp06sdf": "total_precipitation_6hr_seeps_dry_fraction::",
         "tp06st": "total_precipitation_6hr_seeps_threshold::",
         "tp12": "total_precipitation_12hr::",
+        "tp24": "total_precipitation_24hr::",
         "tp24sdf": "total_precipitation_24hr_seeps_dry_fraction::",
         "tp24st": "total_precipitation_24hr_seeps_threshold::",
-        "u50": "u_component_of_wind::50",
-        "u100": "u_component_of_wind::100",
-        "u150": "u_component_of_wind::150",
-        "u200": "u_component_of_wind::200",
-        "u250": "u_component_of_wind::250",
-        "u300": "u_component_of_wind::300",
-        "u400": "u_component_of_wind::400",
-        "u500": "u_component_of_wind::500",
-        "u600": "u_component_of_wind::600",
-        "u700": "u_component_of_wind::700",
-        "u850": "u_component_of_wind::850",
-        "u925": "u_component_of_wind::925",
-        "u1000": "u_component_of_wind::1000",
-        "v50": "v_component_of_wind::50",
-        "v100": "v_component_of_wind::100",
-        "v150": "v_component_of_wind::150",
-        "v200": "v_component_of_wind::200",
-        "v250": "v_component_of_wind::250",
-        "v300": "v_component_of_wind::300",
-        "v400": "v_component_of_wind::400",
-        "v500": "v_component_of_wind::500",
-        "v600": "v_component_of_wind::600",
-        "v700": "v_component_of_wind::700",
-        "v850": "v_component_of_wind::850",
-        "v925": "v_component_of_wind::925",
-        "v1000": "v_component_of_wind::1000",
-        "w50": "vertical_velocity::50",
-        "w100": "vertical_velocity::100",
-        "w150": "vertical_velocity::150",
-        "w200": "vertical_velocity::200",
-        "w250": "vertical_velocity::250",
-        "w300": "vertical_velocity::300",
-        "w400": "vertical_velocity::400",
-        "w500": "vertical_velocity::500",
-        "w600": "vertical_velocity::600",
-        "w700": "vertical_velocity::700",
-        "w850": "vertical_velocity::850",
-        "w925": "vertical_velocity::925",
-        "w1000": "vertical_velocity::1000",
-        "z50": "geopotential::50",
-        "z100": "geopotential::100",
-        "z150": "geopotential::150",
-        "z200": "geopotential::200",
-        "z250": "geopotential::250",
-        "z300": "geopotential::300",
-        "z400": "geopotential::400",
-        "z500": "geopotential::500",
-        "z600": "geopotential::600",
-        "z700": "geopotential::700",
-        "z850": "geopotential::850",
-        "z925": "geopotential::925",
-        "z1000": "geopotential::1000",
-        "t50": "temperature::50",
-        "t100": "temperature::100",
-        "t150": "temperature::150",
-        "t200": "temperature::200",
-        "t250": "temperature::250",
-        "t300": "temperature::300",
-        "t400": "temperature::400",
-        "t500": "temperature::500",
-        "t600": "temperature::600",
-        "t700": "temperature::700",
-        "t850": "temperature::850",
-        "t925": "temperature::925",
-        "t1000": "temperature::1000",
-        "q50": "specific_humidity::50",
-        "q100": "specific_humidity::100",
-        "q150": "specific_humidity::150",
-        "q200": "specific_humidity::200",
-        "q250": "specific_humidity::250",
-        "q300": "specific_humidity::300",
-        "q400": "specific_humidity::400",
-        "q500": "specific_humidity::500",
-        "q600": "specific_humidity::600",
-        "q700": "specific_humidity::700",
-        "q850": "specific_humidity::850",
-        "q925": "specific_humidity::925",
-        "q1000": "specific_humidity::1000",
-        "r50": "relative_humidity::50",
-        "r100": "relative_humidity::100",
-        "r150": "relative_humidity::150",
-        "r200": "relative_humidity::200",
-        "r250": "relative_humidity::250",
-        "r300": "relative_humidity::300",
-        "r400": "relative_humidity::400",
-        "r500": "relative_humidity::500",
-        "r600": "relative_humidity::600",
-        "r700": "relative_humidity::700",
-        "r850": "relative_humidity::850",
-        "r925": "relative_humidity::925",
-        "r1000": "relative_humidity::1000",
     }
+    VOCAB.update({f"u{level}": f"u_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"v{level}": f"v_component_of_wind::{level}" for level in LEVELS})
+    VOCAB.update({f"w{level}": f"vertical_velocity::{level}" for level in LEVELS})
+    VOCAB.update({f"z{level}": f"geopotential::{level}" for level in LEVELS})
+    VOCAB.update({f"t{level}": f"temperature::{level}" for level in LEVELS})
+    VOCAB.update({f"q{level}": f"specific_humidity::{level}" for level in LEVELS})
+    VOCAB.update({f"r{level}": f"relative_humidity::{level}" for level in LEVELS})
 
     @classmethod
     def get_item(cls, val: str) -> tuple[str, Callable]:

--- a/test/data/test_arco.py
+++ b/test/data/test_arco.py
@@ -20,18 +20,17 @@ import shutil
 
 import numpy as np
 import pytest
-import xarray
 
 from earth2studio.data import ARCO
 
 
 @pytest.mark.slow
 @pytest.mark.xfail
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 @pytest.mark.parametrize(
     "time",
     [
-        datetime.datetime(year=1959, month=1, day=31),
+        datetime.datetime(year=2000, month=1, day=31),
         [
             datetime.datetime(year=1971, month=6, day=1, hour=6),
             datetime.datetime(year=2021, month=11, day=23, hour=12),
@@ -63,40 +62,7 @@ def test_arco_fetch(time, variable):
 
 @pytest.mark.slow
 @pytest.mark.xfail
-@pytest.mark.timeout(15)
-@pytest.mark.parametrize(
-    "time",
-    [
-        np.array([np.datetime64("1993-04-05T00:00")]),
-    ],
-)
-@pytest.mark.parametrize(
-    "variable, arco_variable, arco_level",
-    [("t2m", "2m_temperature", None), ("u200", "u_component_of_wind", 200)],
-)
-def test_arco_zarr(time, variable, arco_variable, arco_level):
-
-    ds = ARCO(cache=False)
-    data = ds(time, variable)
-
-    # From https://cloud.google.com/storage/docs/public-datasets/era5
-    era5 = xarray.open_zarr(
-        "gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3",
-        chunks={"time": 48},
-        consolidated=True,
-    )
-
-    if arco_level:
-        xr_data = era5[arco_variable].sel(time=time, level=arco_level)
-    else:
-        xr_data = era5[arco_variable].sel(time=time)
-
-    assert np.allclose(data.values, xr_data.values)
-
-
-@pytest.mark.slow
-@pytest.mark.xfail
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 @pytest.mark.parametrize(
     "time",
     [np.array([np.datetime64("1993-04-05T00:00")])],

--- a/test/data/test_arco.py
+++ b/test/data/test_arco.py
@@ -30,7 +30,7 @@ from earth2studio.data import ARCO
 @pytest.mark.parametrize(
     "time",
     [
-        datetime.datetime(year=2000, month=1, day=31),
+        datetime.datetime(year=1959, month=1, day=31),
         [
             datetime.datetime(year=1971, month=6, day=1, hour=6),
             datetime.datetime(year=2021, month=11, day=23, hour=12),

--- a/test/data/test_wb2climate.py
+++ b/test/data/test_wb2climate.py
@@ -20,10 +20,8 @@ import shutil
 
 import numpy as np
 import pytest
-import xarray
 
 from earth2studio.data import WB2Climatology
-from earth2studio.utils.time import timearray_to_datetime
 
 
 @pytest.mark.slow
@@ -59,44 +57,6 @@ def test_wb2c_fetch(time, variable):
     assert shape[3] == 1440
     assert np.array_equal(data.coords["variable"].values, np.array(variable))
     assert not np.isnan(data.values).any()
-
-
-@pytest.mark.slow
-@pytest.mark.xfail
-@pytest.mark.timeout(15)
-@pytest.mark.parametrize(
-    "time",
-    [
-        np.array([np.datetime64("1993-04-05T00:00")]),
-    ],
-)
-@pytest.mark.parametrize(
-    "variable, arco_variable, arco_level",
-    [("t2m", "2m_temperature", None), ("u200", "u_component_of_wind", 200)],
-)
-def test_wb2c_zarr(time, variable, arco_variable, arco_level):
-
-    ds = WB2Climatology(cache=False)
-    data = ds(time, variable)
-
-    era5 = xarray.open_zarr(
-        "gs://weatherbench2/datasets/era5-hourly-climatology/1990-2017_6h_1440x721.zarr",
-        consolidated=True,
-    )
-
-    hour, day_of_year = ds._get_time_index(timearray_to_datetime(time)[0])
-    # day_of_year is 0-based but convert to 1-based for xarray selection.
-    day_of_year += 1
-    if arco_level:
-        xr_data = era5[arco_variable].sel(
-            hour=hour, dayofyear=day_of_year, level=arco_level
-        )
-    else:
-        xr_data = era5[arco_variable].sel(hour=hour, dayofyear=day_of_year)
-
-    assert np.allclose(data.values, xr_data.values), np.max(
-        np.abs(data.values - xr_data.values)
-    )
 
 
 @pytest.mark.slow

--- a/test/data/test_wb2era5.py
+++ b/test/data/test_wb2era5.py
@@ -21,11 +21,11 @@ import shutil
 import numpy as np
 import pytest
 
-from earth2studio.data import ARCO, WB2ERA5, WB2ERA5_32x64, WB2ERA5_121x240
+from earth2studio.data import WB2ERA5, WB2ERA5_32x64, WB2ERA5_121x240
 
 
 @pytest.mark.slow
-@pytest.mark.xfail
+# @pytest.mark.xfail
 @pytest.mark.timeout(15)
 @pytest.mark.parametrize(
     "time",
@@ -58,31 +58,6 @@ def test_wb2era5_fetch(time, variable, Datasource):
     assert shape[3] == Datasource.WB2_ERA5_LON.shape[0]
     assert np.array_equal(data.coords["variable"].values, np.array(variable))
     assert not np.isnan(data.values).any()
-
-
-@pytest.mark.slow
-@pytest.mark.xfail
-@pytest.mark.timeout(15)
-@pytest.mark.parametrize(
-    "time",
-    [
-        np.array([np.datetime64("1993-04-05T00:00")]),
-        np.array([np.datetime64("2001-02-27T18:00")]),
-    ],
-)
-@pytest.mark.parametrize(
-    "variable",
-    ["t2m", "u200"],
-)
-def test_wb2era5_verify(time, variable):
-
-    ds = WB2ERA5(cache=False)
-    data = ds(time, variable)
-
-    ds = ARCO(cache=False)
-    data_arco = ds(time, variable)
-
-    assert np.allclose(data.values, data_arco.values)
 
 
 @pytest.mark.slow

--- a/test/data/test_wb2era5.py
+++ b/test/data/test_wb2era5.py
@@ -25,7 +25,7 @@ from earth2studio.data import WB2ERA5, WB2ERA5_32x64, WB2ERA5_121x240
 
 
 @pytest.mark.slow
-# @pytest.mark.xfail
+@pytest.mark.xfail
 @pytest.mark.timeout(15)
 @pytest.mark.parametrize(
     "time",

--- a/test/lexicon/test_wb2_lexicon.py
+++ b/test/lexicon/test_wb2_lexicon.py
@@ -17,7 +17,7 @@
 import pytest
 import torch
 
-from earth2studio.lexicon import WB2Lexicon
+from earth2studio.lexicon import WB2ClimatetologyLexicon, WB2Lexicon
 
 
 @pytest.mark.parametrize(
@@ -33,6 +33,12 @@ def test_wb2_lexicon(variable, device):
         assert input.shape == output.shape
         assert input.device == output.device
 
+        label, modifier = WB2ClimatetologyLexicon[v]
+        output = modifier(input)
+        assert isinstance(label, str)
+        assert input.shape == output.shape
+        assert input.device == output.device
+
 
 @pytest.mark.parametrize(
     "variable", [["t2m"], ["u10m", "v200"], ["msl", "t150", "q700"]]
@@ -41,3 +47,6 @@ def test_wb2_lexicon(variable, device):
 def test_wb2_lexicon_failure(variable, device):
     with pytest.raises(KeyError):
         label, modifier = WB2Lexicon["t3m"]
+
+    with pytest.raises(KeyError):
+        label, modifier = WB2ClimatetologyLexicon["t3m"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Same deal as ARCO, but limits WB2 to zarr 3.0 and up. ARCO supports both but not dealing with both here. Too messy. Also adding to lexicons.

As usual validated it with this script:

```python
import random
import time

from earth2studio.data import WB2ERA5, WB2ERA5_121x240, WB2ERA5_32x64, WB2Climatology
from earth2studio.lexicon import WB2Lexicon#, WB2ClimatetologyLexicon
from datetime import datetime
import time

start = time.time()
ds = WB2ERA5(cache=False)

dtime = [datetime(2010, 2, 12, 18), datetime(1992, 8, 12, 0), datetime(1992, 8, 12, 0)]

common_variables = list(set(WB2Lexicon.VOCAB.keys()))
common_variables.sort()

random.seed(0)
variables = random.sample(list(common_variables), len(common_variables))

da = ds(time=dtime, variable=variables)

print(f"Time taken: {time.time() - start:.2f} seconds")
da.to_netcdf("wb2_era5_old.nc", engine="h5netcdf")
```

All outputs are validated against main branch to confirm consistency.

WB2Climate:
New: 17.46
Old: 165.84

WB2ERA5
New 28.29
Old: 156.38

WB2ERA5_121x240
New: 7.23
Old: 44.23

WB2ERA5_32x64
New: 8.05
Old: 32.19

![era5](https://github.com/user-attachments/assets/e65d38cc-5ebe-4326-aa96-3ceac45c367c)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
