### PR TITLE
Fixing doc code links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed source code links in documentation
+
 ### Security
 
 ### Dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import inspect
 import logging
 import os
 import pathlib
@@ -57,10 +58,77 @@ author = "NVIDIA"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+
+def linkcode_resolve(domain, info):
+    """Determine a GitHub URL corresponding to a Python object.
+
+    Used by sphinx.ext.linkcode to generate [source] links that point directly
+    to the source on GitHub instead of local _modules/ pages.
+
+    Based on the common pattern used by NumPy, SciPy, and scikit-learn.
+    See: https://github.com/scikit-learn/scikit-learn/blob/main/doc/sphinxext/github_link.py
+    """
+    if domain != "py":
+        return None
+
+    modname = info.get("module")
+    fullname = info.get("fullname")
+    if not modname or not fullname:
+        return None
+
+    # Import the module and resolve the object
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return None
+
+    # Unwrap decorated objects to get the original source
+    try:
+        obj = inspect.unwrap(obj)
+    except ValueError:
+        pass
+
+    # Get the source file
+    try:
+        fn = inspect.getsourcefile(obj)
+    except TypeError:
+        fn = None
+    if not fn:
+        return None
+
+    # Only link to files within the earth2studio package
+    import earth2studio
+
+    try:
+        fn = os.path.relpath(fn, start=os.path.dirname(earth2studio.__file__))
+    except ValueError:
+        return None
+    if fn.startswith(".."):
+        return None
+
+    # Get line number range
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
+    except (OSError, TypeError):
+        linespec = ""
+
+    return (
+        f"https://github.com/NVIDIA/earth2studio/blob/{doc_version}/"
+        f"earth2studio/{fn}{linespec}"
+    )
+
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.autosummary",
     "sphinx_favicon",
     "myst_parser",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ def linkcode_resolve(domain, info):
 
     return (
         f"https://github.com/NVIDIA/earth2studio/blob/{doc_version}/"
-        f"earth2studio/{fn}{linespec}"
+        f"earth2studio/{fn.replace(os.sep, '/')}{linespec}"
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Don't how to prove this works other than saying it runs locally. Basically just had claude look at these other repos.

## Summary

Switch Sphinx [source] links from viewcode to linkcode, linking directly to GitHub source instead of generated _modules/ pages.

## Problem

The [source] links on all API documentation pages have been broken since the docs were first deployed. The sphinx.ext.viewcode extension generates highlighted source pages under _modules/earth2studio/, but the CI deploy pipeline never copies that directory to the gh-pages branch on NVIDIA/earth2studio. I didnt like having separate source pages anyway.

Closes: https://github.com/NVIDIA/earth2studio/issues/816

## Change

Replace sphinx.ext.viewcode with sphinx.ext.linkcode and add a linkcode_resolve function that generates GitHub URLs directly (e.g. https://github.com/NVIDIA/earth2studio/blob/main/earth2studio/data/gfs.py#L42-L150). This eliminates the _modules/ directory entirely, sidestepping the deploy issue.
The linkcode_resolve implementation follows the standard pattern used by NumPy, SciPy, and scikit-learn — resolving Python objects to source files and line numbers via inspect.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
