### PR TITLE
default chunking in zarr

### DIFF
--- a/earth2studio/io/zarr.py
+++ b/earth2studio/io/zarr.py
@@ -55,12 +55,12 @@ class ZarrBackend:
     def __init__(
         self,
         file_name: str = None,
-        chunks: dict[str, int] = {                  # to avoid writing in the same chunk by default
-                                    "ensemble": 1,  # dimensions not present in data are ignored
-                                    "time": 1,
-                                    "lead_time": 1,
-                                    "variable": 1,
-                                 },
+        chunks: dict[str, int] = {  # to avoid writing in the same chunk by default
+            "ensemble": 1,  # dimensions not present in data are ignored
+            "time": 1,
+            "lead_time": 1,
+            "variable": 1,
+        },
         backend_kwargs: dict[str, Any] = {"overwrite": False},
         zarr_codecs: CompressorsLike = None,
     ) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Had a few times in new user interactions that they reported extremely slow inference speeds due to default chunking in zarr writing everything in the same chunk.
Updated the default chunking to 1 along ensemble, time, lead_time, variable. Dimenions not present in data are ignored, so that default also works for eg deterministic data.

test:
```
from earth2studio.models.px import DLWP
from earth2studio.data import NCAR_ERA5
from earth2studio.io import ZarrBackend
from earth2studio.run import deterministic as run
import zarr

model = DLWP.load_model(DLWP.load_default_package())
data = NCAR_ERA5()
io = ZarrBackend("fcn_forecast.zarr", backend_kwargs = {"overwrite": True})
run(["2025-01-01T00:00:00"], 10, model, data, io)
zarr.consolidate_metadata(io.store)
```

old:
```
# zarrdump fcn_forecast.zarr/
<xarray.Dataset> Size: 320MB
Dimensions:    (time: 1, lead_time: 11, lat: 721, lon: 1440)
Coordinates:
  * time       (time) datetime64[ns] 8B 2025-01-01
  * lead_time  (lead_time) timedelta64[h] 88B 0 days 00:00:00 ... 2 days 12:0...
  * lat        (lat) float64 6kB 90.0 89.75 89.5 89.25 ... -89.5 -89.75 -90.0
  * lon        (lon) float64 12kB 0.0 0.25 0.5 0.75 ... 359.0 359.2 359.5 359.8
Data variables:
    t2m        (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    t850       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    tcwv       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    z1000      (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    z300       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    z500       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
    z700       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 11, 721, 1440), meta=np.ndarray>
```


now:
```
# zarrdump fcn_forecast.zarr/
<xarray.Dataset> Size: 320MB
Dimensions:    (time: 1, lead_time: 11, lat: 721, lon: 1440)
Coordinates:
  * time       (time) datetime64[ns] 8B 2025-01-01
  * lead_time  (lead_time) timedelta64[h] 88B 0 days 00:00:00 ... 2 days 12:0...
  * lat        (lat) float64 6kB 90.0 89.75 89.5 89.25 ... -89.5 -89.75 -90.0
  * lon        (lon) float64 12kB 0.0 0.25 0.5 0.75 ... 359.0 359.2 359.5 359.8
Data variables:
    t2m        (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    t850       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    tcwv       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    z1000      (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    z300       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    z500       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
    z700       (time, lead_time, lat, lon) float32 46MB dask.array<chunksize=(1, 1, 721, 1440), meta=np.ndarray>
```


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
