### PR TITLE
Add checkpointing functionality to workflows

### DIFF
--- a/earth2studio/utils/checkpoint.py
+++ b/earth2studio/utils/checkpoint.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from earth2studio.models.px import PrognosticModel
+from earth2studio.utils.coords import CoordSystem
+
+
+def save_checkpoint(
+    step: int,
+    state: torch.Tensor,
+    coords: CoordSystem,
+    checkpoint_path: str,
+    workflow_type: str = "deterministic",
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Save workflow checkpoint to disk.
+    Parameters
+    ----------
+
+    step : int
+        Current simulation step number
+    state : torch.Tensor
+        Current atmospheric state tensor on GPU
+    coords : CoordSystem
+        Current coordinate system (OrderedDict or coordinate arrays)
+    checkpoint_path : str
+        File path where checkpoint will be saved
+    workflow_type : str, optional
+        Type of workflow being checkpointed, be default "deterministic"
+    metadata : dict[str, Any], optional
+        Additional metadata to store with checkpoint, by default None
+    """
+
+    checkpoint = {
+        "step": step,
+        "state": state,
+        "coords": coords,
+        "workflow_type": workflow_type,
+        "torch_rng_state": torch.get_rng_state(),
+        "metadata": metadata or {},
+    }
+
+    if torch.cuda.is_available():
+        checkpoint["cuda_rng_state"] = torch.cuda.get_rng_state()
+
+    Path(checkpoint_path).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(checkpoint, checkpoint_path)
+
+
+def load_checkpoint(checkpoint_path: str, device: torch.device) -> dict[str, Any]:
+    """Load workflow checkpoint from disk."""
+
+    if not Path(checkpoint_path).exists():
+        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+
+    checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
+
+    if "torch_rng_state" in checkpoint:
+        torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+
+    if "cuda_rng_state" in checkpoint and torch.cuda.is_available():
+        torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu())
+
+    return checkpoint
+
+
+def validate_checkpoint_compatibility(
+    checkpoint_coords: CoordSystem, prognostic: PrognosticModel
+) -> bool:
+    """Validate that checkpoint is compatible with prognostic model."""
+    try:
+        expected_coords = prognostic.input_coords()
+
+        for key in expected_coords:
+            if key not in checkpoint_coords:
+                return False
+            if key == "batch":
+                continue
+            if expected_coords[key].shape != checkpoint_coords[key].shape:
+                return False
+
+        return True
+    except Exception:
+        return False
+
+
+def should_checkpoint(
+    step: int,
+    checkpoint_interval: int | None,
+    checkpoint_path: str | None,
+) -> bool:
+    """Determine if checkpoint should be saved at current step."""
+    return (
+        checkpoint_path is not None
+        and checkpoint_interval is not None
+        and step % checkpoint_interval == 0
+    )

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+
+from earth2studio.utils.checkpoint import (
+    load_checkpoint,
+    save_checkpoint,
+    should_checkpoint,
+    validate_checkpoint_compatibility,
+)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_checkpoint_save_load_cycle(device):
+    """Test complete save/load cycle preserves data"""
+    if device == "cuda:0" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    device = torch.device(device)
+
+    # Create test data
+    x = torch.randn(2, 3, 4, 5).to(device)
+    coords = OrderedDict(
+        {
+            "batch": np.array([0, 1]),
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 4),
+            "lon": np.linspace(0, 360, 5),
+        }
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        # Save checkpoint
+        save_checkpoint(10, x, coords, checkpoint_path, "deterministic")
+
+        # Load checkpoint
+        loaded = load_checkpoint(checkpoint_path, device)
+
+        # Verify data integrity
+        assert loaded["step"] == 10
+        assert loaded["workflow_type"] == "deterministic"
+        assert torch.allclose(loaded["state"], x)
+
+        # Verify coordinates
+        loaded_coords = loaded["coords"]
+        assert loaded_coords.keys() == coords.keys()
+        for key in coords.keys():
+            np.testing.assert_array_equal(loaded_coords[key], coords[key])
+
+    finally:
+        os.unlink(checkpoint_path)
+
+
+@pytest.mark.parametrize(
+    "step,interval,path,expected",
+    [
+        (5, None, None, False),
+        (5, 10, None, False),
+        (5, None, "/path", False),
+        (0, 5, "/path", True),
+        (5, 5, "/path", True),
+        (10, 5, "/path", True),
+        (3, 5, "/path", False),
+        (7, 5, "/path", False),
+    ],
+)
+def test_should_checkpoint(step, interval, path, expected):
+    """Test checkpoint decision logic"""
+    assert should_checkpoint(step, interval, path) == expected
+
+
+def test_validate_checkpoint_compatibility():
+    """Test checkpoint compatibility validation"""
+
+    # Create mock prognostic model
+    class MockPrognostic:
+        def input_coords(self):
+            return OrderedDict(
+                {
+                    "batch": np.array([]),
+                    "variable": np.array(["u", "v", "t"]),
+                    "lat": np.linspace(-90, 90, 4),
+                    "lon": np.linspace(0, 360, 5),
+                }
+            )
+
+    prognostic = MockPrognostic()
+
+    # Compatible coordinates (batch can be different size)
+    compatible_coords = OrderedDict(
+        {
+            "batch": np.array([0, 1]),
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 4),
+            "lon": np.linspace(0, 360, 5),
+        }
+    )
+
+    assert validate_checkpoint_compatibility(compatible_coords, prognostic)
+
+    # Incompatible coordinates (wrong variables)
+    incompatible_coords = OrderedDict(
+        {
+            "batch": np.array([0, 1]),
+            "variable": np.array(["u", "v"]),  # Missing 't'
+            "lat": np.linspace(-90, 90, 4),
+            "lon": np.linspace(0, 360, 5),
+        }
+    )
+
+    assert not validate_checkpoint_compatibility(incompatible_coords, prognostic)
+
+
+@pytest.mark.parametrize("workflow_type", ["deterministic", "diagnostic", "ensemble"])
+def test_checkpoint_workflow_type(workflow_type):
+    """Test checkpoint saves workflow type correctly"""
+    device = torch.device("cpu")
+    x = torch.randn(2, 3, 4, 5)
+    coords = OrderedDict(
+        {
+            "batch": np.array([0, 1]),
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 4),
+            "lon": np.linspace(0, 360, 5),
+        }
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        save_checkpoint(5, x, coords, checkpoint_path, workflow_type)
+        loaded = load_checkpoint(checkpoint_path, device)
+        assert loaded["workflow_type"] == workflow_type
+    finally:
+        os.unlink(checkpoint_path)
+
+
+def test_checkpoint_contains_rng_state():
+    """Test checkpoint includes RNG states for reproducibility"""
+    device = torch.device("cpu")
+    x = torch.randn(2, 3)
+    coords = OrderedDict(
+        {"batch": np.array([0, 1]), "variable": np.array(["u", "v", "t"])}
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        save_checkpoint(0, x, coords, checkpoint_path, "deterministic")
+        loaded = load_checkpoint(checkpoint_path, device)
+
+        # Should contain RNG states
+        assert "torch_rng_state" in loaded
+        assert isinstance(loaded["torch_rng_state"], torch.ByteTensor)
+
+        # CUDA RNG state only if CUDA available
+        if torch.cuda.is_available():
+            assert "cuda_rng_state" in loaded
+
+    finally:
+        os.unlink(checkpoint_path)
+
+
+def test_checkpoint_coordinate_types():
+    """Test checkpoint handles different coordinate types"""
+    device = torch.device("cpu")
+    x = torch.randn(2, 3, 4)
+    coords = OrderedDict(
+        {
+            "batch": np.array([0, 1]),
+            "variable": np.array(["u", "v", "t"]),
+            "time": np.array(
+                [
+                    np.datetime64("2024-01-01"),
+                    np.datetime64("2024-01-02"),
+                    np.datetime64("2024-01-03"),
+                    np.datetime64("2024-01-04"),
+                ]
+            ),
+        }
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        save_checkpoint(0, x, coords, checkpoint_path, "deterministic")
+        loaded = load_checkpoint(checkpoint_path, device)
+
+        # Verify datetime handling
+        loaded_coords = loaded["coords"]
+        np.testing.assert_array_equal(loaded_coords["time"], coords["time"])
+
+    finally:
+        os.unlink(checkpoint_path)
+
+
+def test_load_checkpoint_file_not_found():
+    """Test load_checkpoint raises FileNotFoundError for missing files"""
+    device = torch.device("cpu")
+
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        nonexistent_path = f.name + "_nonexistent"
+
+    with pytest.raises(FileNotFoundError):
+        load_checkpoint(nonexistent_path, device)
+
+
+def test_validate_checkpoint_compatibility_missing_dims():
+    """Test validation fails for missing dimensions"""
+
+    class MockPrognostic:
+        def input_coords(self):
+            return OrderedDict(
+                {
+                    "variable": np.array(["u", "v", "t"]),
+                    "lat": np.linspace(-90, 90, 4),
+                    "lon": np.linspace(0, 360, 5),
+                }
+            )
+
+    prognostic = MockPrognostic()
+
+    # Missing required dimension
+    incomplete_coords = OrderedDict(
+        {
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 4),
+            # Missing 'lon'
+        }
+    )
+
+    assert not validate_checkpoint_compatibility(incomplete_coords, prognostic)
+
+
+def test_validate_checkpoint_compatibility_shape_mismatch():
+    """Test validation fails for shape mismatches"""
+
+    class MockPrognostic:
+        def input_coords(self):
+            return OrderedDict(
+                {
+                    "variable": np.array(["u", "v", "t"]),
+                    "lat": np.linspace(-90, 90, 4),
+                    "lon": np.linspace(0, 360, 5),
+                }
+            )
+
+    prognostic = MockPrognostic()
+
+    # Wrong shape for lat dimension
+    mismatched_coords = OrderedDict(
+        {
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 6),  # Different size
+            "lon": np.linspace(0, 360, 5),
+        }
+    )
+
+    assert not validate_checkpoint_compatibility(mismatched_coords, prognostic)
+
+
+@pytest.mark.parametrize("interval", [1, 2, 5, 10])
+def test_checkpoint_interval_patterns(interval):
+    """Test checkpoint saving at different intervals"""
+    path = "/dummy/path"
+
+    # Test steps 0-20
+    expected_saves = [i for i in range(0, 21, interval)]
+
+    actual_saves = [
+        step for step in range(21) if should_checkpoint(step, interval, path)
+    ]
+
+    assert actual_saves == expected_saves
+
+
+def test_checkpoint_ensemble_coordinates():
+    """Test checkpoint handling of ensemble coordinates"""
+    device = torch.device("cpu")
+    x = torch.randn(4, 3, 8, 16)  # 4 ensemble members
+    coords = OrderedDict(
+        {
+            "ensemble": np.array([0, 1, 2, 3]),
+            "variable": np.array(["u", "v", "t"]),
+            "lat": np.linspace(-90, 90, 8),
+            "lon": np.linspace(0, 360, 16),
+        }
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        save_checkpoint(2, x, coords, checkpoint_path, "ensemble")
+        loaded = load_checkpoint(checkpoint_path, device)
+
+        # Verify ensemble dimension preserved
+        assert "ensemble" in loaded["coords"]
+        assert len(loaded["coords"]["ensemble"]) == 4
+        np.testing.assert_array_equal(loaded["coords"]["ensemble"], coords["ensemble"])
+
+    finally:
+        os.unlink(checkpoint_path)
+
+
+def test_checkpoint_metadata_structure():
+    """Test checkpoint contains expected metadata fields"""
+    device = torch.device("cpu")
+    x = torch.randn(2, 3)
+    coords = OrderedDict(
+        {"batch": np.array([0, 1]), "variable": np.array(["u", "v", "t"])}
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        checkpoint_path = f.name
+
+    try:
+        save_checkpoint(7, x, coords, checkpoint_path, "diagnostic")
+        loaded = load_checkpoint(checkpoint_path, device)
+
+        # Check all required fields
+        required_fields = [
+            "step",
+            "state",
+            "coords",
+            "workflow_type",
+            "torch_rng_state",
+        ]
+        for field in required_fields:
+            assert field in loaded, f"Missing required field: {field}"
+
+        # Check field types
+        assert isinstance(loaded["step"], int)
+        assert isinstance(loaded["state"], torch.Tensor)
+        assert isinstance(loaded["coords"], OrderedDict)
+        assert isinstance(loaded["workflow_type"], str)
+
+    finally:
+        os.unlink(checkpoint_path)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Add checkpointing functionality for workflow resume capability

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
- Implemented restart functionality for workflows.
- While this adds significant functionality, much of the implementation follows consistent patterns across the three workflow types.
- This implementation does not implement the IO pattern that @NickGeneva mentioned in the issue thread, but this should be a good base to expand upon.

#### Core Changes:
1. New Checkpoint Module (earth2studio/utils/checkpoint.py)
     * save_checkpoint() - Saves simulation state, coordinates, RNG states
     * load_checkpoint() - Restores saved state with device handling
     * validate_checkpoint_compatibility() - Validates that checkpoint works with current model
     * should_checkpoint() - Decision logic for when to save
2. Enhanced Workflows (earth2studio/run.py)
     * Added 3 optional parameters to all workflow functions:
          - checkpoint_path - Where to save/load checkpoints
          - checkpoint_interval - Save every N steps
          - resume_from_step Resume from specified step
     * Dual execution paths:
          - Normal: Uses existing iterators (exact same behavior)
          - Resume: Manual time-stepping to account for mid-simulation restart
3. Comprehensive Testing (test/utils/test_checkpoint.py)
     * 25 tests covering save/load, validation, error handling
     * 90% code coverage on checkpoint utilities, can increase if needed
     * Tested CPU/CUDA compatibility edge cases
     

#### Notes
* Zero breaking changes, works identically since checkpoint params are optional
* Maintains reproducibility through RNG state preservation
* Used PyTorch's save/load for file-based checkpointing
* Prevents incompatible resumes via Coordinate System validation
* Parameters are independent, and can be used flexibly (save-only, resume-only, or both)


This PR closes #446

## Checklist

- [ x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ x] New or existing tests cover these changes.
- [ x] The documentation is up to date with these changes. (Added docstring comments)
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes. (Will add in a new commit once changes have been reviewed)
- [ x] An [issue](https://github.com/NVIDIA/earth2studio/issues/446) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
None - Uses existing PyTorch save/load functionality