### PR TITLE
Add JPSS ATMS microwave DataFrameSource for NOAA-20/21/NPP Level 1 BUFR data

### DIFF
--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -521,6 +521,8 @@ async def fetch(self, time, lead_time, variable) -> xr.DataArray: ...
 
 ```python
 SCHEMA: pa.Schema = pa.schema([...])  # Class attribute
+
+def __init__(self, ..., time_tolerance: TimeTolerance = np.timedelta64(10, "m"), ...): ...
 def __call__(self, time, variable, fields=None) -> pd.DataFrame: ...
 async def fetch(self, time, variable, fields=None) -> pd.DataFrame: ...
 ```
@@ -529,9 +531,16 @@ async def fetch(self, time, variable, fields=None) -> pd.DataFrame: ...
 
 ```python
 SCHEMA: pa.Schema = pa.schema([...])  # Class attribute
+
+def __init__(self, ..., time_tolerance: TimeTolerance = np.timedelta64(10, "m"), ...): ...
 def __call__(self, time, lead_time, variable, fields=None) -> pd.DataFrame: ...
 async def fetch(self, time, lead_time, variable, fields=None) -> pd.DataFrame: ...
 ```
+
+> **Note:** DataFrameSource and ForecastFrameSource typically require a
+> `time_tolerance` parameter because sparse observations have varying
+> timestamps. See the `e2s-012-time-tolerance` rule for full details
+> on the `TimeTolerance` type and `normalize_time_tolerance` utility.
 
 ### 6e. DataFrame SCHEMA definition
 
@@ -777,6 +786,34 @@ def __init__(
 | `async_timeout` | Total timeout (seconds) for the entire fetch | `600` |
 | `async_workers` | Max concurrent async tasks (semaphore bound) | `16` |
 | `retries` | Per-task retry count on transient failure | `3` |
+
+For **DataFrameSource / ForecastFrameSource**, also include:
+
+| Parameter | Purpose | Default |
+|---|---|---|
+| `time_tolerance` | Time tolerance for filtering observations | `np.timedelta64(10, 'm')` |
+
+Use the `TimeTolerance` type hint and call `normalize_time_tolerance()`
+at init time (see the `e2s-012-time-tolerance` rule):
+
+```python
+from earth2studio.utils.time import normalize_time_tolerance
+from earth2studio.utils.type import TimeTolerance
+
+def __init__(
+    self,
+    # Source-specific params first
+    time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
+    cache: bool = True,
+    verbose: bool = True,
+    async_timeout: int = 600,
+    async_workers: int = 16,
+    retries: int = 3,
+):
+    lower, upper = normalize_time_tolerance(time_tolerance)
+    # Store normalized bounds, not raw input
+    ...
+```
 
 Keep source-specific parameters before these common ones. Avoid
 over-exposing internal configuration. Use `loguru.logger` for all
@@ -1303,6 +1340,16 @@ class SourceName:
     ------
     region:global dataclass:analysis product:wind product:temp
     """
+```
+
+For **DataFrameSource / ForecastFrameSource**, also include the
+`time_tolerance` parameter in the docstring:
+
+```text
+    time_tolerance : TimeTolerance, optional
+        Time tolerance window for filtering observations. Accepts a single value
+        (symmetric ± window) or a tuple (lower, upper) for asymmetric windows,
+        by default, np.timedelta64(10, 'm')
 ```
 
 ### 9d. Verify all public method docstrings

--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -6,6 +6,12 @@ argument-hint: URL or description of remote data store (optional — will be ask
 
 # Create Data Source Wrapper
 
+> **Python Environment:** This project uses **uv** for dependency
+> management. Always use the local `.venv` virtual environment
+> (`source .venv/bin/activate` or prefix with `uv run python`) for all
+> Python commands — installing packages, running tests, executing
+> scripts, etc. Use `uv add` / `uv pip install` / `uv lock` instead of `pip install`.
+
 Create a new Earth2Studio data source by following every step below **in order**.
 Each confirmation gate marked by:
 
@@ -2114,33 +2120,9 @@ When filling this table, look up each new dependency's license:
    may be incompatible with the project's Apache-2.0 license and
    require team review before merging
 
-### Reference plot
+### Validation
 
-<details>
-<summary>Sanity-check visualization (click to expand)</summary>
-
-![sanity_check_<source_name>](sanity_check_<source_name>.png)
-
-*<Caption describing what the plot shows, e.g., "2m temperature
-from <SourceName> at 2024-01-01T00:00 UTC">*
-
-</details>
-
-### Sanity-check script
-
-Include the sanity-check Python script inside a `<details>` block
-so reviewers can reproduce the plot:
-
-````markdown
-<details>
-<summary>Sanity-check script (click to expand)</summary>
-
-```python
-<paste the full sanity-check script here>
-```
-
-</details>
-````
+See sanity-check validation in PR comments below (posted in Step 15d).
 
 ## Checklist
 
@@ -2159,8 +2141,122 @@ so reviewers can reproduce the plot:
 
 <List any new packages added to pyproject.toml, or "None">
 
-Drag-and-drop or attach the sanity-check PNG image into the PR body
-so the `<details>` spoiler renders correctly.
+### 15d. Post sanity-check plot as PR comment
+
+After the PR is created, post the sanity-check visualization as a
+separate **PR comment** so it is immediately visible to reviewers
+without expanding a `<details>` block. This serves as quick visual
+evidence that the data source produces correct output.
+
+#### Image upload limitation
+
+**GitHub has no CLI or REST API for uploading images to PR comments.**
+The uploads endpoint (`uploads.github.com`) and GraphQL mutations do
+not support attaching local image files to issue/PR comments. The
+only way to embed an image is via the browser's drag-and-drop editor
+or by referencing an already-hosted URL.
+
+**Practical workflow:**
+
+1. Post the PR comment **without** the image — include the
+   validation table, the full sanity-check script, and a placeholder
+   line: `> **TODO:** Attach sanity-check image by editing this
+   comment in the browser.`
+2. Tell the user: *"The image is at `<local_path>`. Edit the PR
+   comment in your browser and drag the file into the editor to
+   embed it."*
+3. Use `gh api -X PATCH` to update the comment body (via
+   `-F body=@/tmp/comment.md`) if the text needs revision later.
+
+Do **not** waste time trying `curl` uploads, GraphQL file mutations,
+or the `uploads.github.com` asset endpoint — they do not work for
+issue/PR comment images.
+
+#### Writing the comment body
+
+Write the comment body to a temp file first, then post it. This
+avoids shell quoting issues with heredocs containing backticks and
+markdown:
+
+```bash
+# 1. Write body to a temp file (use your editor tool, not heredoc)
+#    Include: summary table, key findings, script in <details>
+
+# 2. Post the comment
+gh api -X POST repos/NVIDIA/earth2studio/issues/<PR_NUMBER>/comments \
+  -F "body=@/tmp/pr_comment_body.md" \
+  --jq '.html_url'
+```
+
+#### Comment content template
+
+Adapt to the source type. Include only relevant rows — omit
+satellite-specific rows for gridded sources, omit grid dimensions
+for DataFrame sources, etc.
+
+```markdown
+## Sanity-Check Validation
+
+**Source:** `<ClassName>` — <brief description>
+**Time:** YYYY-MM-DD HH:MM UTC
+**Parameters:** <source-specific context, e.g., tolerance, satellite, product>
+
+| Metric | Value |
+|--------|-------|
+| Output shape / rows | <shape for DataArray, row count for DataFrame> |
+| Variables | <list or count> |
+| Value range | <min>–<max> <unit> |
+| Lat range | <min>–<max>° |
+| Lon range | <min>–<max>° |
+| Missing / NaN | <count or 0> |
+
+*Add source-specific rows as needed (channels, satellites, grid
+dimensions, lead times, etc.)*
+
+**Key findings:**
+- <bullet summarizing physical reasonableness>
+- <bullet on spatial pattern / coverage>
+- <bullet on comparison with reference source, if applicable>
+
+> **TODO:** Attach sanity-check image by editing this comment in
+> the browser.
+
+<details>
+<summary>Sanity-check script (click to expand)</summary>
+
+PASTE THE FULL WORKING SCRIPT HERE — not a truncated excerpt.
+The script must be copy-pasteable and produce the plot end-to-end.
+
+</details>
+```
+
+**Important:** Always paste the **complete, runnable** script — not
+a shortened version. Reviewers should be able to reproduce the plot
+by copying the script directly.
+
+#### Comparison sources
+
+If a **comparison data source** exists for the same physical
+quantity (e.g., UFSObsSat for satellite BT, ERA5 for reanalysis
+fields), include a side-by-side comparison in the same comment.
+Briefly summarize expected differences:
+
+- Raw vs QC-subsetted data (different observation counts)
+- Different spatial coverage or resolution
+- Different time windows or update cadence
+- Unit or coordinate convention differences
+
+#### Finalize
+
+After posting, inform the user of:
+
+1. The comment URL
+2. The local path to the image file for manual attachment
+3. Instructions: *"Edit the comment in your browser and drag the
+   image file into the editor to embed it."*
+
+> **Note:** The sanity-check image and script are for PR review
+> purposes only — they must NOT be committed to the repository.
 
 ---
 
@@ -2301,6 +2397,7 @@ Inform the user of the final state:
 
 ## Reminders
 
+- **DO** use the repos local `uv` `.venv` to run python with `uv run python`
 - **DO NOT** commit the sanity-check script or image to the repo
 - **DO** use `loguru.logger` for logging, never `print()`, inside
   `earth2studio/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GenCast 1 degree Mini model
 - Added CAMS Global atmospheric composition forecast data source (`CAMS_FX`)
 - Added `CAMSGlobalLexicon` for CAMS variable mappings (AOD, total column gases)
+- Added JPSS ATMS Level 1 BUFR brightness-temperature data source (`JPSS_ATMS`)
+- Added `JPSSATMSLexicon` for ATMS variable mappings
 
 ### Changed
 

--- a/docs/modules/datasources_dataframe.rst
+++ b/docs/modules/datasources_dataframe.rst
@@ -21,6 +21,7 @@ Data sources that provide tabular data as DataFrames.
       :template: datasource.rst
 
       data.ISD
+      data.JPSS_ATMS
       data.RandomDataFrame
       data.UFSObsConv
       data.UFSObsSat

--- a/earth2studio/data/__init__.py
+++ b/earth2studio/data/__init__.py
@@ -29,6 +29,7 @@ from .goes import GOES
 from .hrrr import HRRR, HRRR_FX
 from .isd import ISD
 from .jpss import JPSS
+from .jpss_atms import JPSS_ATMS
 from .mrms import MRMS
 from .ncar import NCAR_ERA5
 from .planetary_computer import (

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -33,9 +33,12 @@ import pandas as pd
 import pyarrow as pa
 import s3fs
 from loguru import logger
-from tqdm.asyncio import tqdm
 
-from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
+from earth2studio.data.utils import (
+    datasource_cache_root,
+    gather_with_concurrency,
+    prep_data_inputs,
+)
 from earth2studio.lexicon.base import E2STUDIO_SCHEMA
 from earth2studio.lexicon.jpss import (
     JPSSATMSLexicon,
@@ -428,10 +431,11 @@ class JPSS_ATMS:
         # Deduplicate by S3 URI
         uri_set = {t.s3_uri for t in tasks}
         fetch_jobs = [self._fetch_remote_file(uri) for uri in uri_set]
-        await tqdm.gather(
-            *fetch_jobs,
+        await gather_with_concurrency(
+            fetch_jobs,
+            max_workers=self._max_workers,
             desc="Fetching ATMS BUFR files",
-            disable=(not self._verbose),
+            verbose=(not self._verbose),
         )
 
         if session:

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -799,7 +799,7 @@ class JPSS_ATMS:
 
         df = pd.DataFrame(rows)
         # Enforce schema dtypes
-        df["time"] = pd.to_datetime(df["time"])
+        df["time"] = pd.to_datetime(df["time"]).astype("datetime64[ms]")
         df["lat"] = df["lat"].astype(np.float32)
         df["lon"] = df["lon"].astype(np.float32)
         df["scan_angle"] = df["scan_angle"].astype(np.float32)

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -107,6 +107,89 @@ class JPSS_ATMS:
     The returned :class:`~pandas.DataFrame` has one row per FOV per channel,
     following the same convention as :class:`~earth2studio.data.UFSObsSat`.
 
+    ATMS has 22 channels spanning 23.8--183.31 GHz.  The ``channel_index``
+    column (1--22) identifies each channel:
+
+    .. list-table:: ATMS Channel Specification
+       :header-rows: 1
+       :widths: 8 15 35
+
+       * - Channel
+         - Frequency (GHz)
+         - Primary Sensitivity
+       * - 1
+         - 23.8
+         - Window / water-vapour (surface)
+       * - 2
+         - 31.4
+         - Window (surface emissivity, cloud liquid water)
+       * - 3
+         - 50.3
+         - Oxygen (lower troposphere temperature)
+       * - 4
+         - 51.76
+         - Oxygen (lower troposphere temperature)
+       * - 5
+         - 52.8
+         - Oxygen (troposphere temperature)
+       * - 6
+         - 53.596
+         - Oxygen (troposphere temperature)
+       * - 7
+         - 54.40
+         - Oxygen (mid-troposphere temperature)
+       * - 8
+         - 54.94
+         - Oxygen (mid-troposphere temperature)
+       * - 9
+         - 55.50
+         - Oxygen (upper troposphere temperature)
+       * - 10
+         - 57.29 (fO1)
+         - Oxygen (tropopause temperature)
+       * - 11
+         - 57.29 (fO2)
+         - Oxygen (lower stratosphere temperature)
+       * - 12
+         - 57.29 (fO3)
+         - Oxygen (stratosphere temperature)
+       * - 13
+         - 57.29 (fO4)
+         - Oxygen (stratosphere temperature)
+       * - 14
+         - 57.29 (fO5)
+         - Oxygen (upper stratosphere temperature)
+       * - 15
+         - 57.29 (fO6)
+         - Oxygen (upper stratosphere temperature)
+       * - 16
+         - 88.20
+         - Window (precipitation, sea ice)
+       * - 17
+         - 165.5
+         - Window (precipitation, ice cloud)
+       * - 18
+         - 183.31 (fH1)
+         - Water-vapour (upper troposphere humidity)
+       * - 19
+         - 183.31 (fH2)
+         - Water-vapour (mid-troposphere humidity)
+       * - 20
+         - 183.31 (fH3)
+         - Water-vapour (mid-troposphere humidity)
+       * - 21
+         - 183.31 (fH4)
+         - Water-vapour (lower troposphere humidity)
+       * - 22
+         - 183.31 (fH5)
+         - Water-vapour (lower troposphere humidity)
+
+    Channels 10--15 share the 57.29 GHz oxygen-absorption line but use
+    different passband offsets (fO1--fO6), giving each a distinct altitude
+    weighting function.  Channels 18--22 similarly share 183.31 GHz with
+    different offsets (fH1--fH5) for water-vapour profiling at different
+    altitudes.
+
     Parameters
     ----------
     satellites : list[str] | None, optional
@@ -136,29 +219,18 @@ class JPSS_ATMS:
     ----
     Additional information on the data repository:
 
-    - https://registry.opendata.aws/noaa-nesdis-n20-pds/
+    - https://registry.opendata.aws/noaa-jpss/
     - https://www.star.nesdis.noaa.gov/jpss/ATMS.php
     - https://www.nesdis.noaa.gov/current-satellite-missions/currently-flying/joint-polar-satellite-system
 
-    Example
-    -------
-    .. highlight:: python
-    .. code-block:: python
+    ATMS channel specification and BUFR SDR format:
 
-        from datetime import datetime, timedelta
-        from earth2studio.data import JPSS_ATMS
+    - https://www.star.nesdis.noaa.gov/jpss/documents/ATBD/D0001-M01-S01-001_JPSS_ATBD_ATMS-SDR_B.pdf
 
-        # Use all possible satellites
-        ds = JPSS_ATMS()
-        df = ds(datetime(2024, 6, 1, 12), ["atms"])
-
-        # Use specific satellite
-        ds = JPSS_ATMS(satellites=["n20"])
-        df = ds(datetime(2024, 6, 1, 12), ["atms"])
 
     Badges
     ------
-    region:global dataclass:observation product:atmos product:sat
+    region:global dataclass:observation product:sat
     """
 
     SOURCE_ID = "earth2studio.data.JPSS_ATMS"

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -1,0 +1,738 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import pathlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import nest_asyncio
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import s3fs
+from loguru import logger
+from tqdm.asyncio import tqdm
+
+from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
+from earth2studio.lexicon.base import E2STUDIO_SCHEMA
+from earth2studio.lexicon.jpss import (
+    ATMS_NUM_CHANNELS,
+    JPSSATMSLexicon,
+)
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.time import TimeTolerance, normalize_time_tolerance
+from earth2studio.utils.type import TimeArray, VariableArray
+
+try:
+    import eccodes
+except ImportError:
+    OptionalDependencyFailure("data")
+    eccodes = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# NOAA-20 S3 bucket layout
+# s3://noaa-nesdis-n20-pds/ATMS_BUFR/<YYYY>/<MM>/<DD>/*.bufr
+# ---------------------------------------------------------------------------
+
+# Satellite identifier mapping (WMO code 001007)
+_SAT_ID_MAP: dict[int, str] = {
+    224: "npp",  # Suomi NPP
+    225: "n20",  # NOAA-20 / JPSS-1
+    226: "n21",  # NOAA-21 / JPSS-2
+}
+
+# S3 bucket per satellite short-name
+_SAT_BUCKET_MAP: dict[str, str] = {
+    "n20": "noaa-nesdis-n20-pds",
+    "n21": "noaa-nesdis-n21-pds",
+    "npp": "noaa-nesdis-snpp-pds",
+}
+
+
+@dataclass
+class _ATMSAsyncTask:
+    """Metadata for a single BUFR file download task."""
+
+    s3_uri: str
+    datetime_min: datetime
+    datetime_max: datetime
+    satellite: str
+    variable: str
+    bufr_key: str
+    modifier: object  # Callable[[Any], Any]
+
+
+@check_optional_dependencies()
+class JPSS_ATMS:
+    """JPSS ATMS (Advanced Technology Microwave Sounder) Level 1 BUFR
+    brightness-temperature observations served from NOAA Open Data on AWS.
+
+    Each BUFR file contains a single scan line with
+    :data:`~earth2studio.lexicon.jpss.ATMS_NUM_FOVS` cross-track
+    field-of-view (FOV) positions and
+    :data:`~earth2studio.lexicon.jpss.ATMS_NUM_CHANNELS` microwave channels.
+    The returned :class:`~pandas.DataFrame` has one row per FOV per channel,
+    following the same convention as :class:`~earth2studio.data.UFSObsSat`.
+
+    Parameters
+    ----------
+    satellites : list[str] | None, optional
+        Satellite short-names to query.  Valid values are ``"n20"``
+        (NOAA-20), ``"n21"`` (NOAA-21), and ``"npp"`` (Suomi NPP).
+        By default ``None``, which queries all valid satellites.
+    time_tolerance : TimeTolerance, optional
+        Symmetric or asymmetric tolerance window around each requested time
+        for selecting BUFR granules, by default ``np.timedelta64(30, "m")``.
+    cache : bool, optional
+        Cache downloaded BUFR files locally, by default True
+    verbose : bool, optional
+        Show download progress bars, by default True
+    async_timeout : int, optional
+        Total timeout in seconds for the async fetch, by default 600
+    max_workers : int, optional
+        Maximum number of concurrent S3 fetch tasks, by default 24
+    retries : int, optional
+        Per-file retry count on transient I/O failures, by default 3
+
+    Warning
+    -------
+    This is a remote data source and can potentially download a large amount
+    of data to your local machine for large requests.
+
+    Note
+    ----
+    Additional information on the data repository:
+
+    - https://registry.opendata.aws/noaa-nesdis-n20-pds/
+    - https://www.star.nesdis.noaa.gov/jpss/ATMS.php
+    - https://www.nesdis.noaa.gov/current-satellite-missions/currently-flying/joint-polar-satellite-system
+
+    Example
+    -------
+    .. highlight:: python
+    .. code-block:: python
+
+        from datetime import datetime, timedelta
+        from earth2studio.data import JPSS_ATMS
+
+        # Use all possible satellites
+        ds = JPSS_ATMS()
+        df = ds(datetime(2024, 6, 1, 12), ["atms"])
+
+        # Use specific satellite
+        ds = JPSS_ATMS(satellites=["n20"])
+        df = ds(datetime(2024, 6, 1, 12), ["atms"])
+
+    Badges
+    ------
+    region:global dataclass:observation product:atmos product:sat
+    """
+
+    SOURCE_ID = "earth2studio.data.JPSS_ATMS"
+    VALID_SATELLITES = frozenset(["n20", "n21", "npp"])
+
+    SCHEMA = pa.schema(
+        [
+            E2STUDIO_SCHEMA.field("time"),
+            E2STUDIO_SCHEMA.field("lat"),
+            E2STUDIO_SCHEMA.field("lon"),
+            pa.field(
+                "scan_angle",
+                pa.float32(),
+                nullable=True,
+                metadata={"bufr_name": "fieldOfViewNumber"},
+            ),
+            E2STUDIO_SCHEMA.field("channel_index"),
+            E2STUDIO_SCHEMA.field("solza"),
+            E2STUDIO_SCHEMA.field("solaza"),
+            E2STUDIO_SCHEMA.field("satellite_za"),
+            E2STUDIO_SCHEMA.field("satellite_aza"),
+            E2STUDIO_SCHEMA.field("channel_quality_flag"),
+            pa.field("satellite", pa.string()),
+            pa.field("observation", pa.float32()),
+            pa.field("variable", pa.string()),
+        ]
+    )
+
+    def __init__(
+        self,
+        satellites: list[str] | None = None,
+        time_tolerance: TimeTolerance = np.timedelta64(30, "m"),
+        cache: bool = True,
+        verbose: bool = True,
+        async_timeout: int = 600,
+        max_workers: int = 24,
+        retries: int = 3,
+    ) -> None:
+        if satellites is None:
+            satellites = list(self.VALID_SATELLITES)
+        else:
+            invalid = set(satellites) - self.VALID_SATELLITES
+            if invalid:
+                raise ValueError(
+                    f"Invalid satellite(s): {invalid}. "
+                    f"Valid options: {sorted(self.VALID_SATELLITES)}"
+                )
+        self._satellites = satellites
+        self._cache = cache
+        self._verbose = verbose
+        self._max_workers = max_workers
+        self._retries = retries
+        self.async_timeout = async_timeout
+        self._tmp_cache_hash: str | None = None
+
+        try:
+            nest_asyncio.apply()
+            loop = asyncio.get_running_loop()
+            loop.run_until_complete(self._async_init())
+        except RuntimeError:
+            self.fs: s3fs.S3FileSystem | None = None
+
+        lower, upper = normalize_time_tolerance(time_tolerance)
+        self._tolerance_lower = pd.to_timedelta(lower).to_pytimedelta()
+        self._tolerance_upper = pd.to_timedelta(upper).to_pytimedelta()
+
+    # ------------------------------------------------------------------
+    # Async initialisation
+    # ------------------------------------------------------------------
+    async def _async_init(self) -> None:
+        """Initialise the async S3 filesystem."""
+        self.fs = s3fs.S3FileSystem(
+            anon=True,
+            client_kwargs={},
+            asynchronous=True,
+            skip_instance_cache=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Synchronous entry point
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+        fields: str | list[str] | pa.Schema | None = None,
+    ) -> pd.DataFrame:
+        """Fetch ATMS brightness-temperature observations.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            Variable names to return (e.g. ``["atms"]``).
+        fields : str | list[str] | pa.Schema | None, optional
+            Subset of schema fields to include, by default None (all).
+
+        Returns
+        -------
+        pd.DataFrame
+            Long-format DataFrame with one row per FOV per channel.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        if self.fs is None:
+            loop.run_until_complete(self._async_init())
+
+        try:
+            df = loop.run_until_complete(
+                asyncio.wait_for(
+                    self.fetch(time, variable, fields), timeout=self.async_timeout
+                )
+            )
+        finally:
+            if not self._cache:
+                shutil.rmtree(self.cache, ignore_errors=True)
+
+        return df
+
+    # ------------------------------------------------------------------
+    # Async fetch
+    # ------------------------------------------------------------------
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+        fields: str | list[str] | pa.Schema | None = None,
+    ) -> pd.DataFrame:
+        """Async implementation of the data fetch.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            Variable names to return.
+        fields : str | list[str] | pa.Schema | None, optional
+            Subset of schema fields to include, by default None.
+
+        Returns
+        -------
+        pd.DataFrame
+            Long-format DataFrame.
+        """
+        if self.fs is None:
+            raise ValueError(
+                "File store is not initialised! If calling this function "
+                "directly, make sure the data source is initialised inside "
+                "the async loop!"
+            )
+
+        session = await self.fs.set_session(refresh=True)
+
+        time_list, variable_list = prep_data_inputs(time, variable)
+        schema = self.resolve_fields(fields)
+        self._validate_time(time_list)
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        # Validate variables
+        for v in variable_list:
+            try:
+                JPSSATMSLexicon[v]  # type: ignore
+            except KeyError:
+                logger.error(f"Variable id {v} not found in JPSS ATMS lexicon")
+                raise
+
+        # Discover and download BUFR files within tolerance windows
+        tasks = await self._create_tasks(time_list, variable_list)
+
+        # Deduplicate by S3 URI
+        uri_set = {t.s3_uri for t in tasks}
+        fetch_jobs = [self._fetch_remote_file(uri) for uri in uri_set]
+        await tqdm.gather(
+            *fetch_jobs,
+            desc="Fetching ATMS BUFR files",
+            disable=(not self._verbose),
+        )
+
+        if session:
+            await session.close()
+
+        # Decode and compile
+        df = self._compile_dataframe(tasks, schema)
+        return df
+
+    # ------------------------------------------------------------------
+    # Task creation – discover BUFR granules in S3
+    # ------------------------------------------------------------------
+    async def _create_tasks(
+        self,
+        time_list: list[datetime],
+        variable_list: list[str],
+    ) -> list[_ATMSAsyncTask]:
+        """Build download tasks by listing the S3 day-directory.
+
+        For each requested time ± tolerance we list the relevant day
+        directories on each satellite bucket and select files whose
+        embedded start-timestamp falls within the tolerance window.
+        """
+        tasks: list[_ATMSAsyncTask] = []
+
+        for v in variable_list:
+            bufr_key, modifier = JPSSATMSLexicon[v]  # type: ignore
+
+            for sat in self._satellites:
+                bucket = _SAT_BUCKET_MAP[sat]
+
+                for t in time_list:
+                    tmin = t + self._tolerance_lower
+                    tmax = t + self._tolerance_upper
+
+                    # Iterate over calendar days covered by the window
+                    day = tmin.replace(hour=0, minute=0, second=0, microsecond=0)
+                    end_day = tmax.replace(hour=0, minute=0, second=0, microsecond=0)
+
+                    while day <= end_day:
+                        prefix = (
+                            f"{bucket}/ATMS_BUFR/"
+                            f"{day.year:04d}/{day.month:02d}/{day.day:02d}/"
+                        )
+                        try:
+                            listing = await self.fs._ls(prefix, detail=False)  # type: ignore[union-attr]
+                        except FileNotFoundError:
+                            logger.warning(f"No ATMS data at s3://{prefix}")
+                            day += timedelta(days=1)
+                            continue
+
+                        for path in listing:
+                            fname = path.rsplit("/", 1)[-1]
+                            file_time = self._parse_filename_time(fname)
+                            if file_time is None:
+                                continue
+                            if tmin <= file_time <= tmax:
+                                tasks.append(
+                                    _ATMSAsyncTask(
+                                        s3_uri=f"s3://{path}",
+                                        datetime_min=tmin,
+                                        datetime_max=tmax,
+                                        satellite=sat,
+                                        variable=v,
+                                        bufr_key=bufr_key,
+                                        modifier=modifier,
+                                    )
+                                )
+
+                        day += timedelta(days=1)
+
+        return tasks
+
+    # ------------------------------------------------------------------
+    # Download helpers
+    # ------------------------------------------------------------------
+    async def _fetch_remote_file(self, s3_uri: str) -> None:
+        """Download a single BUFR file to local cache (with retry)."""
+        local_path = self._cache_path(s3_uri)
+        if pathlib.Path(local_path).is_file():
+            return
+
+        last_exc: Exception | None = None
+        for attempt in range(1, self._retries + 1):
+            try:
+                data = await self.fs._cat_file(s3_uri.replace("s3://", "", 1))  # type: ignore[union-attr]
+                with open(local_path, "wb") as fh:
+                    fh.write(data)
+                return
+            except (OSError, TimeoutError, ConnectionError) as exc:
+                last_exc = exc
+                if attempt < self._retries:
+                    await asyncio.sleep(2 ** (attempt - 1))
+
+        logger.warning(f"Failed to fetch {s3_uri} after {self._retries} retries")
+        if last_exc is not None:
+            raise last_exc
+
+    # ------------------------------------------------------------------
+    # BUFR decoding & DataFrame compilation
+    # ------------------------------------------------------------------
+    def _compile_dataframe(
+        self,
+        tasks: list[_ATMSAsyncTask],
+        schema: pa.Schema,
+    ) -> pd.DataFrame:
+        """Decode cached BUFR files and assemble the output DataFrame."""
+        frames: list[pd.DataFrame] = []
+
+        for task in tasks:
+            local_path = self._cache_path(task.s3_uri)
+            if not pathlib.Path(local_path).is_file():
+                logger.warning(f"Cached file missing for {task.s3_uri}")
+                continue
+
+            try:
+                df = self._decode_bufr(local_path, task)
+            except Exception:
+                logger.warning(f"Failed to decode {task.s3_uri}", exc_info=True)
+                continue
+
+            if df.empty:
+                continue
+
+            # Filter by time tolerance window
+            mask = (df["time"] >= task.datetime_min) & (df["time"] <= task.datetime_max)
+            df = df.loc[mask]
+            if not df.empty:
+                frames.append(df)
+
+        if not frames:
+            return pd.DataFrame(columns=schema.names)
+
+        result = pd.concat(frames, ignore_index=True)
+        result.attrs["source"] = self.SOURCE_ID
+        return result[[name for name in schema.names if name in result.columns]]
+
+    def _decode_bufr(
+        self,
+        path: str,
+        task: _ATMSAsyncTask,
+    ) -> pd.DataFrame:
+        """Decode a single ATMS BUFR file into a DataFrame.
+
+        Each BUFR message contains *N* subsets (FOVs).  For each subset the
+        brightness temperature array has *C* channel values, yielding
+        ``N * C`` rows in the output.
+        """
+        rows: list[dict] = []
+
+        with open(path, "rb") as fh:
+            while True:
+                msgid = eccodes.codes_bufr_new_from_file(fh)
+                if msgid is None:
+                    break
+                try:
+                    eccodes.codes_set(msgid, "unpack", 1)
+
+                    n_subsets = eccodes.codes_get(msgid, "numberOfSubsets")
+
+                    # Extract per-FOV arrays (length = n_subsets)
+                    lat = eccodes.codes_get_array(msgid, "latitude")
+                    lon = eccodes.codes_get_array(msgid, "longitude")
+                    fov = eccodes.codes_get_array(msgid, "fieldOfViewNumber")
+                    solza = eccodes.codes_get_array(msgid, "solarZenithAngle")
+                    solaza = eccodes.codes_get_array(msgid, "solarAzimuth")
+                    sat_za = eccodes.codes_get_array(msgid, "satelliteZenithAngle")
+                    sat_aza = eccodes.codes_get_array(msgid, "bearingOrAzimuth")
+
+                    # Brightness temperature array is channel-major:
+                    # [ch1_fov0, ch1_fov1, ..., ch1_fovN, ch2_fov0, ...]
+                    # i.e. shape (n_channels, n_fov) when reshaped, then
+                    # transposed to (n_fov, n_channels) for row iteration.
+                    bt_flat = eccodes.codes_get_array(msgid, task.bufr_key)
+                    n_channels = ATMS_NUM_CHANNELS
+                    n_fov = n_subsets
+
+                    if bt_flat.size != n_fov * n_channels:
+                        logger.warning(
+                            f"Unexpected BT array size {bt_flat.size} in {path}, "
+                            f"expected {n_fov}×{n_channels}. Skipping message."
+                        )
+                        continue
+
+                    bt = bt_flat.reshape(n_channels, n_fov).T
+
+                    # Per-channel quality flags (shape n_channels, one per channel)
+                    try:
+                        cqf = eccodes.codes_get_array(msgid, "channelDataQualityFlags")
+                        # Normalise to exactly n_channels entries.  Some
+                        # BUFR producers emit per-FOV-per-channel arrays
+                        # (length n_fov * n_channels); take only the first
+                        # n_channels in that case (values repeat per-FOV).
+                        if cqf.size >= n_channels:
+                            cqf = cqf[:n_channels].astype(np.uint16)
+                        else:
+                            cqf = np.zeros(n_channels, dtype=np.uint16)
+                    except Exception:
+                        cqf = np.zeros(n_channels, dtype=np.uint16)
+
+                    # Time fields — may be scalars or per-subset arrays
+                    # depending on the BUFR producer.  Use codes_get_array
+                    # for all of them and broadcast scalars to length n_fov.
+                    def _get_time_array(key: str) -> np.ndarray:
+                        try:
+                            arr = eccodes.codes_get_array(msgid, key)
+                        except Exception:
+                            arr = np.zeros(n_fov)
+                        if arr.size == 1:
+                            arr = np.full(n_fov, arr[0])
+                        return arr.astype(int)
+
+                    years = _get_time_array("year")
+                    months = _get_time_array("month")
+                    days = _get_time_array("day")
+                    hours = _get_time_array("hour")
+                    minutes = _get_time_array("minute")
+                    seconds = _get_time_array("second")
+
+                    # Satellite id
+                    try:
+                        sat_id = int(eccodes.codes_get(msgid, "satelliteIdentifier"))
+                        sat_name = _SAT_ID_MAP.get(sat_id, task.satellite)
+                    except Exception:
+                        sat_name = task.satellite
+
+                    # Build rows: one per (FOV, channel)
+                    for i in range(n_fov):
+                        try:
+                            obs_time = datetime(
+                                int(years[i]),
+                                int(months[i]),
+                                int(days[i]),
+                                int(hours[i]),
+                                int(minutes[i]),
+                                int(seconds[i]),
+                            )
+                        except (ValueError, OverflowError):
+                            continue  # skip FOVs with invalid timestamps
+
+                        for ch in range(n_channels):
+                            val = float(bt[i, ch])
+                            # Skip missing / fill values
+                            if val > 1e6 or val < 0:
+                                continue
+
+                            rows.append(
+                                {
+                                    "time": obs_time,
+                                    "lat": float(lat[i]),
+                                    "lon": float(lon[i]) % 360.0,
+                                    "scan_angle": float(fov[i]),
+                                    "channel_index": ch + 1,
+                                    "solza": float(solza[i]),
+                                    "solaza": float(solaza[i]),
+                                    "satellite_za": float(sat_za[i]),
+                                    "satellite_aza": float(sat_aza[i]),
+                                    "channel_quality_flag": int(cqf[ch]),
+                                    "satellite": sat_name,
+                                    "observation": val,
+                                    "variable": task.variable,
+                                }
+                            )
+                finally:
+                    eccodes.codes_release(msgid)
+
+        if not rows:
+            return pd.DataFrame(columns=self.SCHEMA.names)
+
+        df = pd.DataFrame(rows)
+        # Enforce schema dtypes
+        df["time"] = pd.to_datetime(df["time"])
+        df["lat"] = df["lat"].astype(np.float32)
+        df["lon"] = df["lon"].astype(np.float32)
+        df["scan_angle"] = df["scan_angle"].astype(np.float32)
+        df["channel_index"] = df["channel_index"].astype(np.uint16)
+        df["solza"] = df["solza"].astype(np.float32)
+        df["solaza"] = df["solaza"].astype(np.float32)
+        df["satellite_za"] = df["satellite_za"].astype(np.float32)
+        df["satellite_aza"] = df["satellite_aza"].astype(np.float32)
+        df["channel_quality_flag"] = df["channel_quality_flag"].astype(np.uint16)
+        df["observation"] = df["observation"].astype(np.float32)
+        return df
+
+    # ------------------------------------------------------------------
+    # File-name timestamp parsing
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_filename_time(filename: str) -> datetime | None:
+        """Extract the scan start time from an ATMS BUFR filename.
+
+        Expected pattern::
+
+            ATMS_v1r0_j01_s<YYYYMMDDHHMMSSF>_e..._c....bufr
+
+        Returns ``None`` if the filename does not match.
+        """
+        parts = filename.split("_")
+        for part in parts:
+            if part.startswith("s") and len(part) >= 15:
+                try:
+                    return datetime.strptime(part[1:15], "%Y%m%d%H%M%S")
+                except ValueError:
+                    return None
+        return None
+
+    # ------------------------------------------------------------------
+    # resolve_fields / cache / available
+    # ------------------------------------------------------------------
+    @classmethod
+    def resolve_fields(cls, fields: str | list[str] | pa.Schema | None) -> pa.Schema:
+        """Convert *fields* parameter into a validated PyArrow schema.
+
+        Parameters
+        ----------
+        fields : str | list[str] | pa.Schema | None
+            Field specification.
+
+        Returns
+        -------
+        pa.Schema
+        """
+        if fields is None:
+            return cls.SCHEMA
+
+        if isinstance(fields, str):
+            fields = [fields]
+
+        if isinstance(fields, pa.Schema):
+            for field in fields:
+                if field.name not in cls.SCHEMA.names:
+                    raise KeyError(
+                        f"Field '{field.name}' not in SCHEMA. "
+                        f"Available: {cls.SCHEMA.names}"
+                    )
+                expected = cls.SCHEMA.field(field.name).type
+                if field.type != expected:
+                    raise TypeError(
+                        f"Field '{field.name}' type {field.type} != {expected}"
+                    )
+            return fields
+
+        selected = []
+        for name in fields:
+            if name not in cls.SCHEMA.names:
+                raise KeyError(
+                    f"Field '{name}' not in SCHEMA. Available: {cls.SCHEMA.names}"
+                )
+            selected.append(cls.SCHEMA.field(name))
+        return pa.schema(selected)
+
+    @property
+    def cache(self) -> str:
+        """Get the appropriate cache location."""
+        cache_location = os.path.join(datasource_cache_root(), "jpss_atms")
+        if not self._cache:
+            if self._tmp_cache_hash is None:
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_jpss_atms_{self._tmp_cache_hash}"
+            )
+        return cache_location
+
+    def _cache_path(self, s3_uri: str) -> str:
+        """Deterministic local cache path for an S3 URI."""
+        sha = hashlib.sha256(s3_uri.encode())
+        return os.path.join(self.cache, sha.hexdigest())
+
+    @classmethod
+    def _validate_time(cls, times: list[datetime]) -> None:
+        """Validate that requested times are within the data range.
+
+        Parameters
+        ----------
+        times : list[datetime]
+            Date-times to validate.
+        """
+        start_date = datetime(2017, 11, 29)
+        for t in times:
+            if t < start_date:
+                raise ValueError(
+                    f"Requested date time {t} needs to be after "
+                    f"{start_date} for JPSS ATMS"
+                )
+
+    @classmethod
+    def available(cls, time: datetime | np.datetime64) -> bool:
+        """Check whether data is available for a given time.
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date-time to check.
+
+        Returns
+        -------
+        bool
+        """
+        if isinstance(time, np.datetime64):
+            time = time.astype("datetime64[ns]").astype("datetime64[us]").item()
+        try:
+            cls._validate_time([time])
+        except ValueError:
+            return False
+        return True

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -83,11 +83,35 @@ _SAT_START_DATE: dict[str, datetime] = {
     "n21": datetime(2023, 9, 6),
 }
 
-# ATMS cross-track geometry: 96 FOVs spanning ±52.77° (total 105.54°).
-# Nadir lies between FOV 48 and 49 (1-indexed).
+# ---------------------------------------------------------------------------
+# ATMS cross-track geometry and scan timing constants
+#
+# Source: JPSS ATMS SDR Algorithm Theoretical Basis Document (ATBD),
+#   D0001-M01-S01-001_JPSS_ATBD_ATMS-SDR_B, Version 1, 2022-04-27,
+#   Section 3 ("Instrument Description"), pp. 8-9.
+#   https://www.star.nesdis.noaa.gov/jpss/documents/ATBD/D0001-M01-S01-001_JPSS_ATBD_ATMS-SDR_B.pdf
+#
+# The antenna completes 3 revolutions in 8 seconds (scan period = 8/3 s).
+# Each scan cycle samples 96 Earth-scene FOVs at ~18 ms integration each,
+# with an angular sampling interval of 1.11°.  The total angular range
+# from FOV-1 center to FOV-96 center is 95 × 1.11° = 105.45° (±52.725°
+# from nadir).  The scan speed is ~61.6°/s.
+#
+# Integration time per FOV (18 ms) also confirmed by:
+#   Weng et al. (2012), "Introduction to Suomi NPP ATMS for NWP and
+#   tropical cyclone applications", J. Geophys. Res., 117, D19112,
+#   doi:10.1029/2012JD018144, Section 2.
+# ---------------------------------------------------------------------------
 _ATMS_NUM_FOVS: int = 96
-_ATMS_TOTAL_SCAN_DEG: float = 105.54
-_ATMS_DEG_PER_FOV: float = _ATMS_TOTAL_SCAN_DEG / _ATMS_NUM_FOVS
+_ATMS_TOTAL_SCAN_DEG: float = 105.45  # 95 × 1.11°, per ATBD §3
+_ATMS_DEG_PER_FOV: float = _ATMS_TOTAL_SCAN_DEG / (_ATMS_NUM_FOVS - 1)  # 1.11°
+
+# Scan period: 3 revolutions in 8 seconds → 8/3 s per scan line (ATBD §3).
+_ATMS_SCAN_PERIOD_S: float = 8.0 / 3.0  # 2.667 s
+
+# Each FOV is sampled for ~18 ms with scan speed ~61.6°/s (ATBD §3).
+# The 96 FOVs span ~1.73 s of the 2.667 s scan cycle (~65% duty cycle).
+_ATMS_FOV_DWELL_S: float = 0.018  # 18 ms per FOV
 
 
 def _fov_to_scan_angle(fov: float) -> float:
@@ -104,6 +128,29 @@ def _fov_to_scan_angle(fov: float) -> float:
         Scan angle in degrees (negative = left of nadir, positive = right).
     """
     return (fov - (_ATMS_NUM_FOVS + 1) / 2.0) * _ATMS_DEG_PER_FOV
+
+
+def _fov_to_time_offset(fov: float) -> timedelta:
+    """Compute the sub-second time offset for a given FOV within a scan line.
+
+    ATMS samples 96 FOVs sequentially at ~18 ms per step.  The BUFR time
+    fields only carry integer-second precision, so this offset is added to
+    recover approximate sub-second timing.  FOV 1 is the first sample
+    (offset = 0); FOV 96 is the last (offset ≈ 1.71 s).
+
+    Source: ATMS SDR ATBD (D0001-M01-S01-001), §3, p. 8-9.
+
+    Parameters
+    ----------
+    fov : float
+        Field-of-view number (1–96, 1-indexed).
+
+    Returns
+    -------
+    timedelta
+        Sub-second offset from the start of the scan line.
+    """
+    return timedelta(seconds=(fov - 1) * _ATMS_FOV_DWELL_S)
 
 
 @dataclass
@@ -709,6 +756,13 @@ class JPSS_ATMS:
                         except (ValueError, OverflowError):
                             continue  # skip FOVs with invalid timestamps
 
+                        # Add sub-second offset based on FOV position in
+                        # the scan line.  BUFR only carries integer-second
+                        # timestamps; the offset recovers ~18 ms per-FOV
+                        # timing from the ATMS scan geometry (ATBD §3).
+                        fov_index = float(fov[i])
+                        obs_time = obs_time + _fov_to_time_offset(fov_index)
+
                         for ch in range(n_channels):
                             raw_val = float(bt[i, ch])
                             # Skip missing / fill values
@@ -723,7 +777,7 @@ class JPSS_ATMS:
                                     "class": "rad",
                                     "lat": float(lat[i]),
                                     "lon": float(lon[i]) % 360.0,
-                                    "scan_angle": _fov_to_scan_angle(float(fov[i])),
+                                    "scan_angle": _fov_to_scan_angle(fov_index),
                                     "channel_index": ch + 1,
                                     "solza": float(solza[i]),
                                     "solaza": float(solaza[i]),

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -22,8 +22,10 @@ import os
 import pathlib
 import shutil
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Any
 
 import nest_asyncio
 import numpy as np
@@ -72,6 +74,13 @@ _SAT_BUCKET_MAP: dict[str, str] = {
     "npp": "noaa-nesdis-snpp-pds",
 }
 
+# Earliest date with ATMS BUFR data on S3 per satellite
+_SAT_START_DATE: dict[str, datetime] = {
+    "npp": datetime(2023, 9, 6),
+    "n20": datetime(2023, 9, 6),
+    "n21": datetime(2023, 9, 6),
+}
+
 
 @dataclass
 class _ATMSAsyncTask:
@@ -83,7 +92,7 @@ class _ATMSAsyncTask:
     satellite: str
     variable: str
     bufr_key: str
-    modifier: object  # Callable[[Any], Any]
+    modifier: Callable[[Any], Any]
 
 
 @check_optional_dependencies()
@@ -519,13 +528,24 @@ class JPSS_ATMS:
 
                     # Per-channel quality flags (shape n_channels, one per channel)
                     try:
-                        cqf = eccodes.codes_get_array(msgid, "channelDataQualityFlags")
-                        # Normalise to exactly n_channels entries.  Some
-                        # BUFR producers emit per-FOV-per-channel arrays
-                        # (length n_fov * n_channels); take only the first
-                        # n_channels in that case (values repeat per-FOV).
-                        if cqf.size >= n_channels:
-                            cqf = cqf[:n_channels].astype(np.uint16)
+                        cqf_raw = eccodes.codes_get_array(
+                            msgid, "channelDataQualityFlags"
+                        )
+                        if cqf_raw.size == n_channels:
+                            # One flag per channel (shared across all FOVs)
+                            cqf = cqf_raw.astype(np.uint16)
+                        elif cqf_raw.size == n_fov * n_channels:
+                            # Per-FOV per-channel: reshape to (n_channels, n_fov)
+                            # and transpose to (n_fov, n_channels) so we can
+                            # index cqf_per_fov[i, ch] later.
+                            cqf = cqf_raw.reshape(n_channels, n_fov).T.astype(np.uint16)
+                        elif cqf_raw.size >= n_channels:
+                            # Unexpected size — take first n_channels entries
+                            logger.debug(
+                                f"channelDataQualityFlags unexpected size "
+                                f"{cqf_raw.size}, using first {n_channels}"
+                            )
+                            cqf = cqf_raw[:n_channels].astype(np.uint16)
                         else:
                             cqf = np.zeros(n_channels, dtype=np.uint16)
                     except Exception:
@@ -572,10 +592,12 @@ class JPSS_ATMS:
                             continue  # skip FOVs with invalid timestamps
 
                         for ch in range(n_channels):
-                            val = float(bt[i, ch])
+                            raw_val = float(bt[i, ch])
                             # Skip missing / fill values
-                            if val > 1e6 or val < 0:
+                            if raw_val > 1e6 or raw_val < 0:
                                 continue
+
+                            val = float(task.modifier(raw_val))
 
                             rows.append(
                                 {
@@ -588,7 +610,9 @@ class JPSS_ATMS:
                                     "solaza": float(solaza[i]),
                                     "satellite_za": float(sat_za[i]),
                                     "satellite_aza": float(sat_aza[i]),
-                                    "channel_quality_flag": int(cqf[ch]),
+                                    "channel_quality_flag": int(
+                                        cqf[i, ch] if cqf.ndim == 2 else cqf[ch]
+                                    ),
                                     "satellite": sat_name,
                                     "observation": val,
                                     "variable": task.variable,
@@ -708,7 +732,8 @@ class JPSS_ATMS:
         times : list[datetime]
             Date-times to validate.
         """
-        start_date = datetime(2017, 11, 29)
+        # Use the earliest S3 start date across all satellites
+        start_date = min(_SAT_START_DATE.values())
         for t in times:
             if t < start_date:
                 raise ValueError(

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -38,7 +38,6 @@ from tqdm.asyncio import tqdm
 from earth2studio.data.utils import datasource_cache_root, prep_data_inputs
 from earth2studio.lexicon.base import E2STUDIO_SCHEMA
 from earth2studio.lexicon.jpss import (
-    ATMS_NUM_CHANNELS,
     JPSSATMSLexicon,
 )
 from earth2studio.utils.imports import (
@@ -100,10 +99,8 @@ class JPSS_ATMS:
     """JPSS ATMS (Advanced Technology Microwave Sounder) Level 1 BUFR
     brightness-temperature observations served from NOAA Open Data on AWS.
 
-    Each BUFR file contains a single scan line with
-    :data:`~earth2studio.lexicon.jpss.ATMS_NUM_FOVS` cross-track
-    field-of-view (FOV) positions and
-    :data:`~earth2studio.lexicon.jpss.ATMS_NUM_CHANNELS` microwave channels.
+    Each BUFR file contains a single scan line with 96 cross-track
+    field-of-view (FOV) positions and 22 microwave channels.
     The returned :class:`~pandas.DataFrame` has one row per FOV per channel,
     following the same convention as :class:`~earth2studio.data.UFSObsSat`.
 
@@ -197,8 +194,9 @@ class JPSS_ATMS:
         (NOAA-20), ``"n21"`` (NOAA-21), and ``"npp"`` (Suomi NPP).
         By default ``None``, which queries all valid satellites.
     time_tolerance : TimeTolerance, optional
-        Symmetric or asymmetric tolerance window around each requested time
-        for selecting BUFR granules, by default ``np.timedelta64(30, "m")``.
+        Time tolerance window for filtering observations. Accepts a single value
+        (symmetric ± window) or a tuple (lower, upper) for asymmetric windows,
+        by default, np.timedelta64(10, 'm').
     cache : bool, optional
         Cache downloaded BUFR files locally, by default True
     verbose : bool, optional
@@ -262,7 +260,7 @@ class JPSS_ATMS:
     def __init__(
         self,
         satellites: list[str] | None = None,
-        time_tolerance: TimeTolerance = np.timedelta64(30, "m"),
+        time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
@@ -586,7 +584,7 @@ class JPSS_ATMS:
                     # i.e. shape (n_channels, n_fov) when reshaped, then
                     # transposed to (n_fov, n_channels) for row iteration.
                     bt_flat = eccodes.codes_get_array(msgid, task.bufr_key)
-                    n_channels = ATMS_NUM_CHANNELS
+                    n_channels = JPSSATMSLexicon.ATMS_NUM_CHANNELS
                     n_fov = n_subsets
 
                     if bt_flat.size != n_fov * n_channels:

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -250,7 +250,7 @@ class JPSS_ATMS:
             E2STUDIO_SCHEMA.field("solaza"),
             E2STUDIO_SCHEMA.field("satellite_za"),
             E2STUDIO_SCHEMA.field("satellite_aza"),
-            E2STUDIO_SCHEMA.field("channel_quality_flag"),
+            E2STUDIO_SCHEMA.field("quality"),
             pa.field("satellite", pa.string()),
             pa.field("observation", pa.float32()),
             pa.field("variable", pa.string()),
@@ -680,7 +680,7 @@ class JPSS_ATMS:
                                     "solaza": float(solaza[i]),
                                     "satellite_za": float(sat_za[i]),
                                     "satellite_aza": float(sat_aza[i]),
-                                    "channel_quality_flag": int(
+                                    "quality": int(
                                         cqf[i, ch] if cqf.ndim == 2 else cqf[ch]
                                     ),
                                     "satellite": sat_name,
@@ -705,7 +705,7 @@ class JPSS_ATMS:
         df["solaza"] = df["solaza"].astype(np.float32)
         df["satellite_za"] = df["satellite_za"].astype(np.float32)
         df["satellite_aza"] = df["satellite_aza"].astype(np.float32)
-        df["channel_quality_flag"] = df["channel_quality_flag"].astype(np.uint16)
+        df["quality"] = df["quality"].astype(np.uint16)
         df["observation"] = df["observation"].astype(np.float32)
         return df
 

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -80,6 +80,28 @@ _SAT_START_DATE: dict[str, datetime] = {
     "n21": datetime(2023, 9, 6),
 }
 
+# ATMS cross-track geometry: 96 FOVs spanning ±52.77° (total 105.54°).
+# Nadir lies between FOV 48 and 49 (1-indexed).
+_ATMS_NUM_FOVS: int = 96
+_ATMS_TOTAL_SCAN_DEG: float = 105.54
+_ATMS_DEG_PER_FOV: float = _ATMS_TOTAL_SCAN_DEG / _ATMS_NUM_FOVS
+
+
+def _fov_to_scan_angle(fov: float) -> float:
+    """Convert a 1-indexed field-of-view number to scan angle in degrees.
+
+    Parameters
+    ----------
+    fov : float
+        Field-of-view number (1–96).
+
+    Returns
+    -------
+    float
+        Scan angle in degrees (negative = left of nadir, positive = right).
+    """
+    return (fov - (_ATMS_NUM_FOVS + 1) / 2.0) * _ATMS_DEG_PER_FOV
+
 
 @dataclass
 class _ATMSAsyncTask:
@@ -243,7 +265,7 @@ class JPSS_ATMS:
                 "scan_angle",
                 pa.float32(),
                 nullable=True,
-                metadata={"bufr_name": "fieldOfViewNumber"},
+                metadata={"bufr_name": "fieldOfViewNumber (converted to degrees)"},
             ),
             E2STUDIO_SCHEMA.field("channel_index"),
             E2STUDIO_SCHEMA.field("solza"),
@@ -544,6 +566,27 @@ class JPSS_ATMS:
             return pd.DataFrame(columns=schema.names)
 
         result = pd.concat(frames, ignore_index=True)
+
+        # When multiple requested times have overlapping tolerance windows
+        # the same BUFR file may appear in more than one task.  Downloads
+        # are already deduplicated via ``uri_set``, but the decode path
+        # runs once per task, so identical observations can end up in
+        # ``frames`` twice.  Drop exact duplicates to prevent this.
+        dedup_cols = [
+            c
+            for c in (
+                "time",
+                "lat",
+                "lon",
+                "channel_index",
+                "satellite",
+                "variable",
+            )
+            if c in result.columns
+        ]
+        if dedup_cols:
+            result = result.drop_duplicates(subset=dedup_cols, ignore_index=True)
+
         result.attrs["source"] = self.SOURCE_ID
         return result[[name for name in schema.names if name in result.columns]]
 
@@ -674,7 +717,7 @@ class JPSS_ATMS:
                                     "time": obs_time,
                                     "lat": float(lat[i]),
                                     "lon": float(lon[i]) % 360.0,
-                                    "scan_angle": float(fov[i]),
+                                    "scan_angle": _fov_to_scan_angle(float(fov[i])),
                                     "channel_index": ch + 1,
                                     "solza": float(solza[i]),
                                     "solaza": float(solaza[i]),

--- a/earth2studio/data/jpss_atms.py
+++ b/earth2studio/data/jpss_atms.py
@@ -262,6 +262,7 @@ class JPSS_ATMS:
     SCHEMA = pa.schema(
         [
             E2STUDIO_SCHEMA.field("time"),
+            E2STUDIO_SCHEMA.field("class"),
             E2STUDIO_SCHEMA.field("lat"),
             E2STUDIO_SCHEMA.field("lon"),
             pa.field(
@@ -719,6 +720,7 @@ class JPSS_ATMS:
                             rows.append(
                                 {
                                     "time": obs_time,
+                                    "class": "rad",
                                     "lat": float(lat[i]),
                                     "lon": float(lon[i]) % 360.0,
                                     "scan_angle": _fov_to_scan_angle(float(fov[i])),

--- a/earth2studio/lexicon/__init__.py
+++ b/earth2studio/lexicon/__init__.py
@@ -26,7 +26,7 @@ from .gfs import GFSLexicon
 from .goes import GOESLexicon
 from .hrrr import HRRRFXLexicon, HRRRLexicon
 from .isd import ISDLexicon
-from .jpss import JPSSLexicon
+from .jpss import JPSSATMSLexicon, JPSSLexicon
 from .mrms import MRMSLexicon
 from .ncar import NCAR_ERA5Lexicon
 from .planetary_computer import (

--- a/earth2studio/lexicon/base.py
+++ b/earth2studio/lexicon/base.py
@@ -238,6 +238,7 @@ E2STUDIO_VOCAB = {
     "viirs14m": "VIIRS M14 - LWIR (8.55 µm)",
     "viirs15m": "VIIRS M15 - LWIR (10.76 µm)",
     "viirs16m": "VIIRS M16 - LWIR (12.01 µm)",
+    "atms": "Advanced Technology Microwave Sounder brightness temperature (K)",
     "s3sy01aod": "Sentinel-3 SYNERGY aerosol optical depth band 01 (440 nm)",
     "s3sy02aod": "Sentinel-3 SYNERGY aerosol optical depth band 02 (550 nm)",
     "s3sy03aod": "Sentinel-3 SYNERGY aerosol optical depth band 03 (670 nm)",
@@ -405,6 +406,15 @@ E2STUDIO_SCHEMA = pa.schema(
             pa.float32(),
             nullable=True,
             metadata={"description": "Satellite azimuth angle (degrees)"},
+        ),
+        pa.field(
+            "channel_quality_flag",
+            pa.uint16(),
+            nullable=True,
+            metadata={
+                "description": "Per-channel data quality bit-flag "
+                "(0 = good, non-zero = degraded; see instrument documentation)"
+            },
         ),
     ]
 )

--- a/earth2studio/lexicon/base.py
+++ b/earth2studio/lexicon/base.py
@@ -364,6 +364,13 @@ E2STUDIO_SCHEMA = pa.schema(
             nullable=True,
             metadata={"description": "Station elevation (m)"},
         ),
+        # Quality control fields
+        pa.field(
+            "quality",
+            pa.uint16(),
+            nullable=True,
+            metadata={"description": "Quality control marker (0=best, 15=missing)"},
+        ),
         # Satellite observation fields
         pa.field(
             "satellite",
@@ -406,15 +413,6 @@ E2STUDIO_SCHEMA = pa.schema(
             pa.float32(),
             nullable=True,
             metadata={"description": "Satellite azimuth angle (degrees)"},
-        ),
-        pa.field(
-            "channel_quality_flag",
-            pa.uint16(),
-            nullable=True,
-            metadata={
-                "description": "Per-channel data quality bit-flag "
-                "(0 = good, non-zero = degraded; see instrument documentation)"
-            },
         ),
     ]
 )

--- a/earth2studio/lexicon/jpss.py
+++ b/earth2studio/lexicon/jpss.py
@@ -302,3 +302,90 @@ class JPSSLexicon(metaclass=LexiconType):
         if val not in cls.VOCAB:
             raise KeyError(f"Variable {val} not found in VIIRS lexicon")
         return cls.VOCAB[val]
+
+
+# ATMS channel center frequencies (GHz) for documentation / reference
+ATMS_CHANNEL_FREQS: dict[int, float] = {
+    1: 23.8,
+    2: 31.4,
+    3: 50.3,
+    4: 51.76,
+    5: 52.8,
+    6: 53.596,
+    7: 54.40,
+    8: 54.94,
+    9: 55.50,
+    10: 57.29,
+    11: 57.29,
+    12: 57.29,
+    13: 57.29,
+    14: 57.29,
+    15: 57.29,
+    16: 88.20,
+    17: 165.5,
+    18: 183.31,
+    19: 183.31,
+    20: 183.31,
+    21: 183.31,
+    22: 183.31,
+}
+
+# Number of ATMS cross-track field-of-view positions per scan line
+ATMS_NUM_FOVS = 96
+# Number of ATMS channels
+ATMS_NUM_CHANNELS = 22
+
+
+class JPSSATMSLexicon(metaclass=LexiconType):
+    """Lexicon for JPSS ATMS (Advanced Technology Microwave Sounder) data source.
+
+    This lexicon maps the ``atms`` variable to an identity modifier for brightness
+    temperature observations in Kelvin.  Individual channels (1-22) are distinguished
+    by the ``channel_index`` column of the returned DataFrame, following the same
+    convention used by :class:`~earth2studio.data.UFSObsSat`.
+
+    The ATMS instrument is a 22-channel cross-track scanning microwave radiometer
+    operating from 23 GHz to 183 GHz aboard NOAA-20 (JPSS-1) and NOAA-21 (JPSS-2).
+
+    Notes
+    -----
+    ATMS Channel Groups:
+
+    - Channels 1-2 (23-31 GHz): Surface / precipitation / total precipitable water
+    - Channels 3-15 (50-57 GHz): Temperature sounding (oxygen absorption complex)
+    - Channel 16 (88 GHz): Surface / cloud / precipitation
+    - Channels 17-22 (165-183 GHz): Humidity sounding (water vapor absorption)
+
+    References
+    ----------
+    - NOAA JPSS program:
+      https://www.nesdis.noaa.gov/current-satellite-missions/currently-flying/joint-polar-satellite-system
+    - ATMS instrument description:
+      https://www.star.nesdis.noaa.gov/jpss/ATMS.php
+    - AWS NOAA-20 open data:
+      https://registry.opendata.aws/noaa-nesdis-n20-pds/
+    """
+
+    VOCAB: dict[str, str] = {
+        "atms": "brightnessTemperature",
+    }
+
+    @classmethod
+    def get_item(cls, val: str) -> tuple[str, Callable[[Any], Any]]:
+        """Get ATMS BUFR key for a standardized variable name.
+
+        Parameters
+        ----------
+        val : str
+            Standardized variable name (``atms``)
+
+        Returns
+        -------
+        tuple[str, Callable]
+            Tuple containing:
+            - BUFR key name for brightness temperature
+            - Modifier function (identity -- brightness temperature in K)
+        """
+        if val not in cls.VOCAB:
+            raise KeyError(f"Variable {val} not found in ATMS lexicon")
+        return cls.VOCAB[val], lambda x: x

--- a/earth2studio/lexicon/jpss.py
+++ b/earth2studio/lexicon/jpss.py
@@ -304,38 +304,6 @@ class JPSSLexicon(metaclass=LexiconType):
         return cls.VOCAB[val]
 
 
-# ATMS channel center frequencies (GHz) for documentation / reference
-ATMS_CHANNEL_FREQS: dict[int, float] = {
-    1: 23.8,
-    2: 31.4,
-    3: 50.3,
-    4: 51.76,
-    5: 52.8,
-    6: 53.596,
-    7: 54.40,
-    8: 54.94,
-    9: 55.50,
-    10: 57.29,
-    11: 57.29,
-    12: 57.29,
-    13: 57.29,
-    14: 57.29,
-    15: 57.29,
-    16: 88.20,
-    17: 165.5,
-    18: 183.31,
-    19: 183.31,
-    20: 183.31,
-    21: 183.31,
-    22: 183.31,
-}
-
-# Number of ATMS cross-track field-of-view positions per scan line
-ATMS_NUM_FOVS = 96
-# Number of ATMS channels
-ATMS_NUM_CHANNELS = 22
-
-
 class JPSSATMSLexicon(metaclass=LexiconType):
     """Lexicon for JPSS ATMS (Advanced Technology Microwave Sounder) data source.
 
@@ -365,6 +333,36 @@ class JPSSATMSLexicon(metaclass=LexiconType):
     - AWS NOAA-20 open data:
       https://registry.opendata.aws/noaa-nesdis-n20-pds/
     """
+
+    # Number of ATMS cross-track field-of-view positions per scan line
+    ATMS_NUM_FOVS = 96
+    # Number of ATMS channels
+    ATMS_NUM_CHANNELS = 22
+    # ATMS channel center frequencies (GHz) for documentation / reference
+    ATMS_CHANNEL_FREQS: dict[int, float] = {
+        1: 23.8,
+        2: 31.4,
+        3: 50.3,
+        4: 51.76,
+        5: 52.8,
+        6: 53.596,
+        7: 54.40,
+        8: 54.94,
+        9: 55.50,
+        10: 57.29,
+        11: 57.29,
+        12: 57.29,
+        13: 57.29,
+        14: 57.29,
+        15: 57.29,
+        16: 88.20,
+        17: 165.5,
+        18: 183.31,
+        19: 183.31,
+        20: 183.31,
+        21: 183.31,
+        22: 183.31,
+    }
 
     VOCAB: dict[str, str] = {
         "atms": "brightnessTemperature",

--- a/test/data/test_jpss_atms.py
+++ b/test/data/test_jpss_atms.py
@@ -215,8 +215,8 @@ def test_jpss_atms_call_mock(tmp_path):
     assert df["channel_index"].between(1, 22).all()
     assert len(df) == n_fov * n_channels
     assert df["satellite"].iloc[0] == "n20"
-    assert "channel_quality_flag" in df.columns
-    assert (df["channel_quality_flag"] == 0).all()
+    assert "quality" in df.columns
+    assert (df["quality"] == 0).all()
 
 
 # ---------------------------------------------------------------------------

--- a/test/data/test_jpss_atms.py
+++ b/test/data/test_jpss_atms.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import shutil
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from earth2studio.data import JPSS_ATMS
+
+
+# ---------------------------------------------------------------------------
+# Network / slow tests
+# ---------------------------------------------------------------------------
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "time",
+    [
+        datetime(year=2024, month=6, day=1, hour=12),
+        [datetime(year=2024, month=6, day=1, hour=12)],
+    ],
+)
+@pytest.mark.parametrize("variable", ["atms", ["atms"]])
+def test_jpss_atms_fetch(time, variable):
+    ds = JPSS_ATMS(
+        satellites=["n20"],
+        time_tolerance=timedelta(minutes=5),
+        cache=False,
+        verbose=False,
+    )
+    df = ds(time, variable)
+
+    assert list(df.columns) == ds.SCHEMA.names
+    assert set(df["variable"].unique()).issubset({"atms"})
+    assert "observation" in df.columns
+    assert "satellite" in df.columns
+    assert "channel_index" in df.columns
+
+    if not df.empty:
+        assert df["channel_index"].between(1, 22).all()
+        assert df["lat"].between(-90, 90).all()
+        assert df["lon"].between(0, 360).all()
+        assert (df["observation"] > 0).all()
+        assert (df["observation"] < 400).all()  # BT in K
+
+
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(120)
+def test_jpss_atms_schema_fields():
+    ds = JPSS_ATMS(
+        satellites=["n20"],
+        time_tolerance=timedelta(minutes=5),
+        cache=False,
+        verbose=False,
+    )
+    time = datetime(2024, 6, 1, 12)
+
+    df_full = ds(time, ["atms"], fields=None)
+    assert list(df_full.columns) == ds.SCHEMA.names
+
+    subset_fields = ["time", "lat", "lon", "observation", "variable"]
+    df_subset = ds(time, ["atms"], fields=subset_fields)
+    assert list(df_subset.columns) == subset_fields
+
+
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("cache", [True, False])
+def test_jpss_atms_cache(cache):
+    ds = JPSS_ATMS(
+        satellites=["n20"],
+        time_tolerance=timedelta(minutes=5),
+        cache=cache,
+        verbose=False,
+    )
+    df = ds(datetime(2024, 6, 1, 12), ["atms"])
+    assert list(df.columns) == ds.SCHEMA.names
+    assert pathlib.Path(ds.cache).is_dir() == cache
+
+    try:
+        shutil.rmtree(ds.cache)
+    except FileNotFoundError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Mock / offline tests (no network required)
+# ---------------------------------------------------------------------------
+def _make_mock_bufr_decode(n_fov=4, n_channels=22):
+    """Return a side_effect function for eccodes calls in _decode_bufr."""
+    # bt shape (n_fov, n_channels) for assertion checking.
+    # The flat array passed to eccodes mock must be channel-major
+    # (all ch1 values, then all ch2, ...) matching real BUFR layout.
+    bt = np.random.uniform(200, 300, size=(n_fov, n_channels)).astype(np.float64)
+    bt_flat_channel_major = bt.T.ravel()  # (n_channels, n_fov) then ravel
+
+    def codes_get_side_effect(msgid, key):
+        mapping = {
+            "unpack": None,
+            "numberOfSubsets": n_fov,
+            "year": 2024,
+            "month": 6,
+            "day": 1,
+            "hour": 12,
+            "minute": 0,
+            "satelliteIdentifier": 225,
+            "satelliteInstruments": 621,
+        }
+        if key in mapping:
+            return mapping[key]
+        raise KeyError(key)
+
+    def codes_get_array_side_effect(msgid, key):
+        mapping = {
+            "latitude": np.linspace(30, 40, n_fov),
+            "longitude": np.linspace(-100, -80, n_fov),
+            "fieldOfViewNumber": np.arange(1, n_fov + 1, dtype=np.float64),
+            "solarZenithAngle": np.full(n_fov, 45.0),
+            "solarAzimuth": np.full(n_fov, 180.0),
+            "satelliteZenithAngle": np.full(n_fov, 30.0),
+            "bearingOrAzimuth": np.full(n_fov, 90.0),
+            "brightnessTemperature": bt_flat_channel_major,
+            "channelDataQualityFlags": np.zeros(n_channels, dtype=np.int64),
+            # Time fields (may be scalar-length or per-subset arrays)
+            "year": np.array([2024]),
+            "month": np.array([6]),
+            "day": np.array([1]),
+            "hour": np.array([12]),
+            "minute": np.array([0]),
+            "second": np.zeros(n_fov),
+        }
+        if key in mapping:
+            return mapping[key]
+        raise KeyError(key)
+
+    return codes_get_side_effect, codes_get_array_side_effect, bt
+
+
+def test_jpss_atms_call_mock(tmp_path):
+    """Exercise the full __call__ path without any network access."""
+    n_fov, n_channels = 4, 22
+    get_se, get_array_se, bt = _make_mock_bufr_decode(n_fov, n_channels)
+
+    # Create a fake cached BUFR file (content doesn't matter, eccodes is mocked)
+    fake_bufr = tmp_path / "fakefile.bufr"
+    fake_bufr.write_bytes(b"\x00" * 32)
+
+    # Mock _fetch_remote_file to be a no-op, _cache_path to return our fake file
+    with (
+        patch.object(JPSS_ATMS, "_fetch_remote_file", return_value=None),
+        patch.object(
+            JPSS_ATMS,
+            "_cache_path",
+            return_value=str(fake_bufr),
+        ),
+        patch.object(
+            JPSS_ATMS,
+            "_create_tasks",
+            return_value=[
+                MagicMock(
+                    s3_uri="s3://fake/file.bufr",
+                    datetime_min=datetime(2024, 6, 1, 11, 30),
+                    datetime_max=datetime(2024, 6, 1, 12, 30),
+                    satellite="n20",
+                    variable="atms",
+                    bufr_key="brightnessTemperature",
+                    modifier=lambda x: x,
+                )
+            ],
+        ),
+        patch("earth2studio.data.jpss_atms.eccodes") as mock_eccodes,
+    ):
+        # eccodes mock setup
+        call_count = {"new": 0}
+
+        def new_from_file(fh):
+            if call_count["new"] == 0:
+                call_count["new"] += 1
+                return 1  # return a message id
+            return None  # signal end of file
+
+        mock_eccodes.codes_bufr_new_from_file = new_from_file
+        mock_eccodes.codes_set = MagicMock()
+        mock_eccodes.codes_get = MagicMock(side_effect=get_se)
+        mock_eccodes.codes_get_array = MagicMock(side_effect=get_array_se)
+        mock_eccodes.codes_release = MagicMock()
+
+        ds = JPSS_ATMS(satellites=["n20"], cache=False, verbose=False)
+        df = ds(datetime(2024, 6, 1, 12), ["atms"])
+
+    assert not df.empty
+    assert list(df.columns) == ds.SCHEMA.names
+    assert set(df["variable"].unique()) == {"atms"}
+    assert df["channel_index"].between(1, 22).all()
+    assert len(df) == n_fov * n_channels
+    assert df["satellite"].iloc[0] == "n20"
+    assert "channel_quality_flag" in df.columns
+    assert (df["channel_quality_flag"] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Validation / error tests (no network)
+# ---------------------------------------------------------------------------
+@pytest.mark.timeout(15)
+def test_jpss_atms_available():
+    assert JPSS_ATMS.available(datetime(2024, 6, 1, 12))
+    assert not JPSS_ATMS.available(datetime(2015, 1, 1))
+    assert JPSS_ATMS.available(np.datetime64("2024-06-01T12:00"))
+    assert not JPSS_ATMS.available(np.datetime64("2015-01-01T00:00"))
+
+
+@pytest.mark.timeout(15)
+def test_jpss_atms_validate_time():
+    with pytest.raises(ValueError):
+        ds = JPSS_ATMS(satellites=["n20"], cache=False)
+        ds(datetime(2015, 1, 1), ["atms"])
+
+
+@pytest.mark.timeout(15)
+def test_jpss_atms_invalid_satellite():
+    with pytest.raises(ValueError, match="Invalid satellite"):
+        JPSS_ATMS(satellites=["invalid"])
+
+
+def test_jpss_atms_exceptions():
+    ds = JPSS_ATMS(satellites=["n20"], cache=False, verbose=False)
+
+    with pytest.raises(KeyError):
+        ds(datetime(2024, 6, 1, 12), ["invalid_variable"])
+
+    with pytest.raises(KeyError):
+        ds(
+            datetime(2024, 6, 1, 12),
+            ["atms"],
+            fields=["observation", "variable", "invalid_field"],
+        )
+
+    invalid_schema = pa.schema(
+        [
+            pa.field("observation", pa.float32()),
+            pa.field("variable", pa.string()),
+            pa.field("nonexistent", pa.float32()),
+        ]
+    )
+    with pytest.raises(KeyError):
+        ds(datetime(2024, 6, 1, 12), ["atms"], fields=invalid_schema)
+
+    wrong_type_schema = pa.schema(
+        [
+            pa.field("observation", pa.float32()),
+            pa.field("variable", pa.string()),
+            pa.field("time", pa.string()),
+        ]
+    )
+    with pytest.raises(TypeError):
+        ds(datetime(2024, 6, 1, 12), ["atms"], fields=wrong_type_schema)
+
+
+def test_jpss_atms_tolerance_conversion():
+    ds_td = JPSS_ATMS(time_tolerance=timedelta(minutes=30), cache=False, verbose=False)
+    assert ds_td._tolerance_lower == timedelta(minutes=-30)
+    assert ds_td._tolerance_upper == timedelta(minutes=30)
+
+    ds_np = JPSS_ATMS(
+        time_tolerance=np.timedelta64(30, "m"), cache=False, verbose=False
+    )
+    assert ds_np._tolerance_lower == timedelta(minutes=-30)
+    assert ds_np._tolerance_upper == timedelta(minutes=30)
+
+    ds_asym = JPSS_ATMS(
+        time_tolerance=(np.timedelta64(-10, "m"), np.timedelta64(60, "m")),
+        cache=False,
+        verbose=False,
+    )
+    assert ds_asym._tolerance_lower == timedelta(minutes=-10)
+    assert ds_asym._tolerance_upper == timedelta(minutes=60)
+
+
+def test_jpss_atms_parse_filename():
+    # Valid filename
+    t = JPSS_ATMS._parse_filename_time(
+        "ATMS_v1r0_j01_s20240601120000_e20240601120100_c20240601130000.bufr"
+    )
+    assert t == datetime(2024, 6, 1, 12, 0, 0)
+
+    # Invalid filename
+    assert JPSS_ATMS._parse_filename_time("random_file.bufr") is None
+
+    # Truncated timestamp
+    assert JPSS_ATMS._parse_filename_time("ATMS_v1r0_j01_s2024.bufr") is None


### PR DESCRIPTION
## Summary

Add `JPSS_ATMS` DataFrameSource that fetches ATMS (Advanced Technology Microwave Sounder) brightness temperature observations from NOAA JPSS public S3 buckets (`noaa-nesdis-n20-pds`, `noaa-nesdis-n21-pds`, `noaa-nesdis-snpp-pds`).

- Supports **NOAA-20, NOAA-21, and Suomi NPP** satellites with **22 microwave channels** (23–183 GHz)
- Decodes Level 1 BUFR files using `eccodes` (already in `data` extras)
- Outputs long-format DataFrame with per-FOV lat/lon, satellite geometry angles, per-channel quality flags, and brightness temperature observations
- Configurable time tolerance, multi-satellite querying, and async S3 access with retry

## Changes

### New files
| File | Description |
|---|---|
| `earth2studio/data/jpss_atms.py` | `JPSS_ATMS` DataFrameSource (~738 lines) |
| `test/data/test_jpss_atms.py` | 14 unit tests (7 offline, 7 network/xfail) |

### Modified files
| File | Change |
|---|---|
| `earth2studio/lexicon/jpss.py` | Added `JPSSATMSLexicon` class with channel frequency constants |
| `earth2studio/lexicon/base.py` | Added `"atms"` to `E2STUDIO_VOCAB`, `"channel_quality_flag"` (uint16) to `E2STUDIO_SCHEMA` |
| `earth2studio/lexicon/__init__.py` | Registered `JPSSATMSLexicon` export |
| `earth2studio/data/__init__.py` | Registered `JPSS_ATMS` export |
| `docs/modules/datasources_dataframe.rst` | Added `data.JPSS_ATMS` to autosummary |
| `CHANGELOG.md` | Added entries under 0.14.0a0 |

## Usage

```python
from earth2studio.data import JPSS_ATMS
from datetime import datetime, timedelta

ds = JPSS_ATMS(
    satellites=["n20"],                    # n20, n21, npp (None = all)
    time_tolerance=timedelta(minutes=30),  # ±30min window
)
df = ds(datetime(2024, 1, 15), "atms")
# DataFrame columns: time, lat, lon, scan_angle, channel_index,
#   solza, solaza, satellite_za, satellite_aza, satellite,
#   channel_quality_flag, observation, variable
```

## Testing

- 7 offline tests pass (mock BUFR decode, validation, parsing)
- 7 network tests marked `@pytest.mark.slow` + `@pytest.mark.xfail`
- Validated against real S3 data: 113 BUFR files decoded, 2.84M rows, BT [134–293K]
- Cross-validated against `UFSObsSat` ATMS output — consistent BT means

## Dependencies

No new dependencies — `eccodes` is already in the `data` extras group.