### PR TITLE
Fixing HRRR lead time catches and improving error messages for grib index fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DLWP output coords lead_time array to have proper shape
 - Fixed data sources using GCFS throwing error at end of script from aiohttp session
   clean up
+- Fixed HRRR_FX valid lead time check for date times not on 6 hour interval
 
 ### Security
 

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -420,7 +420,12 @@ class GFS:
             Dictionary of GFS vairables (byte offset, byte length)
         """
         # Grab index file
-        index_file = await self._fetch_remote_file(index_uri)
+        try:
+            index_file = await self._fetch_remote_file(index_uri)
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"The specified data index, {index_uri}, does not exist. Data seems to be missing."
+            )
         with open(index_file) as file:
             index_lines = [line.rstrip() for line in file]
 

--- a/test/data/test_hrrr.py
+++ b/test/data/test_hrrr.py
@@ -231,8 +231,9 @@ def test_hrrr_validate_inputs():
 def test_hrrr_fx_validate_leadtime():
     ds = HRRR_FX(cache=False)
     # Test valid lead times
+    times = [datetime(2024, 1, 1)]
     valid_lead_times = [timedelta(hours=1), timedelta(hours=12), timedelta(hours=48)]
-    ds._validate_leadtime(valid_lead_times)
+    ds._validate_leadtime(times, valid_lead_times)
 
     # Test invalid lead times
     invalid_lead_times = [
@@ -242,7 +243,12 @@ def test_hrrr_fx_validate_leadtime():
     ]
     for lt in invalid_lead_times:
         with pytest.raises(ValueError):
-            ds._validate_leadtime([lt])
+            ds._validate_leadtime(times, [lt])
+
+    times = [datetime(2024, 1, 1, 1), datetime(2024, 1, 1, 2), datetime(2024, 1, 1, 3)]
+    for time0 in times:
+        with pytest.raises(ValueError):
+            ds._validate_leadtime([time0], [timedelta(hours=19)])
 
 
 @pytest.mark.timeout(15)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adds check for lead times not on 6 hour interval for HRRR, also improves error message when grib index files / data is missing for GFS and HRRR.

Closes: https://github.com/NVIDIA/earth2studio/issues/387

Closes: https://github.com/NVIDIA/earth2studio/issues/393

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
