### PR TITLE
Fix SFNO in-place editing bug

### DIFF
--- a/earth2studio/models/px/sfno.py
+++ b/earth2studio/models/px/sfno.py
@@ -335,7 +335,7 @@ class SFNO(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         coords: CoordSystem,
     ) -> tuple[torch.Tensor, CoordSystem]:
         output_coords = self.output_coords(coords)
-        x = x.squeeze(2)
+        x = x.clone().squeeze(2)
         for j, _ in enumerate(coords["batch"]):
             for i, t in enumerate(coords["time"]):
                 # https://github.com/NVIDIA/modulus-makani/blob/933b17d5a1ebfdb0e16e2ebbd7ee78cfccfda9e1/makani/third_party/climt/zenith_angle.py#L197


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Commit https://github.com/NVIDIA/earth2studio/commit/2dc47e3c223c2142afb217d5261b6763e7635ec6 removed the line 
```python
x = (x - self.center) / self.scale
```
from `SFNO._forward`. This line made a new local tensor and assigned it to `x`. It seems that removing the line had the unintended consequence that `_forward` now edits its input tensor `x` in place. This doesn't seem to have caused an issue for plain SFNO but it caused `InterpModAFNO` in combination with `SFNO` to return nonsensical values.

I added a `.clone()` in the beginning of the function to fix the problem.

I tested that:

1. `SFNO`+`InterpModAFNO` _without the fix_ returns weird results
2. `FCN3`+`InterpModAFNO` works ok
3. `SFNO` without interpolation works ok without the fix
4. `SFNO`+`InterpModAFNO` _with the `.clone()` fix_ works ok

Tagging @albertocarpentieri @mariusaurus who reported the issue.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
