### PR TITLE
Add CBottleVideo inference examples

### DIFF
--- a/examples/19_cbottle_video.py
+++ b/examples/19_cbottle_video.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# %%
+"""
+CBottle Video Inference
+=======================
+
+Climate in a Bottle (cBottle) video model inference workflows.
+
+This example will demonstrate the cBottle video diffusion model for generating
+temporal sequences of global weather states. The CBottleVideo model predicts 12
+frames at a time (in 6-hour increments) and can operate in both unconditional and
+conditional modes.
+
+For more information on cBottle see:
+
+- https://arxiv.org/abs/2505.06474v1
+
+In this example you will learn:
+
+- Running unconditional video generation with CBottleVideo
+- Running conditional video generation using ERA5 data with CBottleInfill
+- Post-processing and visualizing the temporal forecasts
+"""
+# /// script
+# dependencies = [
+#   "earth2studio[cbottle] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "cartopy",
+# ]
+# ///
+
+# %%
+# Set Up
+# ------
+# For this example we will use the CBottleVideo prognostic model. Unlike typical
+# prognostic models, CBottleVideo is a diffusion-based video model that generates
+# 12 frames (0-66 hours in 6-hour steps) at once.
+
+# %%
+# We need the following components:
+#
+# - Prognostic Model: Use the CBottleVideo model :py:class:`earth2studio.models.px.CBottleVideo`.
+# - Datasource: Pull data from the WeatherBench2 data api :py:class:`earth2studio.data.WB2ERA5`.
+# - Diagnostic Model: Use the CBottle Infill Model :py:class:`earth2studio.models.dx.CBottleInfill` for conditional generation.
+
+# %%
+import os
+
+os.makedirs("outputs", exist_ok=True)
+from dotenv import load_dotenv
+
+load_dotenv()  # TODO: make common example prep function
+
+import numpy as np
+import torch
+from datetime import datetime
+
+from earth2studio.models.px import CBottleVideo
+from earth2studio.data import WB2ERA5
+from earth2studio.models.dx import CBottleInfill
+from earth2studio.data.utils import fetch_data
+
+# Get the device
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# Load the CBottleVideo model
+package = CBottleVideo.load_default_package()
+cbottle_video = CBottleVideo.load_model(package, seed=42)
+cbottle_video = cbottle_video.to(device)
+
+# %%
+# Unconditional Video Generation
+# -------------------------------
+# First, let's generate a video sequence unconditionally. This means the model will
+# generate plausible weather states based only on the timestamp and SST data, without
+# conditioning on any specific initial atmospheric state. We do this by providing a
+# tensor of NaN values as input.
+
+# %%
+
+# Prepare input coordinates
+time = np.array([datetime(2022, 6, 1)], dtype="datetime64[ns]")
+coords = cbottle_video.input_coords()
+coords["time"] = time
+coords["batch"] = np.array([0])
+
+# Create NaN tensor for unconditional sampling
+x_uncond = torch.full(
+    (1, 1, 1, len(cbottle_video.VARIABLES), 721, 1440),
+    float("nan"),
+    dtype=torch.float32,
+    device=device,
+)
+
+# Run inference - the model generates 12 frames at once
+print("Running unconditional generation...")
+iterator = cbottle_video.create_iterator(x_uncond, coords)
+uncond_outputs = []
+uncond_coords_list = []
+for step, (output, output_coords) in enumerate(iterator):
+    print(f"Step {step}: lead_time = {output_coords['lead_time'][0]}")
+    uncond_outputs.append(output.cpu())
+    uncond_coords_list.append(output_coords)
+    if step >= 11:  # Get first 12 frames (0-66 hours)
+        break
+
+# %%
+# Conditional Video Generation with ERA5
+# ---------------------------------------
+# Next, let's demonstrate conditional generation using real ERA5 data. Since ERA5
+# doesn't contain all 45 variables required by CBottleVideo, we first use the
+# CBottleInfill model to generate the missing variables, then use that complete
+# state to condition the video model.
+
+# %%
+
+# Load ERA5 data source
+era5_ds = WB2ERA5()
+
+# Load CBottleInfill model to generate all required variables
+input_variables = [
+    "u10m",
+    "v10m",
+    "t2m",
+    "msl",
+    "z50",
+    "u50",
+    "v50",
+    "z500",
+    "u500",
+    "v500",
+    "z1000",
+    "u1000",
+    "v1000",
+]
+
+package_infill = CBottleInfill.load_default_package()
+cbottle_infill = CBottleInfill.load_model(
+    package_infill, input_variables=input_variables, sampler_steps=18
+)
+cbottle_infill = cbottle_infill.to(device)
+cbottle_infill.set_seed(42)
+
+# Fetch ERA5 data
+print("Fetching ERA5 data and running infill...")
+times = np.array([datetime(2022, 6, 1)], dtype="datetime64[ns]")
+era5_x, era5_coords = fetch_data(era5_ds, times, input_variables, device=device)
+
+# Infill to get all 45 CBottleVideo variables
+infilled_x, infilled_coords = cbottle_infill(era5_x, era5_coords)
+
+# Reshape for CBottleVideo input: [batch, time, lead_time, variable, lat, lon]
+x_cond = infilled_x.unsqueeze(2)  # Add lead_time dimension
+print(f"Conditioned input shape: {x_cond.shape}")
+
+# Update coordinates for CBottleVideo
+coords_cond = cbottle_video.input_coords()
+coords_cond["time"] = times
+coords_cond["batch"] = np.array([0])
+coords_cond["variable"] = infilled_coords["variable"]
+
+# Run conditional inference
+print("Running conditional generation...")
+cbottle_video.set_seed(42)  # Set seed for reproducibility
+iterator_cond = cbottle_video.create_iterator(x_cond, coords_cond)
+cond_outputs = []
+cond_coords_list = []
+for step, (output, output_coords) in enumerate(iterator_cond):
+    print(f"Step {step}: lead_time = {output_coords['lead_time'][0]}")
+    cond_outputs.append(output.cpu())
+    cond_coords_list.append(output_coords)
+    if step >= 11:  # Get first 12 frames (0-66 hours)
+        break
+
+# %%
+# Post Processing and Visualization
+# ----------------------------------
+# Let's visualize the results by comparing unconditional and conditional generation.
+# We'll plot the mean sea level pressure (msl) at different time steps to see how
+# the weather patterns evolve.
+
+# %%
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+
+variable = "msl"
+var_idx = np.where(uncond_coords_list[0]["variable"] == variable)[0][0]
+
+# Select time steps to visualize (0, 24h, 48h, 66h)
+time_steps = [0, 4, 8, 11]
+
+plt.close("all")
+projection = ccrs.Orthographic(central_longitude=0.0, central_latitude=45.0)
+
+# Create a figure with subplots
+fig, axes = plt.subplots(
+    2, 4, subplot_kw={"projection": projection}, figsize=(16, 8)
+)
+
+
+def plot_field(ax, data, coords, title):
+    """Helper function to plot a field"""
+    im = ax.pcolormesh(
+        coords["lon"],
+        coords["lat"],
+        data,
+        transform=ccrs.PlateCarree(),
+        cmap="viridis",
+        vmin=95000,
+        vmax=105000,
+    )
+    ax.coastlines()
+    ax.gridlines()
+    ax.set_title(title)
+    return im
+
+
+# Plot unconditional generation
+for i, step in enumerate(time_steps):
+    lead_time = uncond_coords_list[step]["lead_time"][0]
+    hours = int(lead_time / np.timedelta64(1, "h"))
+    plot_field(
+        axes[0, i],
+        uncond_outputs[step][0, 0, 0, var_idx].numpy(),
+        uncond_coords_list[step],
+        f"Unconditional: {hours}h",
+    )
+
+# Plot conditional generation
+for i, step in enumerate(time_steps):
+    lead_time = cond_coords_list[step]["lead_time"][0]
+    hours = int(lead_time / np.timedelta64(1, "h"))
+    im = plot_field(
+        axes[1, i],
+        cond_outputs[step][0, 0, 0, var_idx].numpy(),
+        cond_coords_list[step],
+        f"Conditional (ERA5): {hours}h",
+    )
+
+# Add colorbar
+fig.colorbar(im, ax=axes, orientation="horizontal", pad=0.05, label="MSL (Pa)")
+
+plt.tight_layout()
+plt.savefig("outputs/19_cbottle_video.jpg", dpi=150, bbox_inches="tight")
+print("Saved visualization to outputs/19_cbottle_video.jpg")


### PR DESCRIPTION
This commit adds comprehensive inference examples for the CBottleVideo model:

1. Added inline docstring example in cbottle_video.py showing minimal unconditional generation usage pattern (following DLESyM example pattern)

2. Added standalone example file (examples/19_cbottle_video.py) demonstrating:
   - Unconditional video generation with CBottleVideo
   - Conditional generation using ERA5 data via CBottleInfill
   - Visualization comparing both approaches

The ERA5-based conditional approach shows the recommended workflow for using real reanalysis data with CBottleVideo, which requires all 45 CBottle variables. CBottleInfill is used to generate missing variables from a subset of ERA5 fields.

<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
