### PR TITLE
NGC SDK fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- NGC filesystem from API change in version >=3.158.1 of ngcsdk
+
 ### Security
 
 ### Dependencies

--- a/earth2studio/models/auto/ngc.py
+++ b/earth2studio/models/auto/ngc.py
@@ -23,6 +23,7 @@ from typing import Any
 
 # Silence warning from ngcbase pkg_resources use
 warnings.simplefilter("ignore", UserWarning)
+warnings.simplefilter("ignore", SyntaxWarning)
 
 # ruff: noqa: E402
 import aiohttp

--- a/earth2studio/models/auto/ngc.py
+++ b/earth2studio/models/auto/ngc.py
@@ -198,26 +198,37 @@ class NGCModelFileSystem(HTTPFileSystem):
         filepath: str = None,
         authenticated_api: bool = True,
     ) -> str:
-        # Authenticated API
+        # Based on .venv/lib/python3.12/site-packages/registry/api/models.py
+        # get_direct_download_URL
+        def format_org_team(
+            org: str | None = None, team: str | None = None, plural_form: bool = False
+        ) -> str:
+            """Given a combination of org and team values, which can be empty,
+            returns the string that would be used in a URL for working with the API.
+            Taken out of .venv/lib/python3.12/site-packages/ngcbase/util/utils.py
+            """
+            parts = []
+            if org and org is not None and org != "no-org":
+                parts.append(f"org{'s' if plural_form else ''}")
+                parts.append(f"{org}")
+                if team and team is not None and team != "no-team":
+                    parts.append(f"team{'s' if plural_form else ''}")
+                    parts.append(f"{team}")
+            return "/".join(parts)
+
+        # Internal override of the service URLs
+        url = os.environ.get(
+            "NGC_CLI_SEARCH_SERVICE_URL", "https://api.ngc.nvidia.com/"
+        )
+        # Dont know why NGC does this, but it does....
         if authenticated_api:
-            # APIs from registry/api/models.py but switched to use the async download function
-            url = self.model_api.get_direct_download_URL(
-                name, version, org=org, team=team
-            )
-            if filepath:
-                url = f"{url}?path={filepath}"
-        # Public API
+            ep = ["v2", format_org_team(org, team), "models", name, version, "files"]
         else:
-            url = "https://api.ngc.nvidia.com/v2/models/"
-            relative_urls = []
-            if org:
-                relative_urls += ["org", org]
-            if team:
-                relative_urls += ["team", team]
-            relative_urls += [name, version, "files"]
-            url = urllib.parse.urljoin(url, os.path.join(*relative_urls))
-            if filepath:
-                url = f"{url}?path={filepath}"
+            ep = ["v2", "models", format_org_team(org, team), name, version, "files"]
+        url = urllib.parse.urljoin(url, os.path.join(*ep))
+        if filepath:
+            url = f"{url}?path={filepath}"
+
         return url
 
     async def _get_ngc(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Corrects problem with the latest NGC SDK version that changes an API related to construction of the model asset URL. I remove the reliance on that method entirely in favor of just a cleaner impementation for both public and private assets. Also updated test to be a little better.

Also silenced more warnings the package spams and supports passing without NGC_CLI_API_KEY set.

Closes: https://github.com/NVIDIA/earth2studio/issues/396

I manually tested this for both:

```bash
earth2studiolocal-ngeneva@ipp2-2268:~/earth2studio$ uv pip install ngcsdk==3.152.2
Resolved 40 packages in 212ms
Uninstalled 1 package in 46ms
Installed 1 package in 47ms
 - ngcsdk==3.158.1
 + ngcsdk==3.152.2
earth2studiolocal-ngeneva@ipp2-2268:~/earth2studio$ uv run pytest -s test/models/test_auto_models.py 
==================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.6.0 -- /localhome/local-ngeneva/earth2studio/.venv/bin/python
cachedir: .pytest_cache
rootdir: /localhome/local-ngeneva/earth2studio
configfile: pyproject.toml
plugins: anyio-4.9.0, skip-slow-0.0.5, asyncio-1.0.0, timeout-2.4.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 40 items                                                                                                                                                                                                          

test/models/test_auto_models.py::test_auto_model_download[AIFS] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Aurora] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottle3D] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[DLESyM] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[DLWP] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FCN] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FengWu] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FuXi] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[GraphCastOperational] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[GraphCastSmall] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu24] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu6] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu3] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[PrecipitationAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[ClimateNet] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CorrDiffTaiwan] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottleInfill] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottleSR] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[WindgustAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[InterpModAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[PrecipitationAFNOv2] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SolarRadiationAFNO1H] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SolarRadiationAFNO6H] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[StormCast] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_package[None-temp.txt] PASSED
Downloading README.md: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 265/265 [00:00<00:00, 2.00kB/s]
PASSED
test/models/test_auto_models.py::test_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json] 2025-06-30 21:55:43.872 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
Downloading metadata.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 77.0/77.0 [00:00<00:00, 57.8kB/s]
PASSED
Downloading 3-day-geomag-forecast.txt: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 879/879 [00:00<00:00, 632kB/s]
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json-False] 2025-06-30 21:55:45.449 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json-True] 2025-06-30 21:55:46.110 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvstaging/simnet/physicsnemo_ci@0.1-test.txt-True] 2025-06-30 21:55:46.756 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
Downloading test.txt: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 12.0/12.0 [00:00<00:00, 8.03kB/s]
PASSED
test/models/test_auto_models.py::test_ngc_filesystem 2025-06-30 21:55:47.688 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package_errors[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/wrong-metadata.json] 2025-06-30 21:55:48.224 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package_errors[ngc://models/nvidia/earth2/test@v0.1-test.txt] 2025-06-30 21:55:48.982 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_auto_model_mixin PASSED
Test: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 3072.75it/s]
PASSED
Test: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 3477.86it/s]
PASSED
test/models/test_auto_models.py::test_ngc_unsupported_operations 2025-06-30 21:55:49.739 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
Downloading climatenet.zip: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.83M/1.83M [00:00<00:00, 13.8MB/s]
PASSED

================================================================================================== short test summary info ==================================================================================================
SKIPPED [25] test/models/test_auto_models.py:66: need --model-download option to run automodel download tests
======================================================================================= 15 passed, 25 skipped, 138 warnings in 13.47s =======================================================================================
```

and the newer version `3.158.1`


```bash
earth2studiolocal-ngeneva@ipp2-2268:~/earth2studio$ uv pip install ngcsdk==3.158.1
Resolved 40 packages in 15ms
Uninstalled 1 package in 35ms
Installed 1 package in 34ms
 - ngcsdk==3.152.2
 + ngcsdk==3.158.1
earth2studiolocal-ngeneva@ipp2-2268:~/earth2studio$ uv run pytest -s test/models/test_auto_models.py 
==================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.6.0 -- /localhome/local-ngeneva/earth2studio/.venv/bin/python
cachedir: .pytest_cache
rootdir: /localhome/local-ngeneva/earth2studio
configfile: pyproject.toml
plugins: anyio-4.9.0, skip-slow-0.0.5, asyncio-1.0.0, timeout-2.4.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 40 items                                                                                                                                                                                                          

test/models/test_auto_models.py::test_auto_model_download[AIFS] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Aurora] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottle3D] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[DLESyM] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[DLWP] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FCN] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FengWu] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[FuXi] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[GraphCastOperational] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[GraphCastSmall] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu24] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu6] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[Pangu3] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[PrecipitationAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[ClimateNet] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CorrDiffTaiwan] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottleInfill] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[CBottleSR] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[WindgustAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[InterpModAFNO] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[PrecipitationAFNOv2] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SolarRadiationAFNO1H] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[SolarRadiationAFNO6H] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_auto_model_download[StormCast] SKIPPED (need --model-download option to run automodel download tests)
test/models/test_auto_models.py::test_package[None-temp.txt] PASSED
Downloading README.md: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 265/265 [00:00<00:00, 2.74kB/s]
PASSED
test/models/test_auto_models.py::test_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json] 2025-06-30 21:59:01.115 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
Downloading metadata.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 77.0/77.0 [00:00<00:00, 59.0kB/s]
PASSED
Downloading 3-day-geomag-forecast.txt: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 879/879 [00:00<00:00, 686kB/s]
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json-False] 2025-06-30 21:59:02.702 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/metadata.json-True] 2025-06-30 21:59:03.314 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package[ngc://models/nvstaging/simnet/physicsnemo_ci@0.1-test.txt-True] 2025-06-30 21:59:03.964 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
Downloading test.txt: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 12.0/12.0 [00:00<00:00, 8.88kB/s]
PASSED
test/models/test_auto_models.py::test_ngc_filesystem 2025-06-30 21:59:05.062 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package_errors[ngc://models/nvidia/modulus/sfno_73ch_small@0.1.0-sfno_73ch_small/wrong-metadata.json] 2025-06-30 21:59:05.692 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_ngc_package_errors[ngc://models/nvidia/earth2/test@v0.1-test.txt] 2025-06-30 21:59:06.496 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
test/models/test_auto_models.py::test_auto_model_mixin PASSED
Test: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 3113.81it/s]
PASSED
Test: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 2941.31it/s]
PASSED
test/models/test_auto_models.py::test_ngc_unsupported_operations 2025-06-30 21:59:07.321 | WARNING  | earth2studio.models.auto.ngc:__init__:125 - API key found but no org found, using the org nvstaging
PASSED
Downloading climatenet.zip: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.83M/1.83M [00:00<00:00, 16.9MB/s]
PASSED

================================================================================================== short test summary info ==================================================================================================
SKIPPED [25] test/models/test_auto_models.py:66: need --model-download option to run automodel download tests
======================================================================================= 15 passed, 25 skipped, 138 warnings in 13.52s =======================================================================================
```


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
