### PR TITLE
3.10 / Zarr 2.0 fixes for Async Zarr backend

### DIFF
--- a/earth2studio/io/async_zarr.py
+++ b/earth2studio/io/async_zarr.py
@@ -45,7 +45,6 @@ if zarr_major_version >= 3:
     from zarr.core.array import CompressorsLike
 else:
     AsyncGroup = Any
-    AsyncCoreGroup = Any
     CompressorsLike = Any
 
 from earth2studio.utils.type import CoordSystem
@@ -581,7 +580,7 @@ class AsyncZarrBackend:
             Dictionary of tensor(s) to be written to zarr arrays.
         coords : CoordSystem
             Coordinates of the passed data.
-        zs : AsyncCoreGroup
+        zs : zarr.AsyncGroup
             Zarr store to use
         fs : fsspec.AbstractFileSystem
             File system to use (relevant for session creation)

--- a/earth2studio/io/async_zarr.py
+++ b/earth2studio/io/async_zarr.py
@@ -41,7 +41,7 @@ except Exception:
     zarr_major_version = 2
 
 if zarr_major_version >= 3:
-    from zarr import AsyncGroup as AsyncGroup
+    from zarr import AsyncGroup
     from zarr.core.array import CompressorsLike
 else:
     AsyncGroup = Any

--- a/earth2studio/io/async_zarr.py
+++ b/earth2studio/io/async_zarr.py
@@ -41,8 +41,7 @@ except Exception:
     zarr_major_version = 2
 
 if zarr_major_version >= 3:
-    import zarr.AsyncGroup as AsyncGroup
-    import zarr.core.group.AsyncGroup as AsyncCoreGroup
+    from zarr import AsyncGroup as AsyncGroup
     from zarr.core.array import CompressorsLike
 else:
     AsyncGroup = Any
@@ -571,7 +570,7 @@ class AsyncZarrBackend:
         self,
         x: dict[str, torch.Tensor],
         coords: CoordSystem,
-        zs: AsyncCoreGroup,
+        zs: AsyncGroup,
         fs: fsspec.AbstractFileSystem,
     ) -> None:
         """_summary_


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixed some syntax incompatibly between 3.12 and 3.10. As well as supporting Zarr 2.0 installs (had types that were Zarr 3.0 specific)  

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
