### PR TITLE
[Chore 729] Remove legacy infer req flows from cpu_worker.

### DIFF
--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -136,8 +136,8 @@ class ResultMetadata:
     status: str
     completion_time: str | None
     execution_time_seconds: float | None
-    workflow_type: str | None = None  # For legacy inference requests
-    workflow_name: str | None = None  # For custom workflows
+    workflow_type: str | None = None
+    workflow_name: str | None = None
     created_at: str | None = None
     peak_memory_usage: str | None = None
     device: str | None = None
@@ -157,17 +157,23 @@ class ResultMetadata:
         file_manifest: list[FileManifestEntry],
         zip_created_at: str,
     ) -> "ResultMetadata":
-        """
-        Create ResultMetadata from a WorkflowResult (custom workflows).
+        """Create ResultMetadata from a WorkflowResult.
 
-        Args:
-            workflow_result: WorkflowResult instance from custom workflow
-            request_id: Request ID (execution_id from workflow)
-            file_manifest: List of files in the zip
-            zip_created_at: Timestamp when zip was created
+        Parameters
+        ----------
+        workflow_result : WorkflowResult
+            WorkflowResult instance from workflow execution.
+        request_id : str
+            Fallback request ID (used if execution_id is not set).
+        file_manifest : list[FileManifestEntry]
+            List of files in the zip.
+        zip_created_at : str
+            ISO timestamp when zip was created.
 
-        Returns:
-            ResultMetadata instance
+        Returns
+        -------
+        ResultMetadata
+            Populated metadata instance.
         """
         workflow_metadata = workflow_result.metadata or {}
         return cls(
@@ -181,40 +187,6 @@ class ResultMetadata:
             device=workflow_metadata.get("device"),
             zip_created_at=zip_created_at,
             parameters=workflow_metadata.get("parameters"),
-            output_files=file_manifest,
-        )
-
-    @classmethod
-    def from_legacy_dict(
-        cls,
-        inference_request: dict[str, Any],
-        request_id: str,
-        file_manifest: list[FileManifestEntry],
-        zip_created_at: str,
-    ) -> "ResultMetadata":
-        """
-        Create ResultMetadata from a legacy inference request dict.
-
-        Args:
-            inference_request: Legacy inference request dictionary
-            request_id: Request ID
-            file_manifest: List of files in the zip
-            zip_created_at: Timestamp when zip was created
-
-        Returns:
-            ResultMetadata instance
-        """
-        return cls(
-            request_id=request_id,
-            status=inference_request.get("status", "completed"),
-            completion_time=inference_request.get("completion_time"),
-            execution_time_seconds=inference_request.get("execution_time_seconds"),
-            workflow_type=inference_request.get("type"),
-            created_at=inference_request.get("created_at"),
-            peak_memory_usage=inference_request.get("peak_memory_usage"),
-            device=inference_request.get("device"),
-            zip_created_at=zip_created_at,
-            parameters=inference_request.get("request"),
             output_files=file_manifest,
         )
 
@@ -296,20 +268,27 @@ def build_file_manifest(
 def create_results_zip(
     request_id: str,
     output_path: Path,
-    inference_request: dict[str, Any] | WorkflowResult,
+    inference_request: WorkflowResult,
     results_zip_dir: Path,
     redis_client: redis.Redis,
     create_zip: bool = True,
 ) -> str | None:
-    """Create zip file containing inference results and store it in the results directory
+    """Create zip file containing inference results and store it in the results directory.
 
-    Args:
-        request_id: Request ID (for legacy) or execution_id (for custom workflows)
-        output_path: Path to output files
-        inference_request: Dict containing request data (legacy) or WorkflowResult (for custom workflows)
-        results_zip_dir: Directory to store result zips
-        redis_client: Redis client instance
-        create_zip: If False, only build file manifest without creating zip file
+    Parameters
+    ----------
+    request_id : str
+        Execution ID for the workflow run.
+    output_path : Path
+        Path to output files.
+    inference_request : WorkflowResult
+        WorkflowResult instance from the completed workflow execution.
+    results_zip_dir : Path
+        Directory to store result zips.
+    redis_client : redis.Redis
+        Redis client instance.
+    create_zip : bool, optional
+        If False, only build file manifest without creating zip file, by default True
     """
     # Create logger adapter with execution_id for automatic log prefixing
     log = logging.LoggerAdapter(logger, {"execution_id": request_id})
@@ -370,29 +349,14 @@ def create_results_zip(
             )
             zip_filename = None  # No zip file created
 
-        # Create metadata using factory methods
         zip_created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
-        if isinstance(inference_request, WorkflowResult):
-            # Custom workflow (WorkflowResult)
-            metadata = ResultMetadata.from_workflow_result(
-                workflow_result=inference_request,
-                request_id=request_id,
-                file_manifest=file_manifest,
-                zip_created_at=zip_created_at,
-            )
-        elif isinstance(inference_request, dict):
-            # Legacy inference request (dict)
-            metadata = ResultMetadata.from_legacy_dict(
-                inference_request=inference_request,
-                request_id=request_id,
-                file_manifest=file_manifest,
-                zip_created_at=zip_created_at,
-            )
-        else:
-            raise TypeError(
-                f"inference_request must be Dict or WorkflowResult, got {type(inference_request)}"
-            )
+        metadata = ResultMetadata.from_workflow_result(
+            workflow_result=inference_request,
+            request_id=request_id,
+            file_manifest=file_manifest,
+            zip_created_at=zip_created_at,
+        )
 
         # Store metadata in Redis for the object storage worker to finalize
         metadata_key = get_inference_request_metadata_key(request_id)

--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -136,7 +136,7 @@ class ResultMetadata:
     status: str
     completion_time: str | None
     execution_time_seconds: float | None
-    workflow_type: str | None = None
+    workflow_name: str | None = None
     workflow_name: str | None = None
     created_at: str | None = None
     peak_memory_usage: str | None = None

--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -136,7 +136,7 @@ class ResultMetadata:
     status: str
     completion_time: str | None
     execution_time_seconds: float | None
-    workflow_name: str | None = None
+    workflow_type: str | None = None
     workflow_name: str | None = None
     created_at: str | None = None
     peak_memory_usage: str | None = None

--- a/test/serve/server/test_server_cpu_worker.py
+++ b/test/serve/server/test_server_cpu_worker.py
@@ -184,25 +184,26 @@ class TestCreateResultsZip:
 
     @pytest.fixture
     def inference_request(self):
-        """Sample inference request data"""
-        return {
-            "id": "test_req_123",
-            "type": "deterministic",
-            "status": "completed",
-            "completion_time": "2024-01-01T12:00:00Z",
-            "execution_time_seconds": 45.5,
-            "created_at": "2024-01-01T11:00:00Z",
-            "peak_memory_usage": "2.5GB",
-            "device": "cuda:0",
-            "request": {
-                "workflow_type": "deterministic",
-                "time": "2024-01-01T00:00:00Z",
-                "nsteps": 10,
-                "prognostic": {"model_type": "fcn"},
-                "data": {"source_type": "gfs"},
-                "io": {"backend_type": "zarr"},
+        return WorkflowResult(
+            workflow_name="deterministic",
+            execution_id="test_req_123",
+            status="completed",
+            start_time="2024-01-01T11:00:00Z",
+            end_time="2024-01-01T12:00:00Z",
+            execution_time_seconds=45.5,
+            metadata={
+                "peak_memory_usage": "2.5GB",
+                "device": "cuda:0",
+                "parameters": {
+                    "workflow_type": "deterministic",
+                    "time": "2024-01-01T00:00:00Z",
+                    "nsteps": 10,
+                    "prognostic": {"model_type": "fcn"},
+                    "data": {"source_type": "gfs"},
+                    "io": {"backend_type": "zarr"},
+                },
             },
-        }
+        )
 
     def test_create_results_zip_with_single_file(
         self, mock_redis, inference_request, tmp_path
@@ -267,14 +268,14 @@ class TestCreateResultsZip:
         # Verify metadata structure
         assert metadata["request_id"] == "test_req_123"
         assert metadata["status"] == "completed"
-        assert metadata["workflow_type"] == "deterministic"
+        assert metadata["workflow_name"] == "deterministic"
         assert metadata["execution_time_seconds"] == 45.5
         assert metadata["device"] == "cuda:0"
         assert "zip_created_at" in metadata
 
         # Verify parameters field
         assert "parameters" in metadata
-        assert metadata["parameters"] == inference_request["request"]
+        assert metadata["parameters"] == inference_request.metadata["parameters"]
         assert metadata["parameters"]["workflow_type"] == "deterministic"
         assert metadata["parameters"]["nsteps"] == 10
 
@@ -416,47 +417,48 @@ class TestCreateResultsZip:
         assert len(metadata["output_files"]) == 1  # Only zip entry
         assert metadata["output_files"][0]["path"] == "test_req_789"
 
-    def test_create_results_zip_parameters_validation(
-        self, mock_redis, inference_request, tmp_path
-    ):
-        """Test that parameters are correctly stored in metadata"""
-        # Create a temporary output file
+    def test_create_results_zip_parameters_validation(self, mock_redis, tmp_path):
         output_file = tmp_path / "output.nc"
         output_file.write_text("test")
 
-        # Create results directory
         results_zip_dir = tmp_path / "results"
         results_zip_dir.mkdir()
 
-        # Modify inference request to have specific parameters
-        inference_request["request"] = {
-            "workflow_type": "ensemble",
-            "time": "2024-01-15T00:00:00Z",
-            "nsteps": 20,
-            "nensemble": 10,
-            "prognostic": {"model_type": "graphcast"},
-            "data": {"source_type": "era5"},
-            "io": {"backend_type": "netcdf"},
-            "perturbation": {"method": "spherical_gaussian"},
-        }
+        workflow_result = WorkflowResult(
+            workflow_name="ensemble",
+            execution_id="test_req_params",
+            status="completed",
+            start_time="2024-01-15T00:00:00Z",
+            end_time="2024-01-15T01:00:00Z",
+            execution_time_seconds=60.0,
+            metadata={
+                "parameters": {
+                    "workflow_type": "ensemble",
+                    "time": "2024-01-15T00:00:00Z",
+                    "nsteps": 20,
+                    "nensemble": 10,
+                    "prognostic": {"model_type": "graphcast"},
+                    "data": {"source_type": "era5"},
+                    "io": {"backend_type": "netcdf"},
+                    "perturbation": {"method": "spherical_gaussian"},
+                },
+            },
+        )
 
-        # Call create_results_zip
         result = create_results_zip(
             request_id="test_req_params",
             output_path=output_file,
-            inference_request=inference_request,
+            inference_request=workflow_result,
             results_zip_dir=results_zip_dir,
             redis_client=mock_redis,
         )
         assert result is not None
 
-        # Verify metadata is stored in Redis (not as file)
         assert mock_redis.setex.call_count == 4
         calls = mock_redis.setex.call_args_list
         metadata_json = calls[0][0][2]
         metadata = json.loads(metadata_json)
 
-        # Verify parameters field exists and matches
         assert "parameters" in metadata
         params = metadata["parameters"]
 
@@ -537,41 +539,37 @@ class TestCreateResultsZip:
                 assert entry["size"] == actual_size
 
     def test_create_results_zip_missing_request_parameters(self, mock_redis, tmp_path):
-        """Test handling when request doesn't have parameters field"""
-        # Create inference request without 'request' field
-        inference_request = {
-            "id": "test_req_no_params",
-            "type": "deterministic",
-            "status": "completed",
-        }
+        workflow_result = WorkflowResult(
+            workflow_name="deterministic",
+            execution_id="test_req_no_params",
+            status="completed",
+            start_time="2024-01-01T10:00:00Z",
+            end_time="2024-01-01T11:00:00Z",
+            execution_time_seconds=60.0,
+            metadata=None,
+        )
 
-        # Create output file
         output_file = tmp_path / "output.nc"
         output_file.write_text("test")
 
-        # Create results directory
         results_zip_dir = tmp_path / "results"
         results_zip_dir.mkdir()
 
-        # Call create_results_zip
         zip_filename = create_results_zip(
             request_id="test_req_no_params",
             output_path=output_file,
-            inference_request=inference_request,
+            inference_request=workflow_result,
             results_zip_dir=results_zip_dir,
             redis_client=mock_redis,
         )
 
-        # Verify zip was created
         assert zip_filename is not None
 
-        # Verify metadata stored in Redis - parameters should be None
         assert mock_redis.setex.call_count == 4
         calls = mock_redis.setex.call_args_list
         metadata_json = calls[0][0][2]
         metadata = json.loads(metadata_json)
 
-        # Parameters should be None or not present
         assert metadata.get("parameters") is None
 
     def test_create_results_zip_redis_failure(
@@ -661,7 +659,7 @@ class TestCreateResultsZip:
             "status",
             "completion_time",
             "execution_time_seconds",
-            "workflow_type",
+            "workflow_name",
             "created_at",
             "peak_memory_usage",
             "device",
@@ -836,7 +834,7 @@ class TestCreateResultsZip:
         result = create_results_zip(
             request_id="req_invalid",
             output_path=output_file,
-            inference_request=[],  # list is not dict or WorkflowResult
+            inference_request=[],  # invalid type, not WorkflowResult
             results_zip_dir=results_zip_dir,
             redis_client=mock_redis,
         )
@@ -952,24 +950,6 @@ class TestResultMetadata:
         assert meta.parameters == {"n": 1}
         assert meta.output_files == manifest
 
-    def test_from_legacy_dict(self):
-        """ResultMetadata.from_legacy_dict sets workflow_type from dict."""
-        req = {
-            "status": "completed",
-            "completion_time": "2024-01-01T11:00:00Z",
-            "execution_time_seconds": 10.0,
-            "type": "deterministic",
-            "created_at": "2024-01-01T10:00:00Z",
-            "request": {"nsteps": 5},
-        }
-        manifest = [FileManifestEntry(path="out.zarr", size=200)]
-        meta = ResultMetadata.from_legacy_dict(
-            req, "req_123", manifest, "2024-01-01T12:00:00Z"
-        )
-        assert meta.request_id == "req_123"
-        assert meta.workflow_type == "deterministic"
-        assert meta.parameters == {"nsteps": 5}
-
     def test_to_dict_includes_workflow_name_and_type(self):
         """to_dict includes workflow_name or workflow_type when set."""
         meta = ResultMetadata(
@@ -1024,11 +1004,14 @@ class TestProcessResultZip:
         results_zip_dir.mkdir()
 
         mock_workflow_class = Mock()
-        mock_workflow_class._get_execution_data.return_value = {
-            "id": "wf:exec_1",
-            "type": "deterministic",
-            "status": "completed",
-        }
+        mock_workflow_class._get_execution_data.return_value = WorkflowResult(
+            workflow_name="test_wf",
+            execution_id="exec_1",
+            status="completed",
+            start_time="2024-01-01T10:00:00Z",
+            end_time="2024-01-01T11:00:00Z",
+            execution_time_seconds=60.0,
+        )
         mock_workflow_class._update_execution_data = Mock()
 
         with patch(
@@ -1090,10 +1073,14 @@ class TestProcessResultZip:
         results_zip_dir.mkdir()
 
         mock_workflow_class = Mock()
-        mock_workflow_class._get_execution_data.return_value = {
-            "type": "deterministic",
-            "status": "completed",
-        }
+        mock_workflow_class._get_execution_data.return_value = WorkflowResult(
+            workflow_name="test_wf",
+            execution_id="exec_1",
+            status="completed",
+            start_time="2024-01-01T10:00:00Z",
+            end_time="2024-01-01T11:00:00Z",
+            execution_time_seconds=60.0,
+        )
 
         with patch(
             "earth2studio.serve.server.cpu_worker.workflow_registry"
@@ -1133,10 +1120,14 @@ class TestProcessResultZip:
         results_zip_dir.mkdir()
 
         mock_workflow_class = Mock()
-        mock_workflow_class._get_execution_data.return_value = {
-            "type": "deterministic",
-            "status": "completed",
-        }
+        mock_workflow_class._get_execution_data.return_value = WorkflowResult(
+            workflow_name="test_wf",
+            execution_id="exec_1",
+            status="completed",
+            start_time="2024-01-01T10:00:00Z",
+            end_time="2024-01-01T11:00:00Z",
+            execution_time_seconds=60.0,
+        )
 
         with patch(
             "earth2studio.serve.server.cpu_worker.workflow_registry"
@@ -1165,14 +1156,17 @@ class TestProcessResultZip:
         """When create_results_zip returns None (create_zip=True), fail_workflow and return None."""
         results_zip_dir = tmp_path / "results"
         results_zip_dir.mkdir()
-        # Nonexistent output path so create_results_zip may still build manifest but we can mock return
         output_path_str = str(tmp_path / "nonexistent")
 
         mock_workflow_class = Mock()
-        mock_workflow_class._get_execution_data.return_value = {
-            "type": "deterministic",
-            "status": "completed",
-        }
+        mock_workflow_class._get_execution_data.return_value = WorkflowResult(
+            workflow_name="test_wf",
+            execution_id="exec_1",
+            status="completed",
+            start_time="2024-01-01T10:00:00Z",
+            end_time="2024-01-01T11:00:00Z",
+            execution_time_seconds=60.0,
+        )
 
         with patch(
             "earth2studio.serve.server.cpu_worker.workflow_registry"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Completes one item in Chore 729.
- cpu_worker.py: Legacy infer request cleanup 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
