### PR TITLE
Fix SFNO datetime bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Incorrect datetime utc timezone calculation in SFNO wrapper was fixed.
 - DLWP output coords lead_time array to have proper shape
 - Fixed data sources using GCFS throwing error at end of script from aiohttp session
   clean up

--- a/earth2studio/models/px/sfno.py
+++ b/earth2studio/models/px/sfno.py
@@ -17,7 +17,7 @@ import json
 import os
 from collections import OrderedDict
 from collections.abc import Generator, Iterator
-from zoneinfo import ZoneInfo
+from datetime import datetime
 
 import numpy as np
 import torch
@@ -287,7 +287,7 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                 # https://github.com/NVIDIA/modulus-makani/blob/933b17d5a1ebfdb0e16e2ebbd7ee78cfccfda9e1/makani/third_party/climt/zenith_angle.py#L197
                 # Requires time zone data
                 t = [
-                    dt.replace(tzinfo=ZoneInfo("UTC"))
+                    datetime.fromisoformat(dt.isoformat() + "+00:00")
                     for dt in timearray_to_datetime(t + coords["lead_time"])
                 ]
                 x[j, i : i + 1] = self.model(x[j, i : i + 1], t)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
There was a bug in the implementation of SFNO that used `datetime.replace` in the conversion of a numpy datetime64 to a datetime object with UTC timezone. It turns out that the behavior is to actually modify the underlying timestamp depending on the user's location instead of just labeling the timezone. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

