### PR TITLE
Fix windgust cache location and TC tracking in HENS recipe

### DIFF
--- a/earth2studio/models/dx/wind_gust.py
+++ b/earth2studio/models/dx/wind_gust.py
@@ -154,11 +154,11 @@ class WindgustAFNO(torch.nn.Module, AutoModelMixin):
 
     @classmethod
     def load_default_package(cls) -> Package:
-        """Default pre-trained climatenet model package from Nvidia model registry"""
+        """Default pre-trained windgustnet model package from Nvidia model registry"""
         return Package(
             "ngc://models/nvidia/earth-2/afno_dx_wg-v1-era5@v0.1.0",
             cache_options={
-                "cache_storage": Package.default_cache("climatenet"),
+                "cache_storage": Package.default_cache("windgustnet"),
                 "same_names": True,
             },
         )

--- a/recipes/hens/src/hens_ensemble.py
+++ b/recipes/hens/src/hens_ensemble.py
@@ -115,6 +115,8 @@ class EnsembleBase:
         if cyclone_tracking:
             self.cyclone_tracking = cyclone_tracking.tracker
             self.cyclone_tracking_out_path = cyclone_tracking.out_path
+        else:
+            self.cyclone_tracking = None
 
         if len(time) > 1:
             raise ValueError("Only a single IC can be passed here")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
- Hens recipe runs now also without TC tracking in config
- Changed cache folder name of windgustnet from climatenet to windgustnet

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
