### PR TITLE
Adding uv script dependencies to examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Different compression codec support in the ZarrBackend with `zarr_codecs` parameter
 - IO performance example
 - Unified CorrDiff Wrapper
+- Added UV script dependencies to all examples
 
 ### Changed
 

--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -633,7 +633,7 @@ For developer environments, please refer to the {ref}`developer_overview`.
 
 ## uv Project
 
-Using uv is the recommend way to set up a Python environment for Earth2Studio.
+Using uv is the recommend way to set up a local Python environment for Earth2Studio.
 Assuming [uv is installed](https://docs.astral.sh/uv/getting-started/installation/), use
 the following commands:
 
@@ -655,7 +655,8 @@ uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.8.1"
 ## PyTorch Docker Container
 
 For a docker environment the [Nvidia PyTorch container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)
-provides a good base with many dependencies already installed.
+provides a good base with many dependencies already installed and optimized for NVIDIA
+hardware.
 In container instances, using a virtual environment is often [not necessary](https://docs.astral.sh/uv/pip/environments/#using-arbitrary-python-environments).
 It is recommend using the following commands to install using the container's Python
 interpreter:
@@ -683,6 +684,7 @@ uv pip install --system \
 ```
 
 :::
+
 <!-- markdownlint-enable MD013 -->
 
 ## Custom Container

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -118,6 +118,10 @@ Sphinx Gallery supports embedded reST (reStructuredText) syntax in the form of c
 These comments are automatically rendered as formatted text on the documentation web
 pages and as markdown cells in the converted Jupyter notebooks.
 For more details on the syntax, see the [embedded reST documentation](https://sphinx-gallery.github.io/stable/syntax.html#embed-rest-in-your-example-python-files).
+
+To specify required dependencies, use [uv inline metadata](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies>)
+which allows each example to use different dependency groups or packages not shipped
+with Earth2Studio.
 To create an example, the best method is to copy an existing example and follow the
 structure:
 
@@ -140,6 +144,13 @@ In this example you will learn:
 - Running a simple built in workflow
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+#   "other depedencies...",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/01_deterministic_workflow.py
+++ b/examples/01_deterministic_workflow.py
@@ -32,6 +32,12 @@ In this example you will learn:
 - Running a simple built in workflow
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/02_diagnostic_workflow.py
+++ b/examples/02_diagnostic_workflow.py
@@ -33,6 +33,12 @@ In this example you will learn:
 - Running the built in diagnostic workflow
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/03_ensemble_workflow.py
+++ b/examples/03_ensemble_workflow.py
@@ -33,6 +33,12 @@ In this example you will learn:
 - Running a simple built in workflow for ensembling
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[fcn] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/03_ensemble_workflow.py
+++ b/examples/03_ensemble_workflow.py
@@ -35,7 +35,7 @@ In this example you will learn:
 """
 # /// script
 # dependencies = [
-#   "earth2studio[fcn] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[fcn,perturbation] @ git+https://github.com/NVIDIA/earth2studio.git",
 #   "cartopy",
 # ]
 # ///

--- a/examples/04_corrdiff_inference.py
+++ b/examples/04_corrdiff_inference.py
@@ -37,6 +37,12 @@ In this example you will learn:
 - Initializing and running CorrDiff diagnostic model
 - Post-processing results.
 """
+# /// script
+# dependencies = [
+#   "earth2studio[corrdiff] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Creating a Simple CorrDiff Workflow

--- a/examples/05_ensemble_workflow_extend.py
+++ b/examples/05_ensemble_workflow_extend.py
@@ -33,6 +33,12 @@ In this example you will learn:
 - Extend a built-in method using custom code.
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp,perturbation] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/06_model_perturbation_hook.py
+++ b/examples/06_model_perturbation_hook.py
@@ -40,10 +40,16 @@ In this example you will learn:
 - Choose a subselection of coordinates to save to an IO object.
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Creating an Ensemble Workflow
-# -----------------------------------
+# -----------------------------
 #
 # To start let's begin with creating an ensemble workflow to use. We encourage
 # users to explore and experiment with their own custom workflows that borrow ideas from

--- a/examples/07_seasonal_statistics.py
+++ b/examples/07_seasonal_statistics.py
@@ -36,7 +36,7 @@ In this example you will learn:
 """
 # /// script
 # dependencies = [
-#   "earth2studio[pangu] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[pangu,statistics] @ git+https://github.com/NVIDIA/earth2studio.git",
 #   "matplotlib",
 # ]
 # ///

--- a/examples/07_seasonal_statistics.py
+++ b/examples/07_seasonal_statistics.py
@@ -34,10 +34,16 @@ In this example you will learn:
 - Running a simple built in workflow
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[pangu] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
-# Creating a statistical workflow
-# -----------------------------------
+# Creating a Statistical Workflow
+# -------------------------------
 #
 # Start with creating a simple inference workflow to use. We encourage
 # users to explore and experiment with their own custom workflows that borrow ideas from

--- a/examples/08_distributed_manager.py
+++ b/examples/08_distributed_manager.py
@@ -36,6 +36,12 @@ In this example you will learn:
 - Limitations of parallel inference in Earth2Studio
 - Post-processing strategies of parallel job outputs
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/09_stormcast_example.py
+++ b/examples/09_stormcast_example.py
@@ -28,6 +28,12 @@ see
  - https://arxiv.org/abs/2408.10958
 
 """
+# /// script
+# dependencies = [
+#   "earth2studio[data,stormcast] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/10_stormcast_ensemble_example.py
+++ b/examples/10_stormcast_ensemble_example.py
@@ -28,6 +28,13 @@ see
  - https://arxiv.org/abs/2408.10958
 
 """
+# /// script
+# dependencies = [
+#   "earth2studio[data,stormcast] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
+
 # %%
 # Set Up
 # ------

--- a/examples/11_huge_ensembles.py
+++ b/examples/11_huge_ensembles.py
@@ -50,6 +50,12 @@ In this example you will learn:
 - How to visualize results
 
 """
+# /// script
+# dependencies = [
+#   "earth2studio[sfno] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/12_temporal_interpolation.py
+++ b/examples/12_temporal_interpolation.py
@@ -35,6 +35,12 @@ In this example you will learn:
 - How to run the interpolation model
 - How to visualize the results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[sfno,interp-modafno] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/13_cyclone_tracking.py
+++ b/examples/13_cyclone_tracking.py
@@ -34,6 +34,12 @@ In this example you will learn:
 - How to couple the TC tracker to a prognostic model
 - Post-processing results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[cyclone,sfno] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/14_dlesym_example.py
+++ b/examples/14_dlesym_example.py
@@ -37,6 +37,12 @@ In this example you will learn:
 - How to use the output selection and regridding methods to select appropriate data
 - How to use the DLESyMLatLon model with earth2studio workflows
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlesym] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/15_cbottle_generation.py
+++ b/examples/15_cbottle_generation.py
@@ -36,6 +36,12 @@ In this example you will learn:
 - Instantiating cBottle infill diagnostic model
 - Creating a simple infilling inference workflow
 """
+# /// script
+# dependencies = [
+#   "earth2studio[cbottle] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/16_cbottle_super_resolution.py
+++ b/examples/16_cbottle_super_resolution.py
@@ -35,6 +35,12 @@ In this example you will learn:
 - Performing super resolution on ERA5 data after infilling with cBottle
 - Post-processing and visualizing super-resolution results
 """
+# /// script
+# dependencies = [
+#   "earth2studio[cbottle] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/17_io_performance.py
+++ b/examples/17_io_performance.py
@@ -34,6 +34,12 @@ In this example you will learn:
 - Initializing and writing with the Asynchronous Non-blocking Zarr IO backend
 - Discussing performance implications and strategies that can be used
 """
+# /// script
+# dependencies = [
+#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
 # Set Up

--- a/examples/17_io_performance.py
+++ b/examples/17_io_performance.py
@@ -36,7 +36,7 @@ In this example you will learn:
 """
 # /// script
 # dependencies = [
-#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
 #   "matplotlib",
 # ]
 # ///

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -3,3 +3,38 @@ Examples
 
 This is a collection of examples in Earth2Studio that demonstrate various functionality
 and commonly used workflows.
+
+.. dropdown:: Example Dependencies
+    :color: warning
+    :icon: alert
+
+    Examples require installation of optional dependency groups or additional packages
+    for the specific models used or post-processing steps.
+    Each example has `uv inline metadata <https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies>`_
+    to lazily install needed dependencies when using the ``uv run`` command or reference
+    for manual pip installation.
+
+.. dropdown:: Running Examples
+    :color: info
+    :icon: rocket
+
+    Earth2Studio examples can be downloaded as a notebook or runnable Python script.
+    Use uv to auto install dependencies on execution:
+
+    ``uv run <example_script>.py``
+
+    If you are using a container or other environment, and need to pip install then
+    look for the code blocks of the form:
+
+    .. code-block:: python
+
+        # /// script
+        # dependencies = [
+        #   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+        #   "cartopy",
+        # ]
+        # ///
+
+    Pip install these packages then execute the example with:
+
+    ``python <example_script>.py``

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -4,27 +4,20 @@ Examples
 This is a collection of examples in Earth2Studio that demonstrate various functionality
 and commonly used workflows.
 
-.. dropdown:: Example Dependencies
-    :color: warning
-    :icon: alert
-
-    Examples require installation of optional dependency groups or additional packages
-    for the specific models used or post-processing steps.
-    Each example has `uv inline metadata <https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies>`_
-    to lazily install needed dependencies when using the ``uv run`` command or reference
-    for manual pip installation.
-
 .. dropdown:: Running Examples
     :color: info
     :icon: rocket
 
     Earth2Studio examples can be downloaded as a notebook or runnable Python script.
+    Each requires installation of different optional dependency groups or additional
+    packages for the specific models used or post-processing steps.
     Use uv to auto install dependencies on execution:
 
     ``uv run <example_script>.py``
 
     If you are using a container or other environment, and need to pip install then
-    look for the code blocks of the form:
+    look for the `uv inline metadata <https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies>`_
+    blocks of the form:
 
     .. code-block:: python
 

--- a/examples/extend/01_custom_prognostic.py
+++ b/examples/extend/01_custom_prognostic.py
@@ -30,6 +30,12 @@ In this example you will learn:
 - Implementing a custom prognostic model
 - Running this model in existing workflows
 """
+# /// script
+# dependencies = [
+#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
 
 # %%
 # Custom Prognostic

--- a/examples/extend/02_custom_diagnostic.py
+++ b/examples/extend/02_custom_diagnostic.py
@@ -30,6 +30,12 @@ In this example you will learn:
 - Implementing a custom diagnostic model
 - Running this custom model in a workflow with built in prognostic
 """
+# /// script
+# dependencies = [
+#   "earth2studio[dlwp] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Custom Diagnostic

--- a/examples/extend/03_custom_datasource.py
+++ b/examples/extend/03_custom_datasource.py
@@ -31,8 +31,9 @@ In this example you will learn:
 """
 # /// script
 # dependencies = [
-#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[fcn] @ git+https://github.com/NVIDIA/earth2studio.git",
 #   "cartopy",
+#   "scipy",
 # ]
 # ///
 

--- a/examples/extend/03_custom_datasource.py
+++ b/examples/extend/03_custom_datasource.py
@@ -29,6 +29,12 @@ In this example you will learn:
 - API requirements of data soruces
 - Implementing a custom data soruce
 """
+# /// script
+# dependencies = [
+#   "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
 
 # %%
 # Custom Data Source

--- a/test/_ci/run_examples.sh
+++ b/test/_ci/run_examples.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [ -d "outputs" ]; then
+    rm -rf outputs
+fi
+
+for example in examples/*.py; do
+    if [ -f "$example" ]; then
+        echo "Running example: $example"
+        uv run "$example"
+        if [ $? -ne 0 ]; then
+            echo "Error running $example"
+            exit 1
+        fi
+    fi
+done

--- a/test/_ci/sync_version.sh
+++ b/test/_ci/sync_version.sh
@@ -20,3 +20,8 @@ sed -i "s/${PREV_VERSION}/${VERSION}/g" recipes/template/README.md
 sed -i "s/${PREV_VERSION}/${VERSION}/g" .github/ISSUE_TEMPLATE/bug_report.yml
 
 echo "Replaced all occurrences of ${PREV_VERSION} with ${VERSION}"
+
+# Update examples to use versioned git earth2studio
+find examples -type f -name "*.py" -exec sed -i "s|git+https://github.com/NVIDIA/earth2studio.git|git+https://github.com/NVIDIA/earth2studio.git@${VERSION}|g" {} \;
+
+echo "Updated example scripts to use earth2studio version ${VERSION}"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR addresses the long standing problem of needing additional dependencies / specific groups for each example.
Leveraging UV, we can add meta data that will essentially create a mini venv when running the script.

https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies

`uv run example_name.py` now creates a isolated venv and loads needed deps.

I've added this meta data to all examples.
If nothing else this will spell out the dependencies needed for people to manually pip install.

- Added a drop down on the main example page with some information.
- Added CI script for UV running all examples which will be used in nightly pipeline
- Updated versioning bash script that will also tag the installs for examples for a given version of the docs
- Updated example developer docs

<img width="1636" height="1343" alt="image" src="https://github.com/user-attachments/assets/0522c8a2-e066-43b2-8d72-db4602cc716b" />

What examples look like:

<img width="1636" height="1343" alt="image" src="https://github.com/user-attachments/assets/80821982-c6a5-4e0f-8ed7-f9c63158cdf0" />


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
