### PR TITLE
StormCast package update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated default StormCast package version to 1.0.2
+
 ### Deprecated
 
 ### Removed

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -239,7 +239,7 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
         package = Package(
-            "ngc://models/nvidia/modulus/stormcast-v1-era5-hrrr@1.0.1",
+            "ngc://models/nvidia/earth-2/stormcast-v1-era5-hrrr@1.0.2",
             cache_options={
                 "cache_storage": Package.default_cache("stormcast"),
                 "same_names": True,

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -47,7 +47,7 @@ from earth2studio.utils.type import CoordSystem
 
 # Variables used in StormCastV1 paper
 VARIABLES = (
-    ["u10m", "v10m", "t2m", "mslp"]
+    ["u10m", "v10m", "t2m", "msl"]
     + [
         var + str(level)
         for var, level in product(
@@ -64,7 +64,7 @@ VARIABLES = (
     ]
 )
 
-CONDITIONING_VARIABLES = ["u10m", "v10m", "t2m", "tcwv", "mslp", "sp"] + [
+CONDITIONING_VARIABLES = ["u10m", "v10m", "t2m", "tcwv", "sp", "msl"] + [
     var + str(level)
     for var, level in product(["u", "v", "z", "t", "q"], [1000, 850, 500, 250])
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Bumps the default package version for StormCast. Package is now the publicly-visible one released under Earth-2 team on NGC, no longer using the legacy Modulus naming; model weights are the same.

New package version also fixes a bug in the model package conditioning variable list which swapped the order of `msl` and `sp`, causing stagnant forecasts in certain initial conditions.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
