### PR TITLE
fix attribute errors in healda script

### DIFF
--- a/examples/05_data_assimilation/02_healda.py
+++ b/examples/05_data_assimilation/02_healda.py
@@ -224,10 +224,16 @@ lat = results[0].coords["lat"].values
 lon = results[0].coords["lon"].values
 cmaps = ["Spectral_r", "PRGn"]
 
+
+def to_numpy(arr):
+    """CuPy / Numpy helper function"""
+    return arr.get() if hasattr(arr, "get") else arr
+
+
 for row, (title, da) in enumerate(zip(titles, results)):
     for col, var in enumerate(plot_vars):
         ax = axes[row, col]
-        field = da.sel(variable=var).values[0]  # [nlat, nlon] cupy -> numpy
+        field = to_numpy(da.sel(variable=var).data[0])
         im = ax.pcolormesh(
             lon,
             lat,
@@ -276,8 +282,8 @@ diff_titles = ["Conv+Sat - ERA5", "Sat - ERA5", "Conv - ERA5"]
 diff_results = [result_both, result_sat, result_conv]
 for title, da_pred in zip(diff_titles, diff_results):
     for var in plot_vars:
-        field_pred = da_pred.sel(variable=var).values[0]
-        field_era5 = era5_interp.sel(variable=var).values[0]
+        field_pred = to_numpy(da_pred.sel(variable=var).data[0])
+        field_era5 = to_numpy(era5_interp.sel(variable=var).data[0])
         mae = float(np.abs(field_pred - field_era5).mean())
         logger.info(f"{title} | {var} MAE: {mae:.4f}")
 
@@ -296,8 +302,8 @@ fig.subplots_adjust(wspace=0.02, hspace=0.08, left=0.1, right=0.9)
 for row, (title, da_pred) in enumerate(zip(diff_titles, diff_results)):
     for col, var in enumerate(plot_vars):
         ax = axes[row, col]
-        field_pred = da_pred.sel(variable=var).values[0]  # [nlat, nlon] cupy -> numpy
-        field_era5 = era5_interp.sel(variable=var).values[0]  # [nlat, nlon]
+        field_pred = to_numpy(da_pred.sel(variable=var).data[0])
+        field_era5 = to_numpy(era5_interp.sel(variable=var).data[0])
         diff = field_pred - field_era5
         im = ax.pcolormesh(
             lon,


### PR DESCRIPTION
there were several errors like this:

    [~/workspace/earth2studio/examples] main:a93583c0 :(
    $ python3 22_healda.py
    Traceback (most recent call last):
      File "/home/nbrenowitz/workspace/earth2studio/examples/22_healda.py", line 230, in <module>
        field = da.sel(variable=var).data[0].get()  # [nlat, nlon] cupy -> numpy
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'numpy.ndarray' object has no attribute 'get'

<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
