### PR TITLE
Clean up ECMWF data sources

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -48,4 +48,16 @@ uv run pytest test/path/to/test_file.py -v
 uv run pytest test/path/to/test_file.py -k "test_name" -v
 ```
 
+## Slow tests
+
+Many tests are marked `@pytest.mark.slow` and skipped by default (network calls, large
+downloads). To include them, pass `--slow`:
+
+```bash
+uv run pytest test/path/to/test_file.py -v --slow
+```
+
+Slow tests are often also marked `@pytest.mark.xfail` — an `XPASS` result (unexpected
+pass) is fine and means the test succeeded against live data.
+
 Report the test results, including any failures with their tracebacks.

--- a/earth2studio/data/ecmwf.py
+++ b/earth2studio/data/ecmwf.py
@@ -177,13 +177,14 @@ class _ECMWFOpenDataSource(ABC):
 
         xr_array = loop.run_until_complete(
             asyncio.wait_for(
-                self.fetch(time, lead_time, variable), timeout=self.async_timeout
+                self._ecmwf_fetch(time, lead_time, variable),
+                timeout=self.async_timeout,
             )
         )
 
         return xr_array
 
-    async def fetch(
+    async def _ecmwf_fetch(
         self,
         time: datetime | list[datetime] | TimeArray,
         lead_time: timedelta | list[timedelta] | LeadTimeArray,
@@ -518,6 +519,29 @@ class IFS(_ECMWFOpenDataSource):
         da = self._call(time, np.array([0], dtype="datetime64[h]"), variable)
         return da.isel(lead_time=0).drop_vars("lead_time")
 
+    async def fetch(  # type: ignore[override]
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve IFS analysis data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            IFS analysis data array.
+        """
+        da = await super()._ecmwf_fetch(time, timedelta(hours=0), variable)
+        return da.isel(lead_time=0).drop_vars("lead_time")
+
     def _validate_time(self, times: list[datetime]) -> None:
         """Verify all times are valid based on offline knowledge.
 
@@ -607,6 +631,31 @@ class IFS_FX(_ECMWFOpenDataSource):
             IFS forecast data array
         """
         return self._call(time, lead_time, variable)
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve IFS forecast data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            IFS forecast data array.
+        """
+        return await super()._ecmwf_fetch(time, lead_time, variable)
 
     def _validate_time(self, times: list[datetime]) -> None:
         validate_time(
@@ -720,6 +769,31 @@ class IFS_ENS(_ECMWFOpenDataSource):
             IFS ENS initial state data array.
         """
         da = self._call(time, np.array([0], dtype="datetime64[h]"), variable)
+        if "ensemble" in da.dims:
+            da = da.isel(ensemble=0).drop_vars("ensemble")
+        return da.isel(lead_time=0).drop_vars("lead_time")
+
+    async def fetch(  # type: ignore[override]
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve IFS ENS initial state data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            IFS ENS initial state data array.
+        """
+        da = await super()._ecmwf_fetch(time, timedelta(hours=0), variable)
         if "ensemble" in da.dims:
             da = da.isel(ensemble=0).drop_vars("ensemble")
         return da.isel(lead_time=0).drop_vars("lead_time")
@@ -843,6 +917,34 @@ class IFS_ENS_FX(_ECMWFOpenDataSource):
             da = da.isel(ensemble=0).drop_vars("ensemble")
         return da
 
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve IFS ENS forecast data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            IFS ENS forecast data array.
+        """
+        da = await super()._ecmwf_fetch(time, lead_time, variable)
+        if "ensemble" in da.dims:
+            da = da.isel(ensemble=0).drop_vars("ensemble")
+        return da
+
     def _validate_time(self, times: list[datetime]) -> None:
         validate_time(
             self._model, self.client.source, times, min_time=datetime(2024, 3, 1)
@@ -946,6 +1048,31 @@ class AIFS_FX(_ECMWFOpenDataSource):
         """
         return self._call(time, lead_time, variable)
 
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve AIFS forecast data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            AIFS forecast data array.
+        """
+        return await super()._ecmwf_fetch(time, lead_time, variable)
+
     def _validate_time(self, times: list[datetime]) -> None:
         validate_time(
             self._model, self.client.source, times, min_time=datetime(2025, 7, 1, 6)
@@ -1047,6 +1174,34 @@ class AIFS_ENS_FX(_ECMWFOpenDataSource):
             AIFS ENS forecast data array
         """
         da = self._call(time, lead_time, variable)
+        if "ensemble" in da.dims:
+            da = da.isel(ensemble=0).drop_vars("ensemble")
+        return da
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async method to retrieve AIFS ENS forecast data.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the data lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            AIFS ENS forecast data array
+        """
+        da = await super()._ecmwf_fetch(time, lead_time, variable)
         if "ensemble" in da.dims:
             da = da.isel(ensemble=0).drop_vars("ensemble")
         return da

--- a/test/data/test_ecmwf.py
+++ b/test/data/test_ecmwf.py
@@ -262,12 +262,16 @@ async def test_ifs_async_fetch():
     ds_ifs_fx = IFS_FX(cache=False)
     ds_ifs_ens = IFS_ENS(cache=False, member=1)
     ds_ifs_ens_fx = IFS_ENS_FX(cache=False, member=1)
+    ds_aifs_fx = AIFS_FX(cache=False)
+    ds_aifs_ens_fx = AIFS_ENS_FX(cache=False, member=1)
 
-    da_ifs, da_fx, da_ens, da_ens_fx = await asyncio.gather(
+    da_ifs, da_fx, da_ens, da_ens_fx, da_aifs_fx, da_aifs_ens_fx = await asyncio.gather(
         ds_ifs.fetch(t, variable),
         ds_ifs_fx.fetch(t, lt, variable),
         ds_ifs_ens.fetch(t, variable),
         ds_ifs_ens_fx.fetch(t, lt, variable),
+        ds_aifs_fx.fetch(t, lt, variable),
+        ds_aifs_ens_fx.fetch(t, lt, variable),
     )
 
     # IFS (analysis): [time, variable, lat, lon]
@@ -299,6 +303,22 @@ async def test_ifs_async_fetch():
     assert da_ens_fx.shape[3] == 721
     assert da_ens_fx.shape[4] == 1440
     assert not np.isnan(da_ens_fx.values).any()
+
+    # AIFS_FX (forecast): [time, lead_time, variable, lat, lon]
+    assert da_aifs_fx.shape[0] == 1
+    assert da_aifs_fx.shape[1] == 1
+    assert da_aifs_fx.shape[2] == 1
+    assert da_aifs_fx.shape[3] == 721
+    assert da_aifs_fx.shape[4] == 1440
+    assert not np.isnan(da_aifs_fx.values).any()
+
+    # AIFS_ENS_FX (forecast): [time, lead_time, variable, lat, lon]
+    assert da_aifs_ens_fx.shape[0] == 1
+    assert da_aifs_ens_fx.shape[1] == 1
+    assert da_aifs_ens_fx.shape[2] == 1
+    assert da_aifs_ens_fx.shape[3] == 721
+    assert da_aifs_ens_fx.shape[4] == 1440
+    assert not np.isnan(da_aifs_ens_fx.values).any()
 
 
 @pytest.mark.timeout(30)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
The ECMWF data sources had some additional, unused code and xarray coords were not cleanly removed. Changes:
* Rename _call to fetch and remove the previously unused fetch methods
* Rename "sample" to "ensemble" for consistency with other parts of Earth2Studio
* Rename fetch_wrapper to _download_wrapper, because it actually wraps the download method

Two questions:
* Should we remove IFS_ENS? I see the point of keeping IFS in addition to IFS_FX because IFS has been around for longer, but we introduced IFS_ENS alongside IFS_ENS_FX, which has the same functionality. We also don't have AIFS_ENS, just AIFS_ENS_FX
* The _ENS subclasses go out of their way to not allow fetching multiple ensemble members at once. Should we add this functionality back?

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
