### PR TITLE
Async data source notebook fixes

### DIFF
--- a/earth2studio/data/arco.py
+++ b/earth2studio/data/arco.py
@@ -89,6 +89,7 @@ class ARCO:
         if self.zarr_major_version >= 3:
             # Check to see if there is a running loop (initialized in async)
             try:
+                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
                 loop = asyncio.get_running_loop()
                 loop.run_until_complete(self._async_init())
             except RuntimeError:
@@ -172,7 +173,6 @@ class ARCO:
             ERA5 weather data array from ARCO
         """
 
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/earth2studio/data/arco.py
+++ b/earth2studio/data/arco.py
@@ -89,7 +89,7 @@ class ARCO:
         if self.zarr_major_version >= 3:
             # Check to see if there is a running loop (initialized in async)
             try:
-                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
+                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
                 loop = asyncio.get_running_loop()
                 loop.run_until_complete(self._async_init())
             except RuntimeError:

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -129,6 +129,7 @@ class GEFS_FX:
 
         # Check to see if there is a running loop (initialized in async)
         try:
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:
@@ -168,7 +169,6 @@ class GEFS_FX:
         xr.DataArray
             GEFS forecast data array
         """
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -129,7 +129,7 @@ class GEFS_FX:
 
         # Check to see if there is a running loop (initialized in async)
         try:
-            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -112,6 +112,7 @@ class GFS:
             self.uri_prefix = "noaa-gfs-bdp-pds"
             # Check to see if there is a running loop (initialized in async)
             try:
+                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
                 loop = asyncio.get_running_loop()
                 loop.run_until_complete(self._async_init())
             except RuntimeError:
@@ -175,7 +176,6 @@ class GFS:
         xr.DataArray
             GFS weather data array
         """
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -580,7 +580,6 @@ class GFS_FX(GFS):
         xr.DataArray
             GFS weather data array
         """
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -112,7 +112,7 @@ class GFS:
             self.uri_prefix = "noaa-gfs-bdp-pds"
             # Check to see if there is a running loop (initialized in async)
             try:
-                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
+                nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
                 loop = asyncio.get_running_loop()
                 loop.run_until_complete(self._async_init())
             except RuntimeError:

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -171,7 +171,7 @@ class HRRR:
             raise ValueError(f"Invalid HRRR source { self._source}")
 
         try:
-            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -171,6 +171,7 @@ class HRRR:
             raise ValueError(f"Invalid HRRR source { self._source}")
 
         try:
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:
@@ -222,7 +223,6 @@ class HRRR:
         xr.DataArray
             HRRR weather data array
         """
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -752,7 +752,6 @@ class HRRR_FX(HRRR):
         xr.DataArray
             HRRR forecast data array
         """
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -76,6 +76,7 @@ class _WB2Base:
 
         # Check to see if there is a running loop (initialized in async)
         try:
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:
@@ -136,7 +137,6 @@ class _WB2Base:
             ERA5 weather data array from weather bench 2
         """
 
-        nest_asyncio.apply()  # Patch asyncio to work in notebooks
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -76,7 +76,7 @@ class _WB2Base:
 
         # Check to see if there is a running loop (initialized in async)
         try:
-            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks (TODO: remove)
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
             loop = asyncio.get_running_loop()
             loop.run_until_complete(self._async_init())
         except RuntimeError:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixes async data source initialization to be better in notebooks (so theres no annoying runtime warning), basically moves the nested asyncio patch into the constructor rather than the call

Before:
<img width="2533" height="1228" alt="image" src="https://github.com/user-attachments/assets/aa9187ff-5342-4b11-9427-40cf8c2de5ca" />


After:
<img width="2533" height="1228" alt="image" src="https://github.com/user-attachments/assets/e2b0fa6c-fce8-4faf-b2b4-3a123be72d54" />


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
