### PR TITLE
Use ocean output times for ocean coupling

### DIFF
--- a/earth2studio/models/px/dlesym.py
+++ b/earth2studio/models/px/dlesym.py
@@ -679,7 +679,7 @@ class DLESyM(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
         # Slice along the lead_time dim, average, and stack along the variable dim
         # (different time-averaged quantities are defined as different variables)
-        slices = ocean_coupling.chunk(len(self.ocean_input_times), dim=2)
+        slices = ocean_coupling.chunk(len(self.ocean_output_times), dim=2)
         ocean_coupling = torch.concat(
             [s.mean(dim=2, keepdim=True) for s in slices], dim=3
         )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Uses the length of ocean output times to chunk ocean coupled inputs, rather than input times. Does not change behavior of current default package since the output times are same length as the input times, but this should be more flexible/correct for custom or future DLESyM variants.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
