### PR TITLE
Change IFS min date to 2024-03-01

### DIFF
--- a/earth2studio/data/ifs.py
+++ b/earth2studio/data/ifs.py
@@ -208,9 +208,9 @@ class IFS:
                     f"Requested date time {time} needs to be 6 hour interval for IFS"
                 )
 
-            if (datetime.now() - time).days > 4:
+            if time < datetime(2024, 3, 1):
                 raise ValueError(
-                    f"Requested date time {time} needs to be within the past 4 days for IFS"
+                    f"Requested date time {time} needs to be after 2024-03-01 for IFS"
                 )
 
             # if not self.available(time):

--- a/test/data/test_ifs.py
+++ b/test/data/test_ifs.py
@@ -111,7 +111,7 @@ def test_ifs_cache(time, variable, cache):
     "time",
     [
         now6h() - timedelta(days=1, minutes=1),
-        now6h() - timedelta(days=5),
+        now6h() + timedelta(days=5),
         datetime(year=1993, month=4, day=5),
     ],
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
IFS open data seems to be available from 2024-03-01 instead for only the last 4 days. Check, e.g.:
´´´
aws s3 ls --no-sign-request s3://ecmwf-forecasts/20240301/00z/
´´´
Some data is also available before that but under a different prefix format (so `available` fails, it may work through the opendata client, though). I was able to download FCN3 variables across different days in April 2024.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
