### PR TITLE
Adding improved optional import utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow HCBV perturbation to handle constant outputs (like land sea mask, or
   geopotential at surface)
 - test/models/dx/test_corrdiff.py is now test/models/dx/test_corrdiff_taiwan.py
+- Updated APIs for optional dependency managment utils with improved error messages
 
 ### Deprecated
 

--- a/docs/userguide/developer/dependency.md
+++ b/docs/userguide/developer/dependency.md
@@ -70,33 +70,44 @@ handling for the user to communicate that additional dependency group needs to b
 installed.
 A good sanity check if things have properly been caught is by building the API docs
 with `make docs`.
-The pattern to properly handle the use of optional dependencies is:
 
-1. Use a try / except in the import for ImportErrors. Set respective package objects to
-    None if not installed.
-2. Place the `@check_extra_imports` decorator on the class and/or function that requires
-    the optional import.
+Its important to handle the absence of optional dependencies in a standardize way for
+the user.
+Earth2Studio has some utilities to provide informative errors to users that should be
+used when some optional dependency group is needed to be installed:
+
+1. Use a try / except in the optional import for ImportErrors. Set respective package
+    objects to None if not installed. The file should **not** error on import, rather
+    optional imports should be evaluated lazily when needed.
+2. In the catch of the import try catch, instantiate a `OptionalDependencyFailure`. The
+    only parameter needed is the name of the dependency group that needs to be
+    installed.
+3. Place the `@check_optional_dependencies` decorator on the class and/or function that
+    requires the optional import.
     This will check to make sure that the required imports are installed when the user
     attempts to use the respective feature.
 
 For example in the FourCastNet model:
 
 ```python
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 try:
     from physicsnemo.models.afno import AFNO
 except ImportError:
+    OptionalDependencyFailure("afno")
     AFNO = None
-
-from earth2studio.utils import check_extra_imports
 
 
 # Use the decorator on classes
-@check_extra_imports("fcn", [AFNO])
+@check_optional_dependencies()
 class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     ...
     # Use the decorator on functions
     @classmethod
-    @check_extra_imports("fcn", [AFNO])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,
@@ -105,25 +116,53 @@ class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     ...
 ```
 
-When the user attempts to use FCN without the required extra packages, the following
-error will occur:
+In this example, the resulting behavior is the FCN model is able to be imported without
+any issues.
+Only when the user attempts to use FCN without the required extra packages, the
+following error will be printed:
 
-```bash
+```text
 uv run python
-Python 3.12.9 (main, Mar 17 2025, 21:01:58) [Clang 20.1.0 ] on linux
+Python 3.12.3 (main, Jun 18 2025, 17:59:45) [GCC 13.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> from earth2studio.models.px import FCN
 >>> FCN.load_model(FCN.load_default_package())
+┌────────────────────────────────────────────────────────────────────┐
+│ Earth2Studio Extra Dependency Error                                │
+│ This error typically indicates an extra dependency group is        │
+│ needed.                                                            │
+│ Don't panic, this is usually an easy fix.                          │
+├────────────────────────────────────────────────────────────────────┤
+│ This feature ('earth2studio.models.px.fcn.load_model') is marked   │
+│ needing optional dependency group 'fcn'.                           │
+│                                                                    │
+│ uv install with: `uv add earth2studio --extra fcn`                 │
+│                                                                    │
+│ For more information (such as pip install instructions), visit the │
+│ install documentation:                                             │
+│ https://nvidia.github.io/earth2studio/userguide/about/install.html │
+├────────────────────────────────────────────────────────────────────┤
+│ ╭────────────── Traceback (most recent call last) ───────────────╮ │
+│ │ .../earth2studio/earth2studio/models/px/… │ │
+│ │ in <module>                                                    │ │
+│ │                                                                │ │
+│ │    34 from earth2studio.utils.type import CoordSystem          │ │
+│ │    35                                                          │ │
+│ │    36 try:                                                     │ │
+│ │ ❱  37 │   from physicsnemo.models.afno import AFNO             │ │
+│ │    38 except ImportError:                                      │ │
+│ │    39 │   OptionalDependencyFailure("fcn")                     │ │
+│ │    40 │   AFNO = None                                          │ │
+│ ╰────────────────────────────────────────────────────────────────╯ │
+│ ImportError: No module named 'physicsnemo'                         │
+└────────────────────────────────────────────────────────────────────┘
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-  File ".../earth2studio/utils/imports.py", line 78, in _wrapper
-    _check_dependencies(f"{obj.__module__}.{obj.__name__}")
-  File ".../earth2studio/utils/imports.py", line 61, in _check_dependencies
-    raise ExtraDependencyError(extra_name, obj_name)
-earth2studio.utils.imports.ExtraDependencyError: Extra dependency group 'fcn' is
-    required for earth2studio.models.px.fcn.load_model.
-Install with: uv pip install earth2studio --extra fcn
-or refer to the install documentation.
+  File ".../earth2studio/earth2studio/utils/imports.py", line 172, in _wrapper
+    _check_deps(f"{obj.__module__}.{obj.__name__}")
+  File ".../earth2studio/earth2studio/utils/imports.py", line 149, in _check_deps
+    raise OptionalDependencyError(
+earth2studio.utils.imports.OptionalDependencyError: Optional dependency import error
 ```
 
 ### Managing Conflicts

--- a/docs/userguide/developer/dependency.md
+++ b/docs/userguide/developer/dependency.md
@@ -71,7 +71,7 @@ installed.
 A good sanity check if things have properly been caught is by building the API docs
 with `make docs`.
 
-Its important to handle the absence of optional dependencies in a standardize way for
+It is important to handle the absence of optional dependencies in a standardize way for
 the user.
 Earth2Studio has some utilities to provide informative errors to users that should be
 used when some optional dependency group is needed to be installed:

--- a/docs/userguide/developer/dependency.md
+++ b/docs/userguide/developer/dependency.md
@@ -97,7 +97,7 @@ from earth2studio.utils.imports import (
 try:
     from physicsnemo.models.afno import AFNO
 except ImportError:
-    OptionalDependencyFailure("afno")
+    OptionalDependencyFailure("fcn")
     AFNO = None
 
 

--- a/earth2studio/data/cbottle.py
+++ b/earth2studio/data/cbottle.py
@@ -23,6 +23,17 @@ import torch
 import xarray as xr
 from tqdm import tqdm
 
+from earth2studio.data.base import DataSource
+from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
+from earth2studio.lexicon import CBottleLexicon
+from earth2studio.models.auto import Package
+from earth2studio.models.auto.mixin import AutoModelMixin
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import TimeArray, VariableArray
+
 try:
     import earth2grid
     from cbottle.checkpointing import Checkpoint
@@ -38,19 +49,12 @@ except ImportError:
     get_batch_info = None
     TimeUnit = None
     get_denoiser = None
-
-from earth2studio.data.base import DataSource
-from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
-from earth2studio.lexicon import CBottleLexicon
-from earth2studio.models.auto import Package
-from earth2studio.models.auto.mixin import AutoModelMixin
-from earth2studio.utils.imports import check_extra_imports
-from earth2studio.utils.type import TimeArray, VariableArray
+    OptionalDependencyFailure("cbottle")
 
 HPX_LEVEL = 6
 
 
-@check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+@check_optional_dependencies()
 class CBottle3D(torch.nn.Module, AutoModelMixin):
     """Climate in a bottle data source
     Climate in a Bottle (cBottle) is an AI model for emulating global km-scale climate
@@ -399,7 +403,7 @@ class CBottle3D(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
-    @check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/data/cds.py
+++ b/earth2studio/data/cds.py
@@ -24,10 +24,6 @@ from datetime import datetime
 from time import sleep
 from typing import Any
 
-try:
-    import cdsapi
-except ImportError:
-    cdsapi = None
 import numpy as np
 import xarray as xr
 from loguru import logger
@@ -35,7 +31,17 @@ from tqdm import tqdm
 
 from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
 from earth2studio.lexicon import CDSLexicon
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import TimeArray, VariableArray
+
+try:
+    import cdsapi
+except ImportError:
+    OptionalDependencyFailure("data")
+    cdsapi = None
 
 logger.remove()
 logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
@@ -54,6 +60,7 @@ class CDSRequest:
     ids: list[str]
 
 
+@check_optional_dependencies()
 class CDS:
     """The climate data source (CDS) serving ERA5 re-analysis data. This data soure
     requires users to have a CDS API access key which can be obtained for free on the
@@ -85,12 +92,6 @@ class CDS:
     CDS_LON = np.linspace(0, 359.75, 1440)
 
     def __init__(self, cache: bool = True, verbose: bool = True):
-        # Optional import not installed error
-        if cdsapi is None:
-            raise ImportError(
-                "cdsapi is not installed, install manually or using `pip install earth2studio[data]`"
-            )
-
         self._cache = cache
         self._verbose = verbose
         self.cds_client = cdsapi.Client(

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -34,19 +34,23 @@ from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
 from tqdm.asyncio import tqdm
 
-try:
-    import pyproj
-except ImportError:
-    pyproj = None
-
 from earth2studio.data.utils import (
     datasource_cache_root,
     prep_data_inputs,
     prep_forecast_inputs,
 )
 from earth2studio.lexicon import HRRRFXLexicon, HRRRLexicon
-from earth2studio.utils import check_extra_imports
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
+
+try:
+    import pyproj
+except ImportError:
+    OptionalDependencyFailure("data")
+    pyproj = None
 
 logger.remove()
 logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
@@ -63,7 +67,7 @@ class HRRRAsyncTask:
     hrrr_modifier: Callable
 
 
-@check_extra_imports("data", [pyproj])
+@check_optional_dependencies()
 class HRRR:
     """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
     weather analysis data developed by NOAA (used to initialize the HRRR forecast

--- a/earth2studio/data/ifs.py
+++ b/earth2studio/data/ifs.py
@@ -20,10 +20,6 @@ import pathlib
 import shutil
 from datetime import datetime
 
-try:
-    import ecmwf.opendata as opendata
-except ImportError:
-    opendata = None
 import numpy as np
 import xarray as xr
 from loguru import logger
@@ -32,14 +28,23 @@ from tqdm import tqdm
 
 from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
 from earth2studio.lexicon import IFSLexicon
-from earth2studio.utils import check_extra_imports
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import TimeArray, VariableArray
+
+try:
+    import ecmwf.opendata as opendata
+except ImportError:
+    OptionalDependencyFailure("data")
+    opendata = None
 
 logger.remove()
 logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
 
 
-@check_extra_imports("data", [opendata])
+@check_optional_dependencies()
 class IFS:
     """The integrated forecast system (IFS) initial state data source provided on an
     equirectangular grid. This data is part of ECMWF's open data project on AWS. This

--- a/earth2studio/models/dx/cbottle_infill.py
+++ b/earth2studio/models/dx/cbottle_infill.py
@@ -22,9 +22,17 @@ import pandas as pd
 import torch
 import xarray as xr
 
+from earth2studio.lexicon import CBottleLexicon
+from earth2studio.models.auto import Package
+from earth2studio.models.auto.mixin import AutoModelMixin
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
 from earth2studio.utils.coords import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem, VariableArray
 
 try:
     import earth2grid
@@ -33,6 +41,7 @@ try:
     from cbottle.denoiser_factories import DenoiserType, get_denoiser
     from cbottle.diffusion_samplers import edm_sampler_from_sigma
 except ImportError:
+    OptionalDependencyFailure("cbottle")
     earth2grid = None
     Checkpoint = None
     edm_sampler_from_sigma = None
@@ -40,18 +49,12 @@ except ImportError:
     get_mean = None
     get_std = None
 
-from earth2studio.lexicon import CBottleLexicon
-from earth2studio.models.auto import Package
-from earth2studio.models.auto.mixin import AutoModelMixin
-from earth2studio.utils.imports import check_extra_imports
-from earth2studio.utils.type import CoordSystem, VariableArray
-
 HPX_LEVEL = 6
 
 VARIABLES = np.array(list(CBottleLexicon.VOCAB.keys()))
 
 
-@check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+@check_optional_dependencies()
 class CBottleInfill(torch.nn.Module, AutoModelMixin):
     """Climate in a bottle infill diagnostic
     Climate in a Bottle (cBottle) is an AI model for emulating global km-scale climate
@@ -251,7 +254,7 @@ class CBottleInfill(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
-    @check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/dx/cbottle_sr.py
+++ b/earth2studio/models/dx/cbottle_sr.py
@@ -19,6 +19,19 @@ from collections import OrderedDict
 import numpy as np
 import torch
 
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.dx.base import DiagnosticModel
+from earth2studio.utils import (
+    handshake_coords,
+    handshake_dim,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     import earth2grid
     from cbottle import patchify
@@ -33,6 +46,7 @@ try:
     )
     from earth2grid import healpix
 except ImportError:
+    OptionalDependencyFailure("cbottle")
     earth2grid = None
     healpix = None
     patchify = None
@@ -43,16 +57,6 @@ except ImportError:
     StackedRandomGenerator = None
     edm_sampler_from_sigma = None
     get_denoiser = None
-
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.dx.base import DiagnosticModel
-from earth2studio.utils import (
-    check_extra_imports,
-    handshake_coords,
-    handshake_dim,
-)
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES = [
     "tclw",
@@ -73,7 +77,7 @@ HPX_LEVEL_LR = 6
 HPX_LEVEL_HR = 10
 
 
-@check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+@check_optional_dependencies()
 class CBottleSR(torch.nn.Module, AutoModelMixin):
     """Climate in a Bottle Super-Resolution (CBottleSR) model.
 
@@ -285,7 +289,7 @@ class CBottleSR(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
-    @check_extra_imports("cbottle", ["cbottle", "earth2grid"])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/dx/corrdiff.py
+++ b/earth2studio/models/dx/corrdiff.py
@@ -28,6 +28,20 @@ import torch
 import xarray as xr
 import zarr
 
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.dx.base import DiagnosticModel
+from earth2studio.utils import (
+    handshake_coords,
+    handshake_dim,
+    interp,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     from physicsnemo.models import Module as PhysicsNemoModule
     from physicsnemo.utils.corrdiff import (
@@ -40,25 +54,13 @@ try:
         stochastic_sampler,
     )
 except ImportError:
+    OptionalDependencyFailure("corrdiff")
     PhysicsNemoModule = None
     StackedRandomGenerator = None
     deterministic_sampler = None
 
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.dx.base import DiagnosticModel
-from earth2studio.utils import (
-    check_extra_imports,
-    handshake_coords,
-    handshake_dim,
-    interp,
-)
-from earth2studio.utils.type import CoordSystem
 
-
-@check_extra_imports(
-    "corrdiff", [PhysicsNemoModule, StackedRandomGenerator, deterministic_sampler]
-)
+@check_optional_dependencies()
 class CorrDiff(torch.nn.Module, AutoModelMixin):
     """CorrDiff is a Corrector Diffusion model that learns mappings between
     low- and high-resolution weather data with high fidelity. This model combines
@@ -372,9 +374,7 @@ class CorrDiff(torch.nn.Module, AutoModelMixin):
         raise NotImplementedError
 
     @classmethod
-    @check_extra_imports(
-        "corrdiff", [PhysicsNemoModule, StackedRandomGenerator, deterministic_sampler]
-    )
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load CorrDiff model from package.
 
@@ -736,9 +736,7 @@ VARIABLES = [
 OUT_VARIABLES = ["mrr", "t2m", "u10m", "v10m"]
 
 
-@check_extra_imports(
-    "corrdiff", [PhysicsNemoModule, StackedRandomGenerator, deterministic_sampler]
-)
+@check_optional_dependencies()
 class CorrDiffTaiwan(torch.nn.Module, AutoModelMixin):
     """
 
@@ -881,9 +879,7 @@ class CorrDiffTaiwan(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
-    @check_extra_imports(
-        "corrdiff", [PhysicsNemoModule, StackedRandomGenerator, deterministic_sampler]
-    )
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load diagnostic from package"""
 

--- a/earth2studio/models/dx/precipitation_afno.py
+++ b/earth2studio/models/dx/precipitation_afno.py
@@ -24,18 +24,21 @@ import torch
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
+from earth2studio.utils import (
+    handshake_coords,
+    handshake_dim,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
 
 try:
     from earth2studio.models.nn.afno_precip import PrecipNet
 except ImportError:
+    OptionalDependencyFailure("precip-afno")
     PrecipNet = None
-
-from earth2studio.utils import (
-    check_extra_imports,
-    handshake_coords,
-    handshake_dim,
-)
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES = [
     "u10m",
@@ -61,7 +64,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("precip-afno", [PrecipNet])
+@check_optional_dependencies()
 class PrecipitationAFNO(torch.nn.Module, AutoModelMixin):
     """Precipitation AFNO diagnsotic model. Predicts the total precipation parameter
     which is the accumulated amount of liquid and frozen water (rain or snow) with
@@ -157,7 +160,7 @@ class PrecipitationAFNO(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
-    @check_extra_imports("precip-afno", [PrecipNet])
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load diagnostic from package"""
         checkpoint_zip = Path(package.resolve("precipitation_afno.zip"))

--- a/earth2studio/models/dx/precipitation_afno_v2.py
+++ b/earth2studio/models/dx/precipitation_afno_v2.py
@@ -21,23 +21,27 @@ import numpy as np
 import torch
 import xarray as xr
 
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.dx.base import DiagnosticModel
+from earth2studio.utils import (
+    handshake_coords,
+    handshake_dim,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     from physicsnemo.utils.zenith_angle import cos_zenith_angle
 
     from earth2studio.models.nn.afno_precip_v2 import PrecipNet_v2
 except ImportError:
+    OptionalDependencyFailure("precip-afno-v2")
     PrecipNet_v2 = None
     cos_zenith_angle = None
-
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.dx.base import DiagnosticModel
-from earth2studio.utils import (
-    check_extra_imports,
-    handshake_coords,
-    handshake_dim,
-)
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES = [
     "u10m",
@@ -63,7 +67,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("precip-afno-v2", ["physicsnemo"])
+@check_optional_dependencies()
 class PrecipitationAFNOv2(torch.nn.Module, AutoModelMixin):
     """Improved Precipitation AFNO diagnostic model. Predicts the total precipitation
     for the past 6 hours [t-6h, t] with the units m. This model uses an 20 atmospheric
@@ -170,7 +174,7 @@ class PrecipitationAFNOv2(torch.nn.Module, AutoModelMixin):
         return package
 
     @classmethod
-    @check_extra_imports("precip-afno-v2", ["physicsnemo"])
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load diagnostic from package"""
 

--- a/earth2studio/models/dx/solarradiation_afno.py
+++ b/earth2studio/models/dx/solarradiation_afno.py
@@ -25,9 +25,12 @@ from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
 from earth2studio.utils import (
-    check_extra_imports,
     handshake_coords,
     handshake_dim,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
 )
 from earth2studio.utils.type import CoordSystem
 
@@ -36,6 +39,7 @@ try:
 
     from earth2studio.models.nn.afno_ssrd import SolarRadiationNet
 except ImportError:
+    OptionalDependencyFailure("solarradiation-afno")
     SolarRadiationNet = None
     cos_zenith_angle = None
 
@@ -67,7 +71,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("solarradiation-afno", [SolarRadiationNet, cos_zenith_angle])
+@check_optional_dependencies()
 class SolarRadiationAFNO(torch.nn.Module, AutoModelMixin):
     """Base class for Solar Radiation AFNO diagnostic models. Predicts the accumulated global surface solar
     radiation [Jm^-2]. The model uses 31 variables as input and outputs one on a 0.25 degree lat-lon grid
@@ -174,7 +178,7 @@ class SolarRadiationAFNO(torch.nn.Module, AutoModelMixin):
         raise NotImplementedError("Use specific frequency subclass")
 
     @classmethod
-    @check_extra_imports("solarradiation-afno", [SolarRadiationNet, cos_zenith_angle])
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load prognostic from package
 

--- a/earth2studio/models/dx/tc_tracking.py
+++ b/earth2studio/models/dx/tc_tracking.py
@@ -16,6 +16,20 @@
 
 from collections import OrderedDict
 
+import numpy as np
+import torch
+
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.utils import (
+    handshake_coords,
+    handshake_dim,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     import cupy as cp
     from cucim.skimage.feature import peak_local_max as cucim_peak_local_max
@@ -27,6 +41,7 @@ try:
 
     # from cupyx.scipy.spatial import KDTree as CuKDTree
 except ImportError:
+    OptionalDependencyFailure("cyclone")
     cp = None
     cucim_peak_local_max = None
     label = None
@@ -37,17 +52,6 @@ except ImportError:
     convex_hull_image = None
     KDTree = None
     # CuKDTree = None
-
-import numpy as np
-import torch
-
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.utils import (
-    handshake_coords,
-    handshake_dim,
-)
-from earth2studio.utils.imports import check_extra_imports
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES_TCV = [
     "u10m",
@@ -327,7 +331,7 @@ class _TCTrackerBase:
         return torch.cat([path_buffer, next_frame], axis=2)
 
 
-@check_extra_imports("cyclone", [cp, KDTree, "cucim", "skimage"])
+@check_optional_dependencies()
 class TCTrackerWuDuan(torch.nn.Module, _TCTrackerBase):
     """Finds a list of tropical cyclone (TC) centers using an adaption of the method
     described in the conditions in Wu and Duan 2023. The algorithm converts vorticity
@@ -639,7 +643,7 @@ class TCTrackerWuDuan(torch.nn.Module, _TCTrackerBase):
         return out, output_coords
 
 
-@check_extra_imports("cyclone", [cp, KDTree, "cucim", "skimage"])
+@check_optional_dependencies()
 class TCTrackerVitart(torch.nn.Module, _TCTrackerBase):
     """Finds a list of tropical cyclone centers using the conditions in Vitart 1997
 

--- a/earth2studio/models/dx/wind_gust.py
+++ b/earth2studio/models/dx/wind_gust.py
@@ -20,15 +20,6 @@ import numpy as np
 import torch
 import xarray as xr
 
-from earth2studio.utils.imports import check_extra_imports
-
-try:
-    from physicsnemo import Module
-    from physicsnemo.utils.zenith_angle import cos_zenith_angle
-except ImportError:
-    Module = None
-    cos_zenith_angle = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
@@ -36,7 +27,19 @@ from earth2studio.utils import (
     handshake_coords,
     handshake_dim,
 )
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    from physicsnemo import Module
+    from physicsnemo.utils.zenith_angle import cos_zenith_angle
+except ImportError:
+    OptionalDependencyFailure("windgust-afno")
+    Module = None
+    cos_zenith_angle = None
 
 VARIABLES = [
     "u100m",
@@ -59,7 +62,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("windgust-afno", [Module, cos_zenith_angle])
+@check_optional_dependencies()
 class WindgustAFNO(torch.nn.Module, AutoModelMixin):
     """Wind gust AFNO diagnsotic model. Predicts the maximum wind gust during the
     preceding hour with the units m/s. This model uses an 17 atmospheric inputs and
@@ -164,6 +167,7 @@ class WindgustAFNO(torch.nn.Module, AutoModelMixin):
         )
 
     @classmethod
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> DiagnosticModel:
         """Load diagnostic from package"""
         model = Module.from_checkpoint(package.resolve("afno_windgust_1h.mdlus"))

--- a/earth2studio/models/px/aifs.py
+++ b/earth2studio/models/px/aifs.py
@@ -26,8 +26,21 @@ from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
 from earth2studio.utils import handshake_coords, handshake_dim
-from earth2studio.utils.imports import check_extra_imports
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    import anemoi.inference  # noqa: F401
+    import anemoi.models  # noqa: F401
+    import earthkit.regrid  # noqa: F401
+    import ecmwf.opendata  # noqa: F401
+    import flash_attn  # noqa: F401
+except ImportError:
+    OptionalDependencyFailure("aifs")
+
 
 VARIABLES = [
     "q50",
@@ -127,16 +140,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports(
-    "aifs",
-    [
-        "anemoi.inference",
-        "anemoi.models",
-        "earthkit.regrid",
-        "ecmwf.opendata",
-        "flash_attn",
-    ],
-)
+@check_optional_dependencies()
 class AIFS(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """Artificial Intelligence Forecasting System (AIFS), a data driven forecast model
     developed by the European Centre for Medium-Range Weather Forecasts (ECMWF). AIFS is
@@ -450,16 +454,7 @@ class AIFS(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return package
 
     @classmethod
-    @check_extra_imports(
-        "aifs",
-        [
-            "anemoi.inference",
-            "anemoi.models",
-            "earthkit.regrid",
-            "ecmwf.opendata",
-            "flash_attn",
-        ],
-    )
+    @check_optional_dependencies()
     def load_model(cls, package: Package) -> PrognosticModel:
         """Load prognostic from package"""
 

--- a/earth2studio/models/px/aurora.py
+++ b/earth2studio/models/px/aurora.py
@@ -21,20 +21,25 @@ from datetime import datetime, timezone
 import numpy as np
 import torch
 
-try:
-    from aurora import Aurora as Aurora_model
-    from aurora import Batch, Metadata
-except ImportError:
-    Aurora_model = None
-    Batch = None
-    Metadata = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    from aurora import Aurora as Aurora_model
+    from aurora import Batch, Metadata
+except ImportError:
+    OptionalDependencyFailure("aurora")
+    Aurora_model = None
+    Batch = None
+    Metadata = None
 
 VARIABLES = [
     "z1000",
@@ -112,7 +117,7 @@ ATMOS_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50]
 
 
 # Adapted from https://microsoft.github.io/aurora/example_era5.html
-@check_extra_imports("aurora", [Aurora_model, Batch, Metadata])
+@check_optional_dependencies()
 class Aurora(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """Aurora 0.25 degree global forecast model. This model consists of single
     auto-regressive model with a time-step size of 6 hours. This model operates on
@@ -245,7 +250,7 @@ class Aurora(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("aurora", [Aurora_model, Batch, Metadata])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/dlesym.py
+++ b/earth2studio/models/px/dlesym.py
@@ -22,22 +22,28 @@ import numpy as np
 import torch
 import xarray as xr
 
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.px.base import PrognosticModel
+from earth2studio.models.px.utils import PrognosticMixin
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     import earth2grid
     from omegaconf import OmegaConf
     from physicsnemo.models import Module
     from physicsnemo.utils.insolation import insolation
 except ImportError:
+    OptionalDependencyFailure("dlesym")
     Module = None
     insolation = None
     OmegaConf = None
     earth2grid = None
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.px.base import PrognosticModel
-from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
-from earth2studio.utils.type import CoordSystem
 
 _ATMOS_VARIABLES = [
     "z500",
@@ -63,7 +69,7 @@ _ATMOS_OUTPUT_TIMES = np.array(
 _OCEAN_OUTPUT_TIMES = np.array([48, 96], dtype="timedelta64[h]")
 
 
-@check_extra_imports("dlesym", [OmegaConf, Module, insolation])
+@check_optional_dependencies()
 class DLESyM(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """DLESyM-V1-ERA5 prognostic model. This is an ensemble forecast model for
     global earth system modeling. This model includes an atmosphere and ocean
@@ -359,7 +365,7 @@ class DLESyM(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return package
 
     @classmethod
-    @check_extra_imports("dlesym", [Module, OmegaConf])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,
@@ -589,7 +595,7 @@ class DLESyM(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
         return output_data
 
-    @check_extra_imports("dlesym", [insolation])
+    @check_optional_dependencies()
     def _make_insolation_tensor(
         self, anchor_times: np.ndarray, timedeltas: np.ndarray
     ) -> torch.Tensor:
@@ -945,7 +951,7 @@ class DLESyMLatLon(DLESyM):
         Keyword arguments for :class:`DLESyM`
     """
 
-    @check_extra_imports("dlesym", [OmegaConf, Module, insolation, earth2grid])
+    @check_optional_dependencies()
     def __init__(
         self,
         atmos_model: torch.nn.Module,

--- a/earth2studio/models/px/dlwp.py
+++ b/earth2studio/models/px/dlwp.py
@@ -24,25 +24,30 @@ import numpy as np
 import torch
 import xarray
 
-try:
-    import physicsnemo
-    from physicsnemo.utils.zenith_angle import cos_zenith_angle
-except ImportError:
-    physicsnemo = None
-    cos_zenith_angle = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.time import timearray_to_datetime
 from earth2studio.utils.type import CoordSystem
+
+try:
+    import physicsnemo
+    from physicsnemo.utils.zenith_angle import cos_zenith_angle
+except ImportError:
+    OptionalDependencyFailure("dlwp")
+    physicsnemo = None
+    cos_zenith_angle = None
 
 VARIABLES = ["t850", "z1000", "z700", "z500", "z300", "tcwv", "t2m"]
 
 
-@check_extra_imports("dlwp", [physicsnemo, cos_zenith_angle])
+@check_optional_dependencies()
 class DLWP(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """Deep learning weather prediction (DLWP)  prognostic model. This is a parsimonious
     global forecast model with a time-step size of 6 hours. The core model is a
@@ -190,7 +195,7 @@ class DLWP(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("dlwp", [physicsnemo, cos_zenith_angle])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/fcn.py
+++ b/earth2studio/models/px/fcn.py
@@ -22,17 +22,22 @@ from pathlib import Path
 import numpy as np
 import torch
 
-try:
-    from physicsnemo.models.afno import AFNO
-except ImportError:
-    AFNO = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    from physicsnemo.models.afno import AFNO
+except ImportError:
+    OptionalDependencyFailure("fcn")
+    AFNO = None
 
 VARIABLES = [
     "u10m",
@@ -64,7 +69,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("fcn", [AFNO])
+@check_optional_dependencies()
 class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """FourCastNet global prognostic model. Consists of a single model with a time-step
     size of 6 hours. FourCastNet operates on 0.25 degree lat-lon grid (south-pole
@@ -180,7 +185,7 @@ class FCN(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("fcn", [AFNO])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/fengwu.py
+++ b/earth2studio/models/px/fengwu.py
@@ -19,13 +19,6 @@ from collections.abc import Generator, Iterator
 from typing import TypeVar
 
 import numpy as np
-
-try:
-    import onnxruntime as ort
-    from onnxruntime import InferenceSession
-except ImportError:
-    ort = None
-    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 import torch
 
 from earth2studio.models.auto import AutoModelMixin, Package
@@ -33,8 +26,20 @@ from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
 from earth2studio.models.utils import create_ort_session
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    import onnxruntime as ort
+    from onnxruntime import InferenceSession
+except ImportError:
+    OptionalDependencyFailure("fengwu")
+    ort = None
+    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 
 VARIABLES = [
     "u10m",
@@ -109,7 +114,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("fengwu", [ort])
+@check_optional_dependencies()
 class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """FengWu (operational) weather model consists of single auto-regressive model with
     a time-step size of 6 hours. FengWu operates on 0.25 degree lat-lon grid (south-pole
@@ -248,7 +253,7 @@ class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("fengwu", [ort])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/fuxi.py
+++ b/earth2studio/models/px/fuxi.py
@@ -20,23 +20,28 @@ from typing import TypeVar
 
 import numpy as np
 import pandas as pd
-from loguru import logger
-
-try:
-    import onnxruntime as ort
-    from onnxruntime import InferenceSession
-except ImportError:
-    ort = None
-    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 import torch
+from loguru import logger
 
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
 from earth2studio.models.utils import create_ort_session
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem, TimeArray
+
+try:
+    import onnxruntime as ort
+    from onnxruntime import InferenceSession
+except ImportError:
+    OptionalDependencyFailure("fuxi")
+    ort = None
+    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 
 VARIABLES = [
     "z50",
@@ -112,7 +117,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("fuxi", [ort])
+@check_optional_dependencies()
 class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """FuXi weather model consists of three auto-regressive U-net transfomer models with
     a time-step size of 6 hours. The three models are trained to predict short (5days),
@@ -257,7 +262,7 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("fuxi", [ort])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/graphcast_operational.py
+++ b/earth2studio/models/px/graphcast_operational.py
@@ -23,6 +23,18 @@ import numpy as np
 import torch
 import xarray as xr
 
+from earth2studio.lexicon.wb2 import WB2Lexicon
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.px.base import PrognosticModel
+from earth2studio.models.px.utils import PrognosticMixin
+from earth2studio.utils.coords import map_coords
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     import chex
     import haiku as hk
@@ -37,6 +49,7 @@ try:
         rollout,
     )
 except ImportError:
+    OptionalDependencyFailure("graphcast")
     hk = None
     jax = None
     chex = None
@@ -47,15 +60,6 @@ except ImportError:
     graphcast = None
     normalization = None
     rollout = None
-
-from earth2studio.lexicon.wb2 import WB2Lexicon
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.px.base import PrognosticModel
-from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports
-from earth2studio.utils.coords import map_coords
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES = [
     "t2m",
@@ -163,7 +167,7 @@ ATMOS_LEVELS = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
 INV_VOCAB = {v: k for k, v in WB2Lexicon.VOCAB.items()}
 
 
-@check_extra_imports("graphcast", ["haiku", "jax", "graphcast"])
+@check_optional_dependencies()
 class GraphCastOperational(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """GraphCast operational model
 
@@ -760,7 +764,7 @@ class GraphCastOperational(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("graphcast", ["haiku", "jax", "graphcast"])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/graphcast_small.py
+++ b/earth2studio/models/px/graphcast_small.py
@@ -23,6 +23,18 @@ import numpy as np
 import torch
 import xarray as xr
 
+from earth2studio.lexicon.wb2 import WB2Lexicon
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.px.base import PrognosticModel
+from earth2studio.models.px.utils import PrognosticMixin
+from earth2studio.utils.coords import map_coords
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     import chex
     import haiku as hk
@@ -37,6 +49,7 @@ try:
         rollout,
     )
 except ImportError:
+    OptionalDependencyFailure("graphcast")
     hk = None
     jax = None
     chex = None
@@ -48,14 +61,6 @@ except ImportError:
     normalization = None
     rollout = None
 
-from earth2studio.lexicon.wb2 import WB2Lexicon
-from earth2studio.models.auto import AutoModelMixin, Package
-from earth2studio.models.batch import batch_coords, batch_func
-from earth2studio.models.px.base import PrognosticModel
-from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports
-from earth2studio.utils.coords import map_coords
-from earth2studio.utils.type import CoordSystem
 
 VARIABLES = [
     "t2m",
@@ -163,7 +168,7 @@ ATMOS_LEVELS = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
 INV_VOCAB = {v: k for k, v in WB2Lexicon.VOCAB.items()}
 
 
-@check_extra_imports("graphcast", ["haiku", "jax", "graphcast"])
+@check_optional_dependencies()
 class GraphCastSmall(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """GraphCast Small 1.0 degree model
 
@@ -759,7 +764,7 @@ class GraphCastSmall(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
     @classmethod
-    @check_extra_imports("graphcast", ["haiku", "jax", "graphcast"])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/interpmodafno.py
+++ b/earth2studio/models/px/interpmodafno.py
@@ -22,19 +22,24 @@ import numpy as np
 import torch
 import xarray as xr
 
-try:
-    from physicsnemo import Module as PhysicsNemoModule
-    from physicsnemo.utils.zenith_angle import cos_zenith_angle
-except ImportError:
-    PhysicsNemoModule = None
-    cos_zenith_angle = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports
 from earth2studio.utils.coords import CoordSystem, map_coords
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+
+try:
+    from physicsnemo import Module as PhysicsNemoModule
+    from physicsnemo.utils.zenith_angle import cos_zenith_angle
+except ImportError:
+    OptionalDependencyFailure("interp-modafno")
+    PhysicsNemoModule = None
+    cos_zenith_angle = None
+
 
 VARIABLES = [
     "u10m",
@@ -113,7 +118,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("interp-modafno", [PhysicsNemoModule, cos_zenith_angle])
+@check_optional_dependencies()
 class InterpModAFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """ModAFNO interpolation for global prognostic models. Interpolates a forecast model
     to a shorter time-step size (by default from 6 to 1 hour). Operates on 0.25 degree
@@ -272,7 +277,7 @@ class InterpModAFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return package
 
     @classmethod
-    @check_extra_imports("interp-modafno", [PhysicsNemoModule, cos_zenith_angle])
+    @check_optional_dependencies()
     def load_model(
         cls, package: Package, px_model: PrognosticModel | None = None
     ) -> PrognosticModel:

--- a/earth2studio/models/px/pangu.py
+++ b/earth2studio/models/px/pangu.py
@@ -28,13 +28,6 @@ from collections.abc import Generator, Iterator
 from typing import TypeVar
 
 import numpy as np
-
-try:
-    import onnxruntime as ort
-    from onnxruntime import InferenceSession
-except ImportError:
-    ort = None
-    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 import torch
 
 from earth2studio.models.auto import AutoModelMixin, Package
@@ -42,8 +35,20 @@ from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
 from earth2studio.models.utils import create_ort_session
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.type import CoordSystem
+
+try:
+    import onnxruntime as ort
+    from onnxruntime import InferenceSession
+except ImportError:
+    OptionalDependencyFailure("pangu")
+    ort = None
+    InferenceSession = TypeVar("InferenceSession")  # type: ignore
 
 VARIABLES = [
     "z1000",
@@ -325,7 +330,7 @@ class PanguBase(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         yield from self._default_generator(x, coords)
 
 
-@check_extra_imports("pangu", [ort])
+@check_optional_dependencies()
 class Pangu24(PanguBase):
     """Pangu Weather 24 hour model. This model consists of single auto-regressive
     model with a time-step size of 24 hours. Pangu Weather operates on 0.25 degree
@@ -366,7 +371,7 @@ class Pangu24(PanguBase):
         self._output_coords["lead_time"] = np.array([np.timedelta64(24, "h")])
 
     @classmethod
-    @check_extra_imports("pangu", [ort])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,
@@ -424,7 +429,7 @@ class Pangu24(PanguBase):
             yield x, coords.copy()
 
 
-@check_extra_imports("pangu", [ort])
+@check_optional_dependencies()
 class Pangu6(PanguBase):
     """Pangu Weather 6 hour model. This model consists of two underlying auto-regressive
     models with a time-step size of 24 hours and 6 hours. These two models are
@@ -469,7 +474,7 @@ class Pangu6(PanguBase):
         self._output_coords["lead_time"] = np.array([np.timedelta64(6, "h")])
 
     @classmethod
-    @check_extra_imports("pangu", [ort])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,
@@ -539,7 +544,7 @@ class Pangu6(PanguBase):
             yield x, coords.copy()
 
 
-@check_extra_imports("pangu", [ort])
+@check_optional_dependencies()
 class Pangu3(PanguBase):
     """Pangu Weather 3 hour model. This model consists of three underlying
     auto-regressive models with a time-step size of 24, 6 and 3 hours. These three
@@ -589,7 +594,7 @@ class Pangu3(PanguBase):
         self._output_coords["lead_time"] = np.array([np.timedelta64(3, "h")])
 
     @classmethod
-    @check_extra_imports("pangu", [ort])
+    @check_optional_dependencies()
     def load_model(
         cls,
         package: Package,

--- a/earth2studio/models/px/sfno.py
+++ b/earth2studio/models/px/sfno.py
@@ -22,18 +22,23 @@ from zoneinfo import ZoneInfo
 import numpy as np
 import torch
 
-try:
-    from makani.models.model_package import load_model_package
-except ImportError:
-    load_model_package = None
-
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 from earth2studio.utils.time import timearray_to_datetime
 from earth2studio.utils.type import CoordSystem
+
+try:
+    from makani.models.model_package import load_model_package
+except ImportError:
+    OptionalDependencyFailure("sfno")
+    load_model_package = None
 
 VARIABLES = [
     "u10m",
@@ -112,7 +117,7 @@ VARIABLES = [
 ]
 
 
-@check_extra_imports("sfno", [load_model_package])
+@check_optional_dependencies()
 class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     """Spherical Fourier Operator Network global prognostic model.
     Consists of a single model with a time-step size of 6 hours.
@@ -231,7 +236,7 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return package
 
     @classmethod
-    @check_extra_imports("sfno", [load_model_package])
+    @check_optional_dependencies()
     def load_model(
         cls, package: Package, variables: list = VARIABLES
     ) -> PrognosticModel:

--- a/earth2studio/perturbation/gaussian.py
+++ b/earth2studio/perturbation/gaussian.py
@@ -18,16 +18,20 @@ from typing import Any
 
 import numpy as np
 import torch
+from typing_extensions import Self
+
+from earth2studio.utils import handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
 
 try:
     from torch_harmonics import InverseRealSHT
 except ImportError:
+    OptionalDependencyFailure("perturbation")
     InverseRealSHT = None
-from typing_extensions import Self
-
-from earth2studio.utils import handshake_dim
-from earth2studio.utils.imports import check_extra_imports
-from earth2studio.utils.type import CoordSystem
 
 
 class Gaussian:
@@ -71,7 +75,7 @@ class Gaussian:
         return x + noise_amplitude * torch.randn_like(x), coords
 
 
-@check_extra_imports("perturbation", [InverseRealSHT])
+@check_optional_dependencies()
 class CorrelatedSphericalGaussian:
     """Produces Gaussian random field on the sphere with Matern covariance peturbation
     method output to a lat lon grid.

--- a/earth2studio/perturbation/spherical.py
+++ b/earth2studio/perturbation/spherical.py
@@ -17,16 +17,21 @@
 import numpy as np
 import torch
 
+from earth2studio.utils import handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     from torch_harmonics import InverseRealSHT
 except ImportError:
+    OptionalDependencyFailure("perturbation")
     InverseRealSHT = None
 
-from earth2studio.utils import check_extra_imports, handshake_dim
-from earth2studio.utils.type import CoordSystem
 
-
-@check_extra_imports("perturbation", [InverseRealSHT])
+@check_optional_dependencies()
 class SphericalGaussian:
     """Gaussian random field on the sphere with Matern covariance peturbation method
     output to a lat lon grid

--- a/earth2studio/statistics/crps.py
+++ b/earth2studio/statistics/crps.py
@@ -16,17 +16,22 @@
 
 import torch
 
+from earth2studio.statistics.moments import mean
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     from physicsnemo.metrics.general.crps import kcrps
 except ImportError:
+    OptionalDependencyFailure("statistics")
     kcrps = None
 
-from earth2studio.statistics.moments import mean
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
-from earth2studio.utils.type import CoordSystem
 
-
-@check_extra_imports("statistics", [kcrps])
+@check_optional_dependencies()
 class crps:
     """
     Compute the Continuous Ranked Probably Score (CRPS).

--- a/earth2studio/statistics/rank.py
+++ b/earth2studio/statistics/rank.py
@@ -19,17 +19,22 @@ from collections import OrderedDict
 import numpy as np
 import torch
 
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import CoordSystem
+
 try:
     from physicsnemo.metrics.general.histogram import _count_bins, linspace
 except ImportError:
+    OptionalDependencyFailure("statistics")
     _count_bins = None
     linspace = None
 
-from earth2studio.utils import check_extra_imports, handshake_coords, handshake_dim
-from earth2studio.utils.type import CoordSystem
 
-
-@check_extra_imports("statistics", [_count_bins, linspace])
+@check_optional_dependencies()
 class rank_histogram:
     """
     Compute the Rank Histogram for a given set of ensemble forecasts.

--- a/earth2studio/utils/__init__.py
+++ b/earth2studio/utils/__init__.py
@@ -20,4 +20,3 @@ from .coords import (
     handshake_dim,
     handshake_size,
 )
-from .imports import check_extra_imports

--- a/earth2studio/utils/imports.py
+++ b/earth2studio/utils/imports.py
@@ -13,65 +13,146 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import importlib
+import inspect
+import sys
 from collections.abc import Callable
 from functools import wraps
-from importlib.util import find_spec
+from types import TracebackType
 from typing import Any, TypeVar, cast
 
-from loguru import logger
+from rich.console import Console
+from rich.table import Table
+from rich.traceback import Traceback
 
 F = TypeVar("F", bound=Callable[..., Any])
 C = TypeVar("C", bound=type[Any])
 
 
-class ExtraDependencyError(ImportError):
-    """Custom error for missing extra dependencies."""
+class OptionalDependencyError(ImportError):
+    """Custom error for missing optional dependencies."""
 
-    def __init__(self, extra_name: str, obj_name: str):
-        super().__init__(
-            f"Extra dependency group '{extra_name}' is required for {obj_name}.\n"
-            f"Install with: uv pip install earth2studio --extra {extra_name} \n"
-            f"or refer to the install documentation."
+    def __init__(
+        self,
+        group_name: str,
+        object_name: str,
+        error_value: BaseException | None = None,
+        error_traceback: TracebackType | None = None,
+        doc_url: str | None = None,
+    ):
+        if doc_url is None:
+            doc_url = "https://nvidia.github.io/earth2studio/userguide/about/install.html#optional-dependencies"
+
+        console = Console()
+        table = Table(show_header=False, show_lines=True)
+        table.add_row(
+            "[blue]Earth2Studio Extra Dependency Error\n"
+            + "This error typically indicates an extra dependency group is needed.\n"
+            + "Don't panic, this is usually an easy fix.[/blue]"
         )
+        table.add_row(
+            f"[yellow]This feature ('{object_name}') is marked needing optional dependency group '{group_name}'.\n\n"
+            + f"uv install with: `uv add earth2studio --extra {group_name}`\n\n"
+            + "For more information (such as pip install instructions), visit the install documentation: \n"
+            + f"{doc_url}[/yellow]"
+        )
+        if error_value:
+            table.add_row(
+                Traceback(
+                    Traceback.extract(
+                        ImportError, error_value, error_traceback, show_locals=True
+                    )
+                )
+            )
+        console.print(table)
+        super().__init__("Optional dependency import error")
 
 
-def check_extra_imports(
-    extra_name: str, package_obj: Any | list[Any]
+class OptionalDependencyFailure:
+    """Optional dependency group failure.
+    Instantiate this in the catch of an import failure for a group of optional
+    dependencies. This will add the failure the class singleton dictionary.
+
+    Parameters
+    ----------
+    group_name : str
+        Name of the optional dependency group imports are present in. For example
+        this would be "data" if the install command is:
+        `pip install earth2studio[data]`
+    key : str | None, optional
+        Unique dependency group key to id the import. This is used with the
+        `check_extra_imports` to check if needed optional dependencies are
+        installed. Setting this manually is typiclaly not needed. If None, the key
+        will be the filename of the caller object, by default None
+    doc_url : str | None, optional
+        Install doc url override of the install doc link present in error
+        message if import error occurs, by default None
+
+    Raises
+    ------
+    ValueError
+        If key is not unique
+    """
+
+    failures: dict[str, "OptionalDependencyFailure"] = {}
+
+    def __init__(
+        self,
+        group_name: str,
+        key: str | None = None,
+        doc_url: str | None = None,
+    ):
+        if key is None:
+            stack = inspect.stack()
+            caller_frame = stack[1]
+            key = caller_frame.filename
+
+        if key in self.failures:
+            raise ValueError(f"Extra dependency key already defined: {key}")
+        if group_name is None:
+            group_name = key
+
+        # Get current exception and traceback
+        _, exc_value, tb_value = sys.exc_info()
+
+        self.import_exception = exc_value
+        self.import_traceback = tb_value
+        self.doc_url = doc_url
+        self.group_name = group_name
+        self.failures[key] = self
+
+
+def check_optional_dependencies(
+    key: str | None = None,
 ) -> Callable[[Any], Any]:
     """Decorator to handle validating optional dependencies are installed for both
     functions and classes.
 
     Parameters
     ----------
-    extra_name : str
-        Name of the extra/optional dependency group present in the pyproject.toml
-        E.g. 'corrdiff', 'fcn'
-    package_obj : Any | list[Any]
-        Object(s) that should be instantiated / imported. If it is a string, it will be
-        treated as a module path and checked if it is available. Otherwise this will
-        check if the object is instantiated.
+    key : str | None, optional
+        Optional dependency group key to check for any import errors. This typically
+        does not need to be set. If None will use the filename of the caller object, by
+        default None
     """
 
-    def _check_dependencies(obj_name: Any) -> None:
-        package_objs = package_obj if isinstance(package_obj, list) else [package_obj]
-        for pkg in package_objs:
-            # If package is a string (module path like module.submodule), check if the
-            #  module is available.
-            if isinstance(pkg, str):
-                if find_spec(pkg) is None:
-                    logger.error(f"Could not find spec for module {pkg}")
-                    raise ExtraDependencyError(extra_name, obj_name)
-                else:
-                    # Check to make sure that we can actually import the package
-                    try:
-                        importlib.import_module(pkg)
-                    except ImportError as e:
-                        raise ImportError(
-                            f"Unexpected extra dependency import error of package {pkg}:\n{e}"
-                        )
-            elif pkg is None:
-                raise ExtraDependencyError(extra_name, obj_name)
+    def _check_deps(key: str | None, obj_name: str) -> None:
+        if key is None:
+            stack = inspect.stack()
+            caller_frame = stack[2]
+            key = caller_frame.filename
+        # No error in singleton = no import issues
+        if key not in OptionalDependencyFailure.failures:
+            return
+
+        group = OptionalDependencyFailure.failures[key]
+        if group.import_exception is not None:
+            raise OptionalDependencyError(
+                group.group_name,
+                obj_name,
+                group.import_exception,
+                group.import_traceback,
+                group.doc_url,
+            )
 
     def _decorator(obj: F | C) -> F | C:
         if isinstance(obj, type):
@@ -79,7 +160,7 @@ def check_extra_imports(
 
             @wraps(original_init)
             def _wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
-                _check_dependencies(obj.__name__)
+                _check_deps(key, obj.__name__)
                 original_init(self, *args, **kwargs)
 
             obj.__init__ = _wrapped_init  # type: ignore
@@ -88,9 +169,14 @@ def check_extra_imports(
             # Handle function decoration
             @wraps(obj)
             def _wrapper(*args: Any, **kwargs: Any) -> Any:
-                _check_dependencies(f"{obj.__module__}.{obj.__name__}")
+                _check_deps(key, f"{obj.__module__}.{obj.__name__}")
                 return obj(*args, **kwargs)
 
             return cast(F, _wrapper)
 
     return _decorator
+
+
+def check_extra_imports(*args: Any, **kwargs: Any) -> None:
+    """Nothing"""
+    pass

--- a/earth2studio/utils/imports.py
+++ b/earth2studio/utils/imports.py
@@ -137,7 +137,7 @@ def check_optional_dependencies(
     """
     if key is None:
         stack = inspect.stack()
-        caller_frame = stack[2]
+        caller_frame = stack[1]
         key = caller_frame.filename
 
     def _check_deps(obj_name: str) -> None:

--- a/earth2studio/utils/imports.py
+++ b/earth2studio/utils/imports.py
@@ -70,7 +70,8 @@ class OptionalDependencyError(ImportError):
 class OptionalDependencyFailure:
     """Optional dependency group failure.
     Instantiate this in the catch of an import failure for a group of optional
-    dependencies. This will add the failure the class singleton dictionary.
+    dependencies. This will add the failure the class singleton dictionary for
+    later look up.
 
     Parameters
     ----------
@@ -81,7 +82,7 @@ class OptionalDependencyFailure:
     key : str | None, optional
         Unique dependency group key to id the import. This is used with the
         `check_optional_dependencies` to check if needed optional dependencies are
-        installed. Setting this manually is typiclaly not needed. If None, the key
+        installed. Setting this manually is typically not needed. If None, the key
         will be the filename of the caller object, by default None
     doc_url : str | None, optional
         Install doc url override of the install doc link present in error


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Improves the optional import utils with
- better error reporting (will dump import error)
- message formatting
- usability for the developer
- More consistent API names (call things optional instead of extra)

The system now leans more on information in the catch of the import try catch, rather than needing the developer to specify the specific objects to check in the decorator.

The updated process looks like the following:
https://github.com/NickGeneva/earth2studio/blob/ngeneva/optional_deps_improvements/docs/userguide/developer/dependency.md#handling-optional-imports

Also improves error message to be more informative.

Closes: https://github.com/NVIDIA/earth2studio/issues/400

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
