### PR TITLE
OmegaConf Test Bug Fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -306,6 +306,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3284,15 +3290,16 @@ wheels = [
 
 [[package]]
 name = "hydra-core"
-version = "1.4.0.dev1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "antlr4-python3-runtime" },
     { name = "omegaconf" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/05/01eac7f7e16d91933bfb802724847fd004952bff38a72fde51dc19a42af7/hydra_core-1.4.0.dev1.tar.gz", hash = "sha256:664e6755ea78f070b403df911fc460ea3464fdc59bd03affc0d6ffef9dd53221", size = 3287831, upload-time = "2024-07-10T20:09:41.548Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/d2/cf3b19412d1e8b397fd041500d1dccc5e902eb078bc91e3a7244452be9ff/hydra_core-1.4.0.dev1-py3-none-any.whl", hash = "sha256:e82753fe3aff8526ee1e72711f6f941beffcc9a2c1830b76c34242963835d039", size = 154173, upload-time = "2024-07-10T20:09:39.213Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
 ]
 
 [[package]]
@@ -5254,14 +5261,15 @@ wheels = [
 
 [[package]]
 name = "omegaconf"
-version = "2.4.0.dev3"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "antlr4-python3-runtime" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/49/6368e41ec04eafc08895f5e56677914314a1bdf084376a7e392eb17905a7/omegaconf-2.4.0.dev3.tar.gz", hash = "sha256:9948b9bfb15074863883bb90c4bfc9f3878af392e77ef5d8c9b01fac834745b1", size = 3440280, upload-time = "2024-02-29T17:01:42.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/08/29b30970ce5e22440e2bc1fd929a79de08feb3c6c054bc7e832228fc1a94/omegaconf-2.4.0.dev3-py3-none-any.whl", hash = "sha256:acffa42eab0d9cb09ccead6e80d1dfd20a625e21602353f267f3bc2cd131f7b2", size = 224417, upload-time = "2024-02-29T17:01:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Theres this rare issue with omegaconf when having a full install.

<spoiler>

```bash
_____________ ERROR at setup of test_stormcast_sda_package[cuda:0] _____________
    @pytest.fixture(scope="function")
    def sda_model() -> StormCastSDA:
        package = StormCastSDA.load_default_package()
>       return StormCastSDA.load_model(package)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/models/da/test_da_sda_stormcast.py:492: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.venv/lib/python3.12/site-packages/earth2studio/utils/imports.py:177: in _wrapper
    return obj(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/earth2studio/models/da/sda_stormcast.py:396: in load_model
    config = OmegaConf.load(package.resolve("model.yaml"))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/omegaconf/omegaconf.py:205: in load
    ret = OmegaConf.create(obj)
          ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/omegaconf/omegaconf.py:178: in create
    return OmegaConf._create_impl(
.venv/lib/python3.12/site-packages/omegaconf/omegaconf.py:900: in _create_impl
    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:819: in format_and_raise
    _raise(ex, cause)
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:797: in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/omegaconf/omegaconf.py:861: in _create_impl
    return DictConfig(
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:111: in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:899: in format_and_raise
    _raise(ex, cause)
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:797: in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:109: in __init__
    self._set_value(content, flags=flags)
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:647: in _set_value
    raise e
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:644: in _set_value
    self._set_value_impl(value, flags)
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:658: in _set_value_impl
    self._validate_set(key=None, value=value)
.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py:171: in _validate_set
    vk = get_value_kind(value)
         ^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:558: in get_value_kind
    if _is_missing_value(value):
       ^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
value = {'data': {'conditioning_channels': ['u10m', 'v10m', 't2m', 'tcwv', 'sp', 'msl', ...], 'conditioning_dt': 1, 'invariant...2, 2], 'channel_mult_noise': 1, ...}}, 'sampler_args': {'S_churn': 0.0, 'S_max': inf, 'S_min': 0.0, 'S_noise': 1, ...}}
    def _is_missing_value(value: Any) -> bool:
        from omegaconf import Node
    
>       if isinstance(value, Node):
           ^^^^^^^^^^^^^^^^^^^^^^^
E       omegaconf.errors.ConfigTypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
E           full_key: 
E           object_type=None
.venv/lib/python3.12/site-packages/omegaconf/_utils.py:511: ConfigTypeError
---------------------------- Captured stderr setup -----------------------------
Downloading config.json: 100%|██████████| 40.0/40.0 [00:00<00:00, 175B/s]
Downloading model.yaml: 100%|██████████| 2.64k/2.64k [00:00<00:00, 14.0kB/s]
_________________ ERROR at setup of test_aifs_package[cuda:0] __________________
    @pytest.fixture(scope="function")
    def model() -> AIFS:
        # Test only on cuda device
        package = AIFS.load_default_package()
>       p = AIFS.load_model(package)
            ^^^^^^^^^^^^^^^^^^^^^^^^
test/models/px/test_aifs.py:815: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.venv/lib/python3.12/site-packages/earth2studio/utils/imports.py:177: in _wrapper
    return obj(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/earth2studio/models/px/aifs.py:365: in load_model
    model = torch.load(
.venv/lib/python3.12/site-packages/torch/serialization.py:1530: in load
    return _load(
.venv/lib/python3.12/site-packages/torch/serialization.py:2122: in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <[KeyError('_content') raised in repr()] ListConfig object at 0x7c0b101c4050>
d = {'_content': ['tp', 'cp', 'sf', 'ro', 'tcw', 'ssrd', ...], '_metadata': ContainerMetadata(ref_type=typing.Any, object_...'>, element_type=typing.Any), '_parent': <[KeyError('_content') raised in repr()] DictConfig object at 0x7c0b101c6ed0>}
    def __setstate__(self, d: Dict[str, Any]) -> None:
        from omegaconf import DictConfig
        from omegaconf._utils import is_generic_dict, is_generic_list
    
>       if isinstance(self, DictConfig):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
.venv/lib/python3.12/site-packages/omegaconf/basecontainer.py:148: TypeError
```

</spoiler>


The issue was because some mocks in the serve test suite which were marked as dangerous were infact... dangerous resulting in breaking hydra for the entire package.

This fixes the test to no mock the import...

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
