### PR TITLE
Update README latest news and add region badges to docs

### DIFF
--- a/.claude/skills/release-rebase/SKILL.md
+++ b/.claude/skills/release-rebase/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: release-rebase
-description: Prepare a new minor alpha release of Earth2Studio by rebasing the release candidate branch onto main, bumping the version, updating the changelog, stripping example version tags, and pushing for PR. Use this skill whenever the user mentions releasing, cutting a release, preparing a release branch, rebasing a release, bumping the version for a new development cycle, or running the release process. Also trigger when the user references "release-rebase" or asks about the release workflow.
+description: Prepare a new minor alpha release of Earth2Studio by rebasing the release candidate branch onto main, bumping the version, updating the changelog, updating the README latest-news highlights, stripping example version tags, and pushing for PR. Use this skill whenever the user mentions releasing, cutting a release, preparing a release branch, rebasing a release, bumping the version for a new development cycle, or running the release process. Also trigger when the user references "release-rebase" or asks about the release workflow.
 ---
 
 # Release Rebase — Prepare New Minor Alpha Release
 
 Prepare a new minor alpha release of Earth2Studio by rebasing the release
 candidate branch onto main, bumping the version, updating the changelog,
-stripping pinned version tags from examples, and pushing a PR branch.
+updating the README latest-news highlights, stripping pinned version tags
+from examples, and pushing a PR branch.
 
 Follow every step below **in order**. Each step that requires user input is
 marked with a confirmation gate — wait for explicit approval before proceeding.
@@ -149,7 +150,33 @@ look correct.
 
 ---
 
-## Step 6 — Commit and Push
+## Step 6 — Update README Latest News
+
+Update the "Latest News" section in `README.md` with highlights from the
+**released** version's CHANGELOG entry (the section just below the new blank
+development section added in Step 3).
+
+1. Read `CHANGELOG.md` and identify the 3–5 most notable items from the
+   released version's `### Added` subsection. Prefer items that introduce new
+   model classes, new data sources, or significant new capabilities.
+2. Read the current `## Latest News` section in `README.md`.
+3. Replace the existing bullet points (between the `> [!NOTE]` block and the
+   "For a complete list…" line) with new bullets summarising the highlights.
+   Follow the existing style:
+   - Each bullet starts with a bold linked feature name (where a docs link
+     exists) followed by a comma and a short description.
+   - Keep the `> [!NOTE]` version callout and update it to reference the new
+     released version number if it changed.
+4. Show the diff to the user for review.
+
+### **[CONFIRM — README]**
+
+Print the updated Latest News section and ask the user to confirm before
+proceeding.
+
+---
+
+## Step 7 — Commit and Push
 
 Stage only the expected files and commit:
 
@@ -157,6 +184,7 @@ Stage only the expected files and commit:
 git add CHANGELOG.md
 git add earth2studio/__init__.py
 git add examples/
+git add README.md
 git commit -m "Update version to X.(Y+1).0a0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,20 @@ run(["2025-01-01T00:00:00"], 4, model, data, io)
 > [!NOTE]
 > As of version `0.14.0`, Earth2Studio TOML default installs now target CUDA 13.
 
-- [**StormCast SDA**](https://nvidia.github.io/earth2studio/modules/generated/models/da/earth2studio.models.da.StormCastSDA.html),
-    score-based data assimilation (SDA) combined with StormCast for high-resolution
-    regional weather prediction, is now available alongside new data assimilation
-    model utilities.
+- [**GenCast Mini**](https://nvidia.github.io/earth2studio/modules/generated/models/px/earth2studio.models.px.GenCast.html),
+    Google DeepMind's 1-degree ensemble diffusion weather model, is now available as a
+    prognostic model.
+- [**CAMS Global Forecast**](https://nvidia.github.io/earth2studio/modules/datasources_forecast.html),
+    Copernicus Atmosphere Monitoring Service global atmospheric composition forecasts
+    are now accessible via the new `CAMS_FX` forecast data source.
+- **Satellite Level-1 Data Sources**, six new satellite brightness-temperature and
+    radiance data sources added: MetOp AMSU-A, MetOp AVHRR, JPSS ATMS, JPSS CrIS,
+    MetOp IASI, and [Meteosat FCI](https://nvidia.github.io/earth2studio/modules/datasources_dataframe.html).
+- [**NClimGrid Daily**](https://nvidia.github.io/earth2studio/modules/datasources_analysis.html),
+    NOAA daily gridded climate observations for the contiguous US now available as a
+    data source.
 - **Data Assimilation Models**, a new model class for data assimilation including
     equirectangular interpolation and [HealDA](https://nvidia.github.io/earth2studio/examples/05_data_assimilation/02_healda.html).
-- [**NOAA UFS Observation Data Sources**](https://nvidia.github.io/earth2studio/modules/datasources_dataframe.html),
-    for satellite and conventional observation dataframes now available with the new
-    Earth2Studio base schema.
-- [**Planetary Computer Data Sources**](https://nvidia.github.io/earth2studio/modules/datasources_analysis.html)
-    added for ECMWF IFS analysis data and GOES cloud and moisture imagery.
 
 For a complete list of latest features and improvements see the [changelog](./CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ run(["2025-01-01T00:00:00"], 4, model, data, io)
 > [!NOTE]
 > As of version `0.14.0`, Earth2Studio TOML default installs now target CUDA 13.
 
-- [**GenCast Mini**](https://nvidia.github.io/earth2studio/modules/generated/models/px/earth2studio.models.px.GenCast.html),
+- [**GenCast Mini**](https://nvidia.github.io/earth2studio/modules/generated/models/px/earth2studio.models.px.GenCastMini.html),
     Google DeepMind's 1-degree ensemble diffusion weather model, is now available as a
     prognostic model.
-- [**CAMS Global Forecast**](https://nvidia.github.io/earth2studio/modules/datasources_forecast.html),
+- [**CAMS Global Forecast**](https://nvidia.github.io/earth2studio/modules/generated/data/earth2studio.data.CAMS_FX.html#earth2studio.data.CAMS_FX),
     Copernicus Atmosphere Monitoring Service global atmospheric composition forecasts
     are now accessible via the new `CAMS_FX` forecast data source.
 - **Satellite Level-1 Data Sources**, six new satellite brightness-temperature and

--- a/docs/modules/datasources_analysis.rst
+++ b/docs/modules/datasources_analysis.rst
@@ -19,7 +19,7 @@ Used for fetching initial conditions for inference and validation data for scori
 
 .. currentmodule:: earth2studio
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    dataclass:analysis dataclass:reanalysis dataclass:observation dataclass:simulation
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    :filter-mode: or
@@ -71,7 +71,7 @@ for subsequent predictions.
 
 .. currentmodule:: earth2studio
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    dataclass:analysis dataclass:reanalysis dataclass:observation dataclass:simulation
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    :filter-mode: or

--- a/docs/modules/datasources_dataframe.rst
+++ b/docs/modules/datasources_dataframe.rst
@@ -7,7 +7,7 @@ Data sources that provide tabular data as DataFrames.
 
 .. currentmodule:: earth2studio
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    dataclass:analysis dataclass:reanalysis dataclass:observation dataclass:simulation
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    :filter-mode: or

--- a/docs/modules/datasources_forecast.rst
+++ b/docs/modules/datasources_forecast.rst
@@ -9,7 +9,7 @@ Typically used in intercomparison workflows.
 
 .. currentmodule:: earth2studio
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    dataclass:analysis dataclass:reanalysis dataclass:observation dataclass:simulation
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    :filter-mode: or

--- a/docs/modules/models_da.rst
+++ b/docs/modules/models_da.rst
@@ -21,7 +21,7 @@ to process observations independently or maintain internal state across time ste
 
 .. currentmodule:: earth2studio.models.da
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    class:nwc class:ds class:mrf class:s2s class:da class:cm
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    year:2021 year:2022 year:2023 year:2024 year:2025 year:2026

--- a/docs/modules/models_dx.rst
+++ b/docs/modules/models_dx.rst
@@ -20,7 +20,7 @@ etc.
 
 .. currentmodule:: earth2studio.models.dx
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    class:nwc class:ds class:mrf class:s2s class:da class:cm
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    year:2021 year:2022 year:2023 year:2024 year:2025 year:2026

--- a/docs/modules/models_px.rst
+++ b/docs/modules/models_px.rst
@@ -18,7 +18,7 @@ Thus are typically used to generate forecast predictions.
 
 .. currentmodule:: earth2studio.models.px
 
-.. badge-filter:: region:global region:na region:as
+.. badge-filter:: region:global region:na region:eu region:as region:au region:af region:sa
    class:nwc class:ds class:mrf class:s2s class:da class:cm
    product:wind product:precip product:temp product:atmos product:ocean product:land product:veg product:solar product:radar product:sat product:insitu
    year:2021 year:2022 year:2023 year:2024 year:2025 year:2026


### PR DESCRIPTION
## Summary

- Updated the README "Latest News" section with highlights from the 0.14.0 release (GenCast Mini, CAMS Global Forecast, satellite L1 data sources, NClimGrid Daily).
- Added all region badge filters (`region:eu`, `region:au`, `region:af`, `region:sa`) to badge-filter directives across all 6 docs rst files (datasources + models) with consistent ordering: `global > na > eu > as > au > af > sa`.
- Added a new **Step 6 — Update README Latest News** to the `release-rebase` skill so this becomes part of the standard release workflow.