### PR TITLE
Allow HCBV perturbation to handle static inputs

### DIFF
--- a/earth2studio/perturbation/hcbv.py
+++ b/earth2studio/perturbation/hcbv.py
@@ -146,6 +146,7 @@ class HemisphericCentredBredVector:
 
             # scale dx
             dx = self.noise_amplitude * (dx / hem_norm)
+            # set dx back to zero in constant inputs
             dx[..., torch.isnan(dx).all(dim=(0, 1, 2, 4, 5)), :, :] = 0
 
             xunp = (


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
When using HCBV to perturb the inputs for GraphCast, I received the error "zero element in hemispheric norm, maybe noise amplification too small?". 

After digging into this it became clear that the zero elements causing this were the result of using a model that outputs constant inputs (like land sea mask, or geopotential at surface). Because in HCBV we create a `dx` as the difference between a perturbed prediction and unperturbed prediction - for the case where the outputs are constant, those channels will be zero, raising the error above.

In the code there is a comment that mentions: 
```
# if zero elements are requierd, replace NaNs in scaled dx with 0
```
Which then allows the method to be used in such cases. I tested this method with multiple models and the results all look reasonable after this change.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
