### PR TITLE
Move Redis and queue globals to app.state

### DIFF
--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import logging
 import zipfile
@@ -35,7 +37,7 @@ except ImportError:
 
 # Import configuration
 from earth2studio.serve.server.config import get_config, get_config_manager
-from earth2studio.serve.server.redis_factory import create_sync_redis_client
+from earth2studio.serve.server.redis_factory import get_worker_redis_client
 from earth2studio.serve.server.utils import (
     get_inference_request_metadata_key,
     get_inference_request_output_path_key,
@@ -59,23 +61,11 @@ config_manager = get_config_manager()
 config_manager.setup_logging()
 logger = logging.getLogger(__name__)
 
-# Lazily-initialized module-level Redis client for the CPU worker process.
-_redis_client: redis.Redis | None = None
-
-
-def _get_redis_client() -> redis.Redis:
-    """Return the CPU worker-process Redis client, creating it on first call."""
-    global _redis_client
-    if _redis_client is None:
-        _redis_client = create_sync_redis_client()
-    return _redis_client
-
-
 # Register custom workflows in the CPU worker process
 try:
     from earth2studio.serve.server.workflow import register_all_workflows
 
-    register_all_workflows(_get_redis_client())
+    register_all_workflows(get_worker_redis_client())
     logger.info("Custom workflows registered successfully in CPU worker process")
 except ImportError:
     logger.warning(
@@ -114,7 +104,7 @@ def fail_workflow(
                 "error_message": error_message,
             }
             workflow_class._update_execution_data(
-                _get_redis_client(), workflow_name, execution_id, updates
+                get_worker_redis_client(), workflow_name, execution_id, updates
             )
     except Exception:
         logger.exception("Failed to update workflow status")
@@ -157,7 +147,7 @@ class ResultMetadata:
         request_id: str,
         file_manifest: list[FileManifestEntry],
         zip_created_at: str,
-    ) -> "ResultMetadata":
+    ) -> ResultMetadata:
         """Create ResultMetadata from a WorkflowResult.
 
         Parameters
@@ -428,7 +418,7 @@ def process_result_zip(
             raise ValueError(f"Workflow '{workflow_name}' not found in registry")
 
         # Get execution data from Redis for metadata
-        rc = _get_redis_client()
+        rc = get_worker_redis_client()
         execution_data = workflow_class._get_execution_data(
             rc, workflow_name, execution_id
         )
@@ -541,7 +531,7 @@ def process_object_storage_upload(
     """
     output_path = Path(output_path_str)
     request_id = f"{workflow_name}:{execution_id}"
-    rc = _get_redis_client()
+    rc = get_worker_redis_client()
 
     logger.info(f"Processing object storage worker for {request_id}")
 
@@ -874,7 +864,7 @@ def process_finalize_metadata(
     """
 
     request_id = f"{workflow_name}:{execution_id}"
-    rc = _get_redis_client()
+    rc = get_worker_redis_client()
     logger.info(f"Processing finalize metadata for {request_id}")
 
     # Retrieve pending metadata and storage info from Redis
@@ -946,9 +936,7 @@ def process_finalize_metadata(
             "status": WorkflowStatus.COMPLETED,
             "end_time": datetime.now(timezone.utc).isoformat(),
         }
-        workflow_class._update_execution_data(
-            rc, workflow_name, execution_id, updates
-        )
+        workflow_class._update_execution_data(rc, workflow_name, execution_id, updates)
         logger.info(
             f"Workflow {workflow_name} execution {execution_id} status set to COMPLETED"
         )

--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -35,6 +35,7 @@ except ImportError:
 
 # Import configuration
 from earth2studio.serve.server.config import get_config, get_config_manager
+from earth2studio.serve.server.redis_factory import create_sync_redis_client
 from earth2studio.serve.server.utils import (
     get_inference_request_metadata_key,
     get_inference_request_output_path_key,
@@ -58,22 +59,23 @@ config_manager = get_config_manager()
 config_manager.setup_logging()
 logger = logging.getLogger(__name__)
 
-# Redis client for CPU worker
-redis_client = redis.Redis(
-    host=config.redis.host,
-    port=config.redis.port,
-    db=config.redis.db,
-    password=config.redis.password,
-    decode_responses=config.redis.decode_responses,
-    socket_connect_timeout=config.redis.socket_connect_timeout,
-    socket_timeout=config.redis.socket_timeout,
-)
+# Lazily-initialized module-level Redis client for the CPU worker process.
+_redis_client: redis.Redis | None = None
+
+
+def _get_redis_client() -> redis.Redis:
+    """Return the CPU worker-process Redis client, creating it on first call."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = create_sync_redis_client()
+    return _redis_client
+
 
 # Register custom workflows in the CPU worker process
 try:
     from earth2studio.serve.server.workflow import register_all_workflows
 
-    register_all_workflows(redis_client)
+    register_all_workflows(_get_redis_client())
     logger.info("Custom workflows registered successfully in CPU worker process")
 except ImportError:
     logger.warning(
@@ -81,7 +83,6 @@ except ImportError:
     )
 except Exception as e:
     logger.error(f"Failed to register custom workflows in CPU worker: {e}")
-    # Don't raise - worker can still handle other tasks
 
 
 def fail_workflow(
@@ -113,7 +114,7 @@ def fail_workflow(
                 "error_message": error_message,
             }
             workflow_class._update_execution_data(
-                redis_client, workflow_name, execution_id, updates
+                _get_redis_client(), workflow_name, execution_id, updates
             )
     except Exception:
         logger.exception("Failed to update workflow status")
@@ -427,8 +428,9 @@ def process_result_zip(
             raise ValueError(f"Workflow '{workflow_name}' not found in registry")
 
         # Get execution data from Redis for metadata
+        rc = _get_redis_client()
         execution_data = workflow_class._get_execution_data(
-            redis_client, workflow_name, execution_id
+            rc, workflow_name, execution_id
         )
 
         # Create the zip file (or just build manifest if create_zip=False)
@@ -437,7 +439,7 @@ def process_result_zip(
             output_path,
             execution_data,
             results_zip_dir,
-            redis_client,
+            rc,
             create_zip=create_zip,
         )
 
@@ -454,7 +456,7 @@ def process_result_zip(
 
             # Queue next pipeline stage
             job_id = queue_next_stage(
-                redis_client=redis_client,
+                redis_client=rc,
                 current_stage="result_zip",
                 workflow_name=workflow_name,
                 execution_id=execution_id,
@@ -539,6 +541,7 @@ def process_object_storage_upload(
     """
     output_path = Path(output_path_str)
     request_id = f"{workflow_name}:{execution_id}"
+    rc = _get_redis_client()
 
     logger.info(f"Processing object storage worker for {request_id}")
 
@@ -567,7 +570,7 @@ def process_object_storage_upload(
         # Request parameters from pending metadata (written at result_zip)
         request_parameters: dict[str, Any] = {}
         metadata_key = get_inference_request_metadata_key(request_id)
-        pending_metadata_json = redis_client.get(metadata_key)
+        pending_metadata_json = rc.get(metadata_key)
         if pending_metadata_json:
             try:
                 pending = json.loads(pending_metadata_json)
@@ -749,7 +752,7 @@ def process_object_storage_upload(
 
                         # Store signed URL in Redis
                         signed_url_key = get_signed_url_key(request_id)
-                        redis_client.setex(
+                        rc.setex(
                             signed_url_key,
                             config.object_storage.signed_url_expires_in,
                             signed_url,
@@ -799,7 +802,7 @@ def process_object_storage_upload(
             storage_info["signed_url"] = signed_url
 
         storage_info_key = f"inference_request:{request_id}:storage_info"
-        redis_client.setex(
+        rc.setex(
             storage_info_key,
             config.redis.retention_ttl,
             json.dumps(storage_info),
@@ -807,7 +810,7 @@ def process_object_storage_upload(
 
         # Queue next pipeline stage (finalize metadata)
         job_id = queue_next_stage(
-            redis_client=redis_client,
+            redis_client=rc,
             current_stage="object_storage",
             workflow_name=workflow_name,
             execution_id=execution_id,
@@ -871,6 +874,7 @@ def process_finalize_metadata(
     """
 
     request_id = f"{workflow_name}:{execution_id}"
+    rc = _get_redis_client()
     logger.info(f"Processing finalize metadata for {request_id}")
 
     # Retrieve pending metadata and storage info from Redis
@@ -878,9 +882,9 @@ def process_finalize_metadata(
     results_zip_dir_key = get_results_zip_dir_key(request_id)
     storage_info_key = f"inference_request:{request_id}:storage_info"
 
-    pending_metadata_json = redis_client.get(metadata_key)
-    results_zip_dir_str = redis_client.get(results_zip_dir_key)
-    storage_info_json = redis_client.get(storage_info_key)
+    pending_metadata_json = rc.get(metadata_key)
+    results_zip_dir_str = rc.get(results_zip_dir_key)
+    storage_info_json = rc.get(storage_info_key)
 
     if not pending_metadata_json or not results_zip_dir_str:
         logger.error(f"Pending metadata not found in Redis for {request_id}")
@@ -943,17 +947,17 @@ def process_finalize_metadata(
             "end_time": datetime.now(timezone.utc).isoformat(),
         }
         workflow_class._update_execution_data(
-            redis_client, workflow_name, execution_id, updates
+            rc, workflow_name, execution_id, updates
         )
         logger.info(
             f"Workflow {workflow_name} execution {execution_id} status set to COMPLETED"
         )
 
         # Clean up Redis keys
-        redis_client.delete(metadata_key)
-        redis_client.delete(results_zip_dir_key)
+        rc.delete(metadata_key)
+        rc.delete(results_zip_dir_key)
         if storage_info_json:
-            redis_client.delete(storage_info_key)
+            rc.delete(storage_info_key)
 
         logger.info(f"Finalize metadata completed for {request_id}")
         return {

--- a/earth2studio/serve/server/dependencies.py
+++ b/earth2studio/serve/server/dependencies.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastAPI dependency injection helpers for Redis and RQ resources."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from earth2studio.utils.imports import OptionalDependencyError
+
+try:
+    import redis as redis_sync  # type: ignore[import-untyped]
+    import redis.asyncio as redis_async  # type: ignore[import-untyped]
+    from fastapi import Depends, HTTPException, Request
+    from rq import Queue
+except ImportError as e:
+    raise OptionalDependencyError(
+        "serve", "earth2studio.serve.server.dependencies", e, e.__traceback__
+    )
+
+
+def _get_async_redis(request: Request) -> redis_async.Redis:
+    """Retrieve the async Redis client from app.state."""
+    client: redis_async.Redis | None = getattr(request.app.state, "redis_client", None)
+    if client is None:
+        raise HTTPException(status_code=503, detail="Redis connection not initialized")
+    return client
+
+
+def _get_sync_redis(request: Request) -> redis_sync.Redis:
+    """Retrieve the synchronous Redis client from app.state."""
+    client: redis_sync.Redis | None = getattr(
+        request.app.state, "redis_sync_client", None
+    )
+    if client is None:
+        raise HTTPException(status_code=503, detail="Redis connection not initialized")
+    return client
+
+
+def _get_inference_queue(request: Request) -> Queue:
+    """Retrieve the RQ inference queue from app.state."""
+    queue: Queue | None = getattr(request.app.state, "inference_queue", None)
+    if queue is None:
+        raise HTTPException(
+            status_code=503, detail="Inference queue not initialized"
+        )
+    return queue
+
+
+AsyncRedis = Annotated[redis_async.Redis, Depends(_get_async_redis)]
+SyncRedis = Annotated[redis_sync.Redis, Depends(_get_sync_redis)]
+InferenceQueue = Annotated[Queue, Depends(_get_inference_queue)]

--- a/earth2studio/serve/server/dependencies.py
+++ b/earth2studio/serve/server/dependencies.py
@@ -20,19 +20,24 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from earth2studio.utils.imports import OptionalDependencyError
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
 
 try:
     import redis as redis_sync  # type: ignore[import-untyped]
     import redis.asyncio as redis_async  # type: ignore[import-untyped]
     from fastapi import Depends, HTTPException, Request
     from rq import Queue
-except ImportError as e:
-    raise OptionalDependencyError(
-        "serve", "earth2studio.serve.server.dependencies", e, e.__traceback__
-    )
+except ImportError:
+    OptionalDependencyFailure("serve")
+    redis_sync = None
+    redis_async = None
+    Queue = None
 
 
+@check_optional_dependencies()
 def _get_async_redis(request: Request) -> redis_async.Redis:
     """Retrieve the async Redis client from app.state."""
     client: redis_async.Redis | None = getattr(request.app.state, "redis_client", None)
@@ -41,6 +46,7 @@ def _get_async_redis(request: Request) -> redis_async.Redis:
     return client
 
 
+@check_optional_dependencies()
 def _get_sync_redis(request: Request) -> redis_sync.Redis:
     """Retrieve the synchronous Redis client from app.state."""
     client: redis_sync.Redis | None = getattr(
@@ -51,13 +57,12 @@ def _get_sync_redis(request: Request) -> redis_sync.Redis:
     return client
 
 
+@check_optional_dependencies()
 def _get_inference_queue(request: Request) -> Queue:
     """Retrieve the RQ inference queue from app.state."""
     queue: Queue | None = getattr(request.app.state, "inference_queue", None)
     if queue is None:
-        raise HTTPException(
-            status_code=503, detail="Inference queue not initialized"
-        )
+        raise HTTPException(status_code=503, detail="Inference queue not initialized")
     return queue
 
 

--- a/earth2studio/serve/server/main.py
+++ b/earth2studio/serve/server/main.py
@@ -129,7 +129,7 @@ def check_admission_control(sync_redis: redis_sync.Redis) -> None:
             )
 
 
-def get_queue_position(queue: Queue, job_id: str) -> int | None:
+def get_queue_position(queue: Queue | None, job_id: str) -> int | None:
     """
     Get the position of a job in the queue.
 
@@ -138,8 +138,8 @@ def get_queue_position(queue: Queue, job_id: str) -> int | None:
 
     Parameters
     ----------
-    queue : Queue
-        The RQ inference queue.
+    queue : Queue | None
+        The RQ inference queue, or None if unavailable.
     job_id : str
         The ID of the job to find.
 
@@ -148,6 +148,8 @@ def get_queue_position(queue: Queue, job_id: str) -> int | None:
     int or None
         Position in queue (0-indexed), or None if not found (e.g. picked up by worker).
     """
+    if queue is None:
+        return None
     try:
         job_ids = queue.job_ids
 

--- a/earth2studio/serve/server/main.py
+++ b/earth2studio/serve/server/main.py
@@ -184,6 +184,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     queue, and registers custom workflows. On shutdown: closes Redis connections.
     """
     # Startup
+    async_client = None
+    sync_client = None
     try:
         async_client = create_async_redis_client()
         await async_client.ping()
@@ -222,6 +224,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     except Exception:
         logger.exception("Failed to connect to Redis or initialize RQ")
+        if async_client:
+            await async_client.close()
+        if sync_client:
+            sync_client.close()
         raise
 
     # Application is running

--- a/earth2studio/serve/server/main.py
+++ b/earth2studio/serve/server/main.py
@@ -37,7 +37,6 @@ from earth2studio.utils.imports import OptionalDependencyError
 try:
     import aiofiles  # type: ignore[import-untyped]
     import redis as redis_sync  # type: ignore[import-untyped]  # For RQ (synchronous)
-    import redis.asyncio as redis  # type: ignore[import-untyped]
     import uvicorn
     from fastapi import FastAPI, HTTPException, Request
     from fastapi.middleware.cors import CORSMiddleware
@@ -54,6 +53,15 @@ from earth2studio.serve.server.config import (
     get_config,
     get_config_manager,
     resolve_serve_path,
+)
+from earth2studio.serve.server.dependencies import (
+    AsyncRedis,
+    InferenceQueue,
+    SyncRedis,
+)
+from earth2studio.serve.server.redis_factory import (
+    create_async_redis_client,
+    create_sync_redis_client,
 )
 from earth2studio.serve.server.utils import (
     create_file_stream,
@@ -75,12 +83,8 @@ config_manager = get_config_manager()
 config_manager.setup_logging()
 logger = logging.getLogger(__name__)
 
-redis_client: redis.Redis | None = None
-redis_sync_client: redis_sync.Redis | None = None
-inference_queue: Queue | None = None
 
-
-def check_admission_control() -> None:
+def check_admission_control(sync_redis: redis_sync.Redis) -> None:
     """
     Check if the inference request can be admitted based on queue sizes.
 
@@ -88,11 +92,15 @@ def check_admission_control() -> None:
     and finalize metadata) to ensure none are at capacity before allowing
     a new request to be enqueued.
 
+    Parameters
+    ----------
+    sync_redis : redis.Redis
+        Synchronous Redis client.
+
     Raises
     ------
     HTTPException
         429 if any queue is full (service temporarily unavailable; retry later).
-        503 if Redis is not initialized.
         500 if queue status cannot be determined.
     """
     queue_names = [
@@ -104,13 +112,7 @@ def check_admission_control() -> None:
     ]
     for queue_name in queue_names:
         try:
-            if redis_sync_client is None:
-                raise HTTPException(
-                    status_code=503, detail="Redis connection not initialized"
-                )
-            current_queue_size = redis_sync_client.llen(f"rq:queue:{queue_name}")
-        except HTTPException:
-            raise
+            current_queue_size = sync_redis.llen(f"rq:queue:{queue_name}")
         except Exception as e:
             logger.error(f"Failed to get queue length for {queue_name}: {e}")
             raise HTTPException(
@@ -127,7 +129,7 @@ def check_admission_control() -> None:
             )
 
 
-def get_queue_position(job_id: str) -> int | None:
+def get_queue_position(queue: Queue, job_id: str) -> int | None:
     """
     Get the position of a job in the queue.
 
@@ -136,6 +138,8 @@ def get_queue_position(job_id: str) -> int | None:
 
     Parameters
     ----------
+    queue : Queue
+        The RQ inference queue.
     job_id : str
         The ID of the job to find.
 
@@ -144,18 +148,11 @@ def get_queue_position(job_id: str) -> int | None:
     int or None
         Position in queue (0-indexed), or None if not found (e.g. picked up by worker).
     """
-    if not inference_queue:
-        logger.warning("Inference queue not available for position lookup")
-        return None
-
     try:
-        # Get job IDs from the queue
-        # This uses RQ's Queue.job_ids property which correctly handles custom job IDs
-        job_ids = inference_queue.job_ids
+        job_ids = queue.job_ids
 
         logger.debug(f"Queue has {len(job_ids)} jobs. Looking for job_id: '{job_id}'")
 
-        # Find position (0-indexed)
         if job_id in job_ids:
             position = job_ids.index(job_id)
             logger.debug(f"Job {job_id} found at position {position}")
@@ -185,40 +182,23 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     queue, and registers custom workflows. On shutdown: closes Redis connections.
     """
     # Startup
-    global redis_client, redis_sync_client, inference_queue
     try:
-        # Async Redis client for application state
-        redis_client = redis.Redis(
-            host=config.redis.host,
-            port=config.redis.port,
-            db=config.redis.db,
-            password=config.redis.password,
-            decode_responses=config.redis.decode_responses,
-            socket_connect_timeout=config.redis.socket_connect_timeout,
-            socket_timeout=config.redis.socket_timeout,
-        )
-        # Test async connection
-        await redis_client.ping()
+        async_client = create_async_redis_client()
+        await async_client.ping()
 
-        # Synchronous Redis client for RQ
-        redis_sync_client = redis_sync.Redis(
-            host=config.redis.host,
-            port=config.redis.port,
-            db=config.redis.db,
-            password=config.redis.password,
-            decode_responses=config.redis.decode_responses,
-            socket_connect_timeout=config.redis.socket_connect_timeout,
-            socket_timeout=config.redis.socket_timeout,
-        )
-        # Test sync connection
-        redis_sync_client.ping()
+        sync_client = create_sync_redis_client()
+        sync_client.ping()
 
-        # Initialize RQ queue
-        inference_queue = Queue(
+        queue = Queue(
             config.queue.name,
-            connection=redis_sync_client,
+            connection=sync_client,
             default_timeout=config.queue.default_timeout,
         )
+
+        # Store on app.state for dependency injection
+        app.state.redis_client = async_client
+        app.state.redis_sync_client = sync_client
+        app.state.inference_queue = queue
 
         logger.info(f"Connected to Redis at {config.redis.host}:{config.redis.port}")
         logger.info(
@@ -229,7 +209,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         try:
             from earth2studio.serve.server.workflow import register_all_workflows
 
-            register_all_workflows(redis_sync_client)
+            register_all_workflows(sync_client)
             logger.info("Custom workflows registered successfully")
         except ImportError:
             logger.warning(
@@ -237,7 +217,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
         except Exception:
             logger.exception("Failed to register custom workflows")
-            # Don't raise - server can still work without custom workflows
 
     except Exception:
         logger.exception("Failed to connect to Redis or initialize RQ")
@@ -247,11 +226,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     # Shutdown
-    if redis_client:
-        await redis_client.close()
+    if hasattr(app.state, "redis_client") and app.state.redis_client:
+        await app.state.redis_client.close()
         logger.info("Async Redis connection closed")
-    if redis_sync_client:
-        redis_sync_client.close()
+    if hasattr(app.state, "redis_sync_client") and app.state.redis_sync_client:
+        app.state.redis_sync_client.close()
         logger.info("Sync Redis connection closed")
 
 
@@ -498,6 +477,8 @@ class WorkflowExecutionResponse(BaseModel):
 @app.post("/v1/infer", response_model=WorkflowExecutionResponse)
 async def execute_default_workflow(
     request: WorkflowExecutionRequest,
+    sync_redis: SyncRedis,
+    queue: InferenceQueue,
 ) -> WorkflowExecutionResponse:
     """
     Enqueue the single exposed workflow for execution.
@@ -510,6 +491,10 @@ async def execute_default_workflow(
     ----------
     request : WorkflowExecutionRequest
         Request body containing workflow parameters for the selected workflow.
+    sync_redis : SyncRedis
+        Synchronous Redis client (injected).
+    queue : InferenceQueue
+        RQ inference queue (injected).
 
     Returns
     -------
@@ -539,12 +524,15 @@ async def execute_default_workflow(
             ),
         )
     workflow_name = next(iter(exposed))
-    return await execute_workflow(workflow_name, request)
+    return await execute_workflow(workflow_name, request, sync_redis, queue)
 
 
 @app.post("/v1/infer/{workflow_name}", response_model=WorkflowExecutionResponse)
 async def execute_workflow(
-    workflow_name: str, request: WorkflowExecutionRequest
+    workflow_name: str,
+    request: WorkflowExecutionRequest,
+    sync_redis: SyncRedis,
+    queue: InferenceQueue,
 ) -> WorkflowExecutionResponse:
     """
     Enqueue a custom workflow for execution.
@@ -558,6 +546,10 @@ async def execute_workflow(
         Name of the registered workflow.
     request : WorkflowExecutionRequest
         Request body containing workflow parameters.
+    sync_redis : SyncRedis
+        Synchronous Redis client (injected).
+    queue : InferenceQueue
+        RQ inference queue (injected).
 
     Returns
     -------
@@ -584,7 +576,6 @@ async def execute_workflow(
     # Validate parameters early to provide immediate feedback using classmethod
     try:
         validated_params = custom_workflow_class.validate_parameters(request.parameters)
-        # Convert back to dict for serialization in the queue
         validated_params_dict = validated_params.model_dump()
     except ValueError as e:
         logger.error(f"Parameter validation failed for workflow {workflow_name}: {e}")
@@ -601,7 +592,7 @@ async def execute_workflow(
         )
 
     # Admission control: check all queue sizes before enqueuing
-    check_admission_control()
+    check_admission_control(sync_redis)
 
     # Generate execution ID
     execution_id = f"exec_{int(time.time())}_{uuid.uuid4().hex[:8]}"
@@ -616,14 +607,10 @@ async def execute_workflow(
             metadata={"parameters": validated_params_dict},
         )
         custom_workflow_class._save_execution_data(
-            redis_sync_client, workflow_name, execution_id, execution_data
+            sync_redis, workflow_name, execution_id, execution_data
         )
 
-        if inference_queue is None:
-            raise HTTPException(
-                status_code=503, detail="Inference queue not initialized"
-            )
-        job = inference_queue.enqueue(
+        job = queue.enqueue(
             "earth2studio.serve.server.worker.run_custom_workflow",
             workflow_name,
             execution_id,
@@ -632,19 +619,9 @@ async def execute_workflow(
             job_timeout=config.queue.job_timeout,
         )
 
-        # Query Redis directly for the actual queue length to avoid caching issues
-        # RQ stores the queue as a Redis list at "rq:queue:{queue_name}"
         try:
-            if redis_sync_client is None:
-                raise HTTPException(
-                    status_code=503, detail="Redis connection not initialized"
-                )
-            queue_length = redis_sync_client.llen(f"rq:queue:{config.queue.name}")
-            # RQ's llen seems to return position + 1, so we use it directly as 0-indexed position
-            # If length is 1, position is 0; if length is 2, position is 1; etc.
+            queue_length = sync_redis.llen(f"rq:queue:{config.queue.name}")
             queue_position = queue_length
-        except HTTPException:
-            raise
         except Exception as e:
             logger.error(f"Failed to get queue length from Redis: {e}")
             raise HTTPException(
@@ -678,7 +655,12 @@ async def execute_workflow(
 @app.get(
     "/v1/infer/{workflow_name}/{execution_id}/status", response_model=WorkflowResult
 )
-async def get_workflow_status(workflow_name: str, execution_id: str) -> WorkflowResult:
+async def get_workflow_status(
+    workflow_name: str,
+    execution_id: str,
+    sync_redis: SyncRedis,
+    queue: InferenceQueue,
+) -> WorkflowResult:
     """
     Get the status of a workflow execution.
 
@@ -688,6 +670,10 @@ async def get_workflow_status(workflow_name: str, execution_id: str) -> Workflow
         Name of the workflow.
     execution_id : str
         Unique execution identifier.
+    sync_redis : SyncRedis
+        Synchronous Redis client (injected).
+    queue : InferenceQueue
+        RQ inference queue (injected).
 
     Returns
     -------
@@ -699,10 +685,8 @@ async def get_workflow_status(workflow_name: str, execution_id: str) -> Workflow
     HTTPException
         404 if workflow or execution not found; 500 on server error.
     """
-    # Create logger adapter with execution_id
     log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
 
-    # Check if workflow exists and is exposed
     custom_workflow_class = workflow_registry.get_workflow_class(workflow_name)
     if not custom_workflow_class:
         raise HTTPException(
@@ -715,17 +699,13 @@ async def get_workflow_status(workflow_name: str, execution_id: str) -> Workflow
 
     try:
         result = custom_workflow_class._get_execution_data(
-            redis_sync_client, workflow_name, execution_id
+            sync_redis, workflow_name, execution_id
         )
 
-        # If status is QUEUED, add queue position (0-indexed)
         if result.status == WorkflowStatus.QUEUED:
             job_id = f"{workflow_name}_{execution_id}"
-            queue_position = get_queue_position(job_id)
+            queue_position = get_queue_position(queue, job_id)
 
-            # If position is None, the job is not in the queue anymore
-            # This means a worker has picked it up but hasn't updated the status yet
-            # In this case, treat it as RUNNING with no position
             if queue_position is None:
                 log.info(
                     f"Job {job_id} has status QUEUED but not found in queue - worker likely picked it up. "
@@ -748,7 +728,9 @@ async def get_workflow_status(workflow_name: str, execution_id: str) -> Workflow
 
 @app.get("/v1/infer/{workflow_name}/{execution_id}/results", response_model=None)
 async def get_workflow_results(
-    workflow_name: str, execution_id: str
+    workflow_name: str,
+    execution_id: str,
+    sync_redis: SyncRedis,
 ) -> dict[str, Any] | StreamingResponse:
     """
     Get result metadata (e.g. metadata.json) for a completed workflow execution.
@@ -788,7 +770,7 @@ async def get_workflow_results(
     # Check workflow status first
     try:
         result = custom_workflow_class._get_execution_data(
-            redis_sync_client, workflow_name, execution_id
+            sync_redis, workflow_name, execution_id
         )
         if result.status == WorkflowStatus.EXPIRED:
             raise HTTPException(
@@ -836,7 +818,6 @@ async def get_workflow_results(
 
     # Get metadata file
     try:
-        # Metadata file is named metadata_{request_id}.json
         request_id = f"{workflow_name}:{execution_id}"
         metadata_filename = f"metadata_{request_id}.json"
         metadata_path = RESULTS_ZIP_DIR / metadata_filename
@@ -852,7 +833,6 @@ async def get_workflow_results(
                 },
             )
 
-        # Read and return metadata as JSON
         async with aiofiles.open(metadata_path, "r") as f:
             metadata_content = await f.read()
             metadata_json = json.loads(metadata_content)
@@ -879,6 +859,8 @@ async def get_workflow_result_file(
     workflow_name: str,
     execution_id: str,
     filepath: str,
+    sync_redis: SyncRedis,
+    async_redis: AsyncRedis,
 ) -> StreamingResponse:
     """
     Stream a specific file from the workflow execution results.
@@ -895,6 +877,10 @@ async def get_workflow_result_file(
         Execution identifier.
     filepath : str
         Relative path within the output directory, or the request ID for the zip.
+    sync_redis : SyncRedis
+        Synchronous Redis client (injected).
+    async_redis : AsyncRedis
+        Async Redis client (injected).
 
     Returns
     -------
@@ -905,7 +891,7 @@ async def get_workflow_result_file(
     ------
     HTTPException
         403 on path traversal attempt; 404 if workflow, execution, file, or zip
-        not found or results not completed; 503 if Redis not initialized; 500 on error.
+        not found or results not completed; 500 on error.
     """
     # Check if workflow exists and is exposed
     custom_workflow_class = workflow_registry.get_workflow_class(workflow_name)
@@ -921,7 +907,7 @@ async def get_workflow_result_file(
     # Check workflow status first
     try:
         result = custom_workflow_class._get_execution_data(
-            redis_sync_client, workflow_name, execution_id
+            sync_redis, workflow_name, execution_id
         )
         if result.status != WorkflowStatus.COMPLETED:
             raise HTTPException(
@@ -939,13 +925,8 @@ async def get_workflow_result_file(
         # Special case: if filepath matches the request_id format, return the zip file
         request_id = f"{workflow_name}:{execution_id}"
         if filepath == request_id:
-            # Get the zip file path
-            if redis_client is None:
-                raise HTTPException(
-                    status_code=503, detail="Redis connection not initialized"
-                )
             zip_key = get_inference_request_zip_key(request_id)
-            zip_filename = await redis_client.get(zip_key)
+            zip_filename = await async_redis.get(zip_key)
 
             if not zip_filename:
                 raise HTTPException(
@@ -997,12 +978,8 @@ async def get_workflow_result_file(
 
         # Get output directory for this execution
         request_id = f"{workflow_name}:{execution_id}"
-        if redis_client is None:
-            raise HTTPException(
-                status_code=503, detail="Redis connection not initialized"
-            )
         output_path_key = get_inference_request_output_path_key(request_id)
-        output_dir_str = await redis_client.get(output_path_key)
+        output_dir_str = await async_redis.get(output_path_key)
 
         if output_dir_str:
             output_dir = Path(output_dir_str)

--- a/earth2studio/serve/server/redis_factory.py
+++ b/earth2studio/serve/server/redis_factory.py
@@ -62,3 +62,19 @@ def create_async_redis_client() -> redis_async.Redis:
         socket_connect_timeout=config.redis.socket_connect_timeout,
         socket_timeout=config.redis.socket_timeout,
     )
+
+
+_worker_redis_instance: redis.Redis | None = None
+
+
+def get_worker_redis_client() -> redis.Redis:
+    """Singleton Redis client for RQ worker processes.
+
+    Returns the same client instance on every call within a single OS process.
+    Used by both GPU and CPU worker modules to avoid duplicating the singleton
+    pattern.
+    """
+    global _worker_redis_instance
+    if _worker_redis_instance is None:
+        _worker_redis_instance = create_sync_redis_client()
+    return _worker_redis_instance

--- a/earth2studio/serve/server/redis_factory.py
+++ b/earth2studio/serve/server/redis_factory.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Centralized Redis client factory for worker processes.
+
+Worker processes (RQ) run in separate OS processes and cannot access FastAPI's
+app.state. This module provides a single factory function so all Redis client
+construction is defined in one place.
+"""
+
+from __future__ import annotations
+
+from earth2studio.utils.imports import OptionalDependencyError
+
+try:
+    import redis  # type: ignore[import-untyped]
+    import redis.asyncio as redis_async  # type: ignore[import-untyped]
+except ImportError as e:
+    raise OptionalDependencyError(
+        "serve", "earth2studio.serve.server.redis_factory", e, e.__traceback__
+    )
+
+from earth2studio.serve.server.config import get_config
+
+
+def create_sync_redis_client() -> redis.Redis:
+    """Create a synchronous Redis client from the current server configuration."""
+    config = get_config()
+    return redis.Redis(
+        host=config.redis.host,
+        port=config.redis.port,
+        db=config.redis.db,
+        password=config.redis.password,
+        decode_responses=config.redis.decode_responses,
+        socket_connect_timeout=config.redis.socket_connect_timeout,
+        socket_timeout=config.redis.socket_timeout,
+    )
+
+
+def create_async_redis_client() -> redis_async.Redis:
+    """Create an async Redis client from the current server configuration."""
+    config = get_config()
+    return redis_async.Redis(
+        host=config.redis.host,
+        port=config.redis.port,
+        db=config.redis.db,
+        password=config.redis.password,
+        decode_responses=config.redis.decode_responses,
+        socket_connect_timeout=config.redis.socket_connect_timeout,
+        socket_timeout=config.redis.socket_timeout,
+    )

--- a/earth2studio/serve/server/worker.py
+++ b/earth2studio/serve/server/worker.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import time
 from datetime import datetime, timezone
@@ -32,7 +34,7 @@ except ImportError:
     redis = None
 
 from earth2studio.serve.server.config import get_config, get_config_manager
-from earth2studio.serve.server.redis_factory import create_sync_redis_client
+from earth2studio.serve.server.redis_factory import get_worker_redis_client
 from earth2studio.serve.server.utils import queue_next_stage
 from earth2studio.serve.server.workflow import WorkflowStatus, workflow_registry
 
@@ -50,23 +52,11 @@ RESULTS_ZIP_DIR = Path(config.paths.results_zip_dir)
 # Model registry for caching loaded models
 model_registry: dict[str, Any] = {}
 
-# Lazily-initialized module-level Redis client for the worker process.
-_redis_client: redis.Redis | None = None
-
-
-def _get_redis_client() -> redis.Redis:
-    """Return the worker-process Redis client, creating it on first call."""
-    global _redis_client
-    if _redis_client is None:
-        _redis_client = create_sync_redis_client()
-    return _redis_client
-
-
 # Register custom workflows in the worker process
 try:
     from earth2studio.serve.server.workflow import register_all_workflows
 
-    register_all_workflows(_get_redis_client())
+    register_all_workflows(get_worker_redis_client())
     logger.info("Custom workflows registered successfully in worker process")
 except ImportError:
     logger.warning(
@@ -142,7 +132,7 @@ def run_custom_workflow(
         If queuing the next pipeline stage fails.
     """
     log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
-    redis_client = _get_redis_client()
+    redis_client = get_worker_redis_client()
 
     log.info(f"Starting custom workflow {workflow_name}")
 

--- a/earth2studio/serve/server/worker.py
+++ b/earth2studio/serve/server/worker.py
@@ -30,25 +30,14 @@ try:
 except ImportError:
     OptionalDependencyFailure("serve")
     redis = None
-    redis_client = None
 
 from earth2studio.serve.server.config import get_config, get_config_manager
+from earth2studio.serve.server.redis_factory import create_sync_redis_client
 from earth2studio.serve.server.utils import queue_next_stage
 from earth2studio.serve.server.workflow import WorkflowStatus, workflow_registry
 
 config_manager = get_config_manager()
 config = get_config()
-
-if redis:
-    redis_client = redis.Redis(
-        host=config.redis.host,
-        port=config.redis.port,
-        db=config.redis.db,
-        password=config.redis.password,
-        decode_responses=config.redis.decode_responses,
-        socket_connect_timeout=config.redis.socket_connect_timeout,
-        socket_timeout=config.redis.socket_timeout,
-    )
 
 # Configure logging
 config_manager.setup_logging()
@@ -61,11 +50,23 @@ RESULTS_ZIP_DIR = Path(config.paths.results_zip_dir)
 # Model registry for caching loaded models
 model_registry: dict[str, Any] = {}
 
+# Lazily-initialized module-level Redis client for the worker process.
+_redis_client: redis.Redis | None = None
+
+
+def _get_redis_client() -> redis.Redis:
+    """Return the worker-process Redis client, creating it on first call."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = create_sync_redis_client()
+    return _redis_client
+
+
 # Register custom workflows in the worker process
 try:
     from earth2studio.serve.server.workflow import register_all_workflows
 
-    register_all_workflows(redis_client)
+    register_all_workflows(_get_redis_client())
     logger.info("Custom workflows registered successfully in worker process")
 except ImportError:
     logger.warning(
@@ -73,7 +74,6 @@ except ImportError:
     )
 except Exception as e:
     logger.error(f"Failed to register custom workflows in worker: {e}")
-    # Don't raise - worker can still handle other tasks
 
 
 def get_output_path(
@@ -141,17 +141,15 @@ def run_custom_workflow(
     RuntimeError
         If queuing the next pipeline stage fails.
     """
-    # Create logger adapter with execution_id for automatic log prefixing
     log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
+    redis_client = _get_redis_client()
 
     log.info(f"Starting custom workflow {workflow_name}")
 
-    # Get workflow class from registry
     workflow_class = workflow_registry.get_workflow_class(workflow_name)
     if not workflow_class:
         raise ValueError(f"Custom workflow '{workflow_name}' not found in registry")
 
-    # Create workflow instance for execution
     custom_workflow = workflow_registry.get(workflow_name, redis_client=redis_client)
     if custom_workflow is None:
         raise ValueError(f"Custom workflow '{workflow_name}' could not be instantiated")
@@ -170,7 +168,6 @@ def run_custom_workflow(
 
         result = custom_workflow.run(parameters, execution_id)
 
-        # Update status to PENDING_RESULTS and record execution time so far
         execution_time_seconds = time.time() - start_timestamp
         updates = {
             "status": WorkflowStatus.PENDING_RESULTS,
@@ -181,7 +178,6 @@ def run_custom_workflow(
         )
         log.info(f"Workflow {workflow_name} execution {execution_id} pending results")
 
-        # Queue next pipeline stage (determined by configuration)
         output_path = custom_workflow.get_output_path(execution_id)
         job_id = queue_next_stage(
             redis_client=redis_client,
@@ -216,7 +212,6 @@ def run_custom_workflow(
         log.exception(
             f"Custom workflow {workflow_name} execution {execution_id} failed"
         )
-        # Update workflow status to failed if possible
         try:
             updates = {
                 "status": WorkflowStatus.FAILED,

--- a/serve/server/azure_planetary_computer/geocatalog_ingestion.py
+++ b/serve/server/azure_planetary_computer/geocatalog_ingestion.py
@@ -23,10 +23,8 @@ from azure_planetary_computer.pc_client import (
     PlanetaryComputerClient,
 )
 from earth2studio.serve.server.config import get_config
-from earth2studio.serve.server.cpu_worker import (
-    fail_workflow,
-    redis_client,
-)
+from earth2studio.serve.server.cpu_worker import fail_workflow
+from earth2studio.serve.server.redis_factory import get_worker_redis_client
 from earth2studio.serve.server.utils import (
     get_inference_request_metadata_key,
     queue_next_stage,
@@ -41,8 +39,9 @@ def _merge_geocatalog_ids_into_storage_info(
     stac_feature_id: str,
 ) -> None:
     """Persist GeoCatalog collection and STAC feature IDs into Redis ``storage_info`` for finalize."""
+    rc = get_worker_redis_client()
     key = f"inference_request:{request_id}:storage_info"
-    raw = redis_client.get(key)
+    raw = rc.get(key)
     if not raw:
         logger.warning(
             "storage_info missing for %s; cannot attach GeoCatalog IDs", request_id
@@ -56,7 +55,7 @@ def _merge_geocatalog_ids_into_storage_info(
     info["geocatalog_collection_id"] = collection_id
     info["geocatalog_stac_feature_id"] = stac_feature_id
     config = get_config()
-    redis_client.setex(key, config.redis.retention_ttl, json.dumps(info))
+    rc.setex(key, config.redis.retention_ttl, json.dumps(info))
 
 
 def process_geocatalog_ingestion(
@@ -86,19 +85,20 @@ def process_geocatalog_ingestion(
     """
     request_id = f"{workflow_name}:{execution_id}"
     logger.info(f"Processing geocatalog ingestion for {request_id}")
+    rc = get_worker_redis_client()
 
     try:
         storage_info_key = f"inference_request:{request_id}:storage_info"
         metadata_key = get_inference_request_metadata_key(request_id)
-        storage_info_json = redis_client.get(storage_info_key)
-        pending_metadata_json = redis_client.get(metadata_key)
+        storage_info_json = rc.get(storage_info_key)
+        pending_metadata_json = rc.get(metadata_key)
 
         if not storage_info_json or not pending_metadata_json:
             logger.warning(
                 f"Storage info or pending metadata missing for {request_id}, skipping geocatalog ingestion"
             )
             job_id = queue_next_stage(
-                redis_client=redis_client,
+                redis_client=rc,
                 current_stage="geocatalog_ingestion",
                 workflow_name=workflow_name,
                 execution_id=execution_id,
@@ -127,7 +127,7 @@ def process_geocatalog_ingestion(
                 f"geo_catalog_url missing for {request_id}, skipping geocatalog ingestion"
             )
             job_id = queue_next_stage(
-                redis_client=redis_client,
+                redis_client=rc,
                 current_stage="geocatalog_ingestion",
                 workflow_name=workflow_name,
                 execution_id=execution_id,
@@ -153,7 +153,7 @@ def process_geocatalog_ingestion(
                 f"dataset), skipping geocatalog ingestion"
             )
             job_id = queue_next_stage(
-                redis_client=redis_client,
+                redis_client=rc,
                 current_stage="geocatalog_ingestion",
                 workflow_name=workflow_name,
                 execution_id=execution_id,
@@ -173,7 +173,7 @@ def process_geocatalog_ingestion(
                 f"Workflow {workflow_name} not supported by Planetary Computer client, skipping ingestion for {request_id}"
             )
             job_id = queue_next_stage(
-                redis_client=redis_client,
+                redis_client=rc,
                 current_stage="geocatalog_ingestion",
                 workflow_name=workflow_name,
                 execution_id=execution_id,
@@ -220,7 +220,7 @@ def process_geocatalog_ingestion(
             )
 
         job_id = queue_next_stage(
-            redis_client=redis_client,
+            redis_client=rc,
             current_stage="geocatalog_ingestion",
             workflow_name=workflow_name,
             execution_id=execution_id,

--- a/test/serve/server/test_server_cpu_worker.py
+++ b/test/serve/server/test_server_cpu_worker.py
@@ -860,7 +860,7 @@ class TestFailWorkflow:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             mock_registry.get_workflow_class.return_value = mock_workflow_class
-            with patch("earth2studio.serve.server.cpu_worker.redis_client"):
+            with patch("earth2studio.serve.server.cpu_worker._get_redis_client"):
                 out = fail_workflow("my_wf", "exec_1", "Failed")
 
         assert out["success"] is False
@@ -1018,8 +1018,9 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker.redis_client"
-            ) as mock_redis:
+                "earth2studio.serve.server.cpu_worker._get_redis_client"
+            ) as mock_get_redis:
+                mock_redis = mock_get_redis.return_value
                 with patch(
                     "earth2studio.serve.server.cpu_worker.queue_next_stage"
                 ) as mock_queue_next:
@@ -1086,8 +1087,9 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker.redis_client"
-            ) as mock_redis:
+                "earth2studio.serve.server.cpu_worker._get_redis_client"
+            ) as mock_get_redis:
+                mock_redis = mock_get_redis.return_value
                 with patch(
                     "earth2studio.serve.server.cpu_worker.queue_next_stage"
                 ) as mock_queue_next:
@@ -1133,8 +1135,9 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker.redis_client"
-            ) as mock_redis:
+                "earth2studio.serve.server.cpu_worker._get_redis_client"
+            ) as mock_get_redis:
+                mock_redis = mock_get_redis.return_value
                 with patch(
                     "earth2studio.serve.server.cpu_worker.queue_next_stage"
                 ) as mock_queue_next:
@@ -1172,8 +1175,9 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker.redis_client"
-            ) as mock_redis:
+                "earth2studio.serve.server.cpu_worker._get_redis_client"
+            ) as mock_get_redis:
+                mock_redis = mock_get_redis.return_value
                 with patch("earth2studio.serve.server.cpu_worker.queue_next_stage"):
                     with patch(
                         "earth2studio.serve.server.cpu_worker.create_results_zip"
@@ -1222,7 +1226,10 @@ class TestProcessFinalizeMetadata:
         mock_workflow_class = Mock()
         mock_workflow_class._update_execution_data = Mock()
 
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             with patch(
                 "earth2studio.serve.server.cpu_worker.workflow_registry"
             ) as mock_registry:
@@ -1249,7 +1256,10 @@ class TestProcessFinalizeMetadata:
 
     def test_process_finalize_metadata_missing_pending_metadata_returns_failure(self):
         """When pending metadata or results_zip_dir is missing in Redis, returns fail_workflow dict."""
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             with patch(
                 "earth2studio.serve.server.cpu_worker.fail_workflow"
             ) as mock_fail:
@@ -1278,7 +1288,10 @@ class TestProcessFinalizeMetadata:
         metadata_key = f"inference_request:{request_id}:pending_metadata"
         results_zip_dir_key = f"inference_request:{request_id}:results_zip_dir"
 
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             with patch(
                 "earth2studio.serve.server.cpu_worker.workflow_registry"
             ) as mock_registry:
@@ -1320,7 +1333,10 @@ class TestProcessFinalizeMetadata:
         mock_workflow_class = Mock()
         mock_workflow_class._update_execution_data = Mock()
 
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             with patch(
                 "earth2studio.serve.server.cpu_worker.workflow_registry"
             ) as mock_registry:
@@ -1358,7 +1374,10 @@ class TestProcessObjectStorageUpload:
         output_dir.mkdir()
         (output_dir / "f.nc").write_text("data")
 
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             with patch("earth2studio.serve.server.cpu_worker.config") as mock_config:
                 with patch(
                     "earth2studio.serve.server.cpu_worker.queue_next_stage"
@@ -1473,7 +1492,10 @@ class TestProcessObjectStorageUploadEnabled:
         """Context manager helper that patches everything for upload tests."""
         return (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1501,7 +1523,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1536,7 +1561,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1565,7 +1593,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1597,7 +1628,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1630,7 +1664,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1675,7 +1712,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1724,7 +1764,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1771,7 +1814,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1826,7 +1872,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1876,7 +1925,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -1914,7 +1966,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
             patch(
@@ -1953,7 +2008,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -2006,7 +2064,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -2048,7 +2109,10 @@ class TestProcessObjectStorageUploadEnabled:
 
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
-            patch("earth2studio.serve.server.cpu_worker.redis_client", mock_redis),
+            patch(
+                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                return_value=mock_redis,
+            ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
             patch(
                 "earth2studio.serve.server.object_storage.MSCObjectStorage",
@@ -2079,7 +2143,10 @@ class TestProcessFinalizeMetadataEdgeCases:
         metadata_key = f"inference_request:{request_id}:pending_metadata"
         results_zip_dir_key = f"inference_request:{request_id}:results_zip_dir"
 
-        with patch("earth2studio.serve.server.cpu_worker.redis_client") as mock_redis:
+        with patch(
+            "earth2studio.serve.server.cpu_worker._get_redis_client"
+        ) as mock_get_redis:
+            mock_redis = mock_get_redis.return_value
             # Return non-JSON for metadata to trigger json.loads to raise
             mock_redis.get.side_effect = lambda k: {
                 metadata_key: "NOT_VALID_JSON{{{",

--- a/test/serve/server/test_server_cpu_worker.py
+++ b/test/serve/server/test_server_cpu_worker.py
@@ -860,7 +860,7 @@ class TestFailWorkflow:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             mock_registry.get_workflow_class.return_value = mock_workflow_class
-            with patch("earth2studio.serve.server.cpu_worker._get_redis_client"):
+            with patch("earth2studio.serve.server.cpu_worker.get_worker_redis_client"):
                 out = fail_workflow("my_wf", "exec_1", "Failed")
 
         assert out["success"] is False
@@ -1018,7 +1018,7 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client"
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
             ) as mock_get_redis:
                 mock_redis = mock_get_redis.return_value
                 with patch(
@@ -1087,7 +1087,7 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client"
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
             ) as mock_get_redis:
                 mock_redis = mock_get_redis.return_value
                 with patch(
@@ -1135,7 +1135,7 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client"
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
             ) as mock_get_redis:
                 mock_redis = mock_get_redis.return_value
                 with patch(
@@ -1175,7 +1175,7 @@ class TestProcessResultZip:
             "earth2studio.serve.server.cpu_worker.workflow_registry"
         ) as mock_registry:
             with patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client"
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
             ) as mock_get_redis:
                 mock_redis = mock_get_redis.return_value
                 with patch("earth2studio.serve.server.cpu_worker.queue_next_stage"):
@@ -1227,7 +1227,7 @@ class TestProcessFinalizeMetadata:
         mock_workflow_class._update_execution_data = Mock()
 
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             with patch(
@@ -1257,7 +1257,7 @@ class TestProcessFinalizeMetadata:
     def test_process_finalize_metadata_missing_pending_metadata_returns_failure(self):
         """When pending metadata or results_zip_dir is missing in Redis, returns fail_workflow dict."""
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             with patch(
@@ -1289,7 +1289,7 @@ class TestProcessFinalizeMetadata:
         results_zip_dir_key = f"inference_request:{request_id}:results_zip_dir"
 
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             with patch(
@@ -1334,7 +1334,7 @@ class TestProcessFinalizeMetadata:
         mock_workflow_class._update_execution_data = Mock()
 
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             with patch(
@@ -1375,7 +1375,7 @@ class TestProcessObjectStorageUpload:
         (output_dir / "f.nc").write_text("data")
 
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             with patch("earth2studio.serve.server.cpu_worker.config") as mock_config:
@@ -1493,7 +1493,7 @@ class TestProcessObjectStorageUploadEnabled:
         return (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1524,7 +1524,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1562,7 +1562,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1594,7 +1594,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
@@ -1629,7 +1629,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
@@ -1665,7 +1665,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
@@ -1713,7 +1713,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1765,7 +1765,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.fail_workflow") as mock_fail,
@@ -1815,7 +1815,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1873,7 +1873,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1926,7 +1926,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -1967,7 +1967,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -2009,7 +2009,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -2065,7 +2065,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -2110,7 +2110,7 @@ class TestProcessObjectStorageUploadEnabled:
         with (
             patch("earth2studio.serve.server.cpu_worker.config", mock_config),
             patch(
-                "earth2studio.serve.server.cpu_worker._get_redis_client",
+                "earth2studio.serve.server.cpu_worker.get_worker_redis_client",
                 return_value=mock_redis,
             ),
             patch("earth2studio.serve.server.cpu_worker.queue_next_stage", mock_queue),
@@ -2144,7 +2144,7 @@ class TestProcessFinalizeMetadataEdgeCases:
         results_zip_dir_key = f"inference_request:{request_id}:results_zip_dir"
 
         with patch(
-            "earth2studio.serve.server.cpu_worker._get_redis_client"
+            "earth2studio.serve.server.cpu_worker.get_worker_redis_client"
         ) as mock_get_redis:
             mock_redis = mock_get_redis.return_value
             # Return non-JSON for metadata to trigger json.loads to raise

--- a/test/serve/server/test_server_main.py
+++ b/test/serve/server/test_server_main.py
@@ -326,10 +326,14 @@ class TestWorkflowParameterValidation:
         mock_queue.__len__ = MagicMock(return_value=0)
         mock_queue.max_size = 100
 
+        orig_sync = getattr(app.state, "redis_sync_client", None)
+        orig_queue = getattr(app.state, "inference_queue", None)
         app.state.redis_sync_client = mock_redis
         app.state.inference_queue = mock_queue
         test_client = TestClient(app)
         yield test_client, mock_queue, mock_redis
+        app.state.redis_sync_client = orig_sync
+        app.state.inference_queue = orig_queue
 
     def test_valid_deterministic_workflow_parameters(self, client):
         """Test that valid parameters for deterministic workflow are accepted"""
@@ -968,9 +972,13 @@ class TestWorkflowExecutionWithQueuePosition:
             workflow_registry._workflows["test_workflow"] = mock_workflow_class
 
             with TestClient(app, raise_server_exceptions=False) as client:
+                orig_sync = getattr(app.state, "redis_sync_client", None)
+                orig_queue = getattr(app.state, "inference_queue", None)
                 app.state.redis_sync_client = mock_sync_instance
                 app.state.inference_queue = mock_queue
                 yield client, mock_queue, mock_sync_instance
+                app.state.redis_sync_client = orig_sync
+                app.state.inference_queue = orig_queue
 
             # Cleanup
             if "test_workflow" in workflow_registry._workflows:
@@ -1360,7 +1368,13 @@ class TestAdmissionControl:
             workflow_registry._workflows["admit_wf"] = AdmitWorkflow
 
             with TestClient(app, raise_server_exceptions=False) as c:
+                orig_sync = getattr(app.state, "redis_sync_client", None)
+                orig_queue = getattr(app.state, "inference_queue", None)
+                app.state.redis_sync_client = mock_sync_instance
+                app.state.inference_queue = mock_queue
                 yield c, mock_sync_instance, mock_queue
+                app.state.redis_sync_client = orig_sync
+                app.state.inference_queue = orig_queue
 
             if "admit_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["admit_wf"]
@@ -1463,9 +1477,13 @@ class TestExecuteWorkflowBranches:
 
             workflow_registry._workflows["exec_wf"] = ExecWorkflow
             with TestClient(app, raise_server_exceptions=False) as c:
+                orig_sync = getattr(app.state, "redis_sync_client", None)
+                orig_queue = getattr(app.state, "inference_queue", None)
                 app.state.redis_sync_client = mock_sync_instance
                 app.state.inference_queue = mock_queue
                 yield c, mock_sync_instance, mock_queue
+                app.state.redis_sync_client = orig_sync
+                app.state.inference_queue = orig_queue
             if "exec_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["exec_wf"]
 
@@ -1964,7 +1982,13 @@ class TestGetWorkflowResultFileBranches:
 
             workflow_registry._workflows["file_wf"] = FileWorkflow
             with TestClient(app, raise_server_exceptions=False) as c:
+                orig_async = getattr(app.state, "redis_client", None)
+                orig_sync = getattr(app.state, "redis_sync_client", None)
+                app.state.redis_client = mock_async_instance
+                app.state.redis_sync_client = mock_sync_instance
                 yield c, mock_async_instance, mock_sync_instance, tmp_path, WorkflowStatus
+                app.state.redis_client = orig_async
+                app.state.redis_sync_client = orig_sync
             if "file_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["file_wf"]
 
@@ -2428,7 +2452,13 @@ class TestExecuteWorkflowAdditionalBranches:
 
             workflow_registry._workflows["exec2_wf"] = Exec2Workflow
             with TestClient(app, raise_server_exceptions=False) as c:
+                orig_sync = getattr(app.state, "redis_sync_client", None)
+                orig_queue = getattr(app.state, "inference_queue", None)
+                app.state.redis_sync_client = mock_sync_instance
+                app.state.inference_queue = mock_queue
                 yield c, mock_sync_instance, mock_queue, Exec2Workflow
+                app.state.redis_sync_client = orig_sync
+                app.state.inference_queue = orig_queue
             if "exec2_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["exec2_wf"]
 
@@ -2507,7 +2537,10 @@ class TestGetWorkflowResultFileAdditionalBranches:
 
             workflow_registry._workflows["file2_wf"] = File2Workflow
             with TestClient(app, raise_server_exceptions=False) as c:
+                orig_async = getattr(app.state, "redis_client", None)
+                app.state.redis_client = mock_async_instance
                 yield c, mock_async_instance, tmp_path, WorkflowStatus
+                app.state.redis_client = orig_async
             if "file2_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["file2_wf"]
 

--- a/test/serve/server/test_server_main.py
+++ b/test/serve/server/test_server_main.py
@@ -245,7 +245,7 @@ class TestWorkflowParameterValidation:
     def client(self):
         """Create test client"""
         from typing import Any, Literal
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         from pydantic import Field
 
@@ -326,10 +326,10 @@ class TestWorkflowParameterValidation:
         mock_queue.__len__ = MagicMock(return_value=0)
         mock_queue.max_size = 100
 
-        with patch("earth2studio.serve.server.main.redis_sync_client", mock_redis):
-            with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-                test_client = TestClient(app)
-                yield test_client, mock_queue, mock_redis
+        app.state.redis_sync_client = mock_redis
+        app.state.inference_queue = mock_queue
+        test_client = TestClient(app)
+        yield test_client, mock_queue, mock_redis
 
     def test_valid_deterministic_workflow_parameters(self, client):
         """Test that valid parameters for deterministic workflow are accepted"""
@@ -845,70 +845,54 @@ class TestQueuePosition:
 
     def test_get_queue_position_first_in_queue(self, mock_queue):
         """Test getting position for first job in queue"""
-        from unittest.mock import patch
-
         from earth2studio.serve.server.main import get_queue_position
 
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            position = get_queue_position("workflow1_exec_001")
-            assert position == 0  # 0-indexed: first job is at position 0
+        position = get_queue_position(mock_queue, "workflow1_exec_001")
+        assert position == 0  # 0-indexed: first job is at position 0
 
     def test_get_queue_position_middle_of_queue(self, mock_queue):
         """Test getting position for job in middle of queue"""
-        from unittest.mock import patch
-
         from earth2studio.serve.server.main import get_queue_position
 
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            position = get_queue_position("workflow1_exec_003")
-            assert position == 2  # 0-indexed: third job is at position 2
+        position = get_queue_position(mock_queue, "workflow1_exec_003")
+        assert position == 2  # 0-indexed: third job is at position 2
 
     def test_get_queue_position_last_in_queue(self, mock_queue):
         """Test getting position for last job in queue"""
-        from unittest.mock import patch
-
         from earth2studio.serve.server.main import get_queue_position
 
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            position = get_queue_position("workflow3_exec_004")
-            assert position == 3  # 0-indexed: fourth job is at position 3
+        position = get_queue_position(mock_queue, "workflow3_exec_004")
+        assert position == 3  # 0-indexed: fourth job is at position 3
 
     def test_get_queue_position_not_in_queue(self, mock_queue):
         """Test getting position for job not in queue returns None"""
-        from unittest.mock import patch
-
         from earth2studio.serve.server.main import get_queue_position
 
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            position = get_queue_position("nonexistent_job")
-            assert position is None
+        position = get_queue_position(mock_queue, "nonexistent_job")
+        assert position is None
 
     def test_get_queue_position_no_queue(self):
         """Test getting position when queue is not initialized returns None"""
-        from unittest.mock import patch
-
         from earth2studio.serve.server.main import get_queue_position
 
-        with patch("earth2studio.serve.server.main.inference_queue", None):
-            position = get_queue_position("any_job")
-            assert position is None
+        position = get_queue_position(None, "any_job")
+        assert position is None
 
     def test_get_queue_position_empty_queue(self):
         """Test getting position when queue is empty"""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         from earth2studio.serve.server.main import get_queue_position
 
         empty_queue = MagicMock()
         empty_queue.job_ids = []
 
-        with patch("earth2studio.serve.server.main.inference_queue", empty_queue):
-            position = get_queue_position("any_job")
-            assert position is None
+        position = get_queue_position(empty_queue, "any_job")
+        assert position is None
 
     def test_get_queue_position_exception_handling(self):
         """Test that exceptions in get_queue_position are handled gracefully"""
-        from unittest.mock import MagicMock, PropertyMock, patch
+        from unittest.mock import MagicMock, PropertyMock
 
         from earth2studio.serve.server.main import get_queue_position
 
@@ -917,9 +901,8 @@ class TestQueuePosition:
             side_effect=Exception("Queue connection error")
         )
 
-        with patch("earth2studio.serve.server.main.inference_queue", queue_with_error):
-            position = get_queue_position("any_job")
-            assert position is None
+        position = get_queue_position(queue_with_error, "any_job")
+        assert position is None
 
 
 class TestWorkflowExecutionWithQueuePosition:
@@ -985,6 +968,8 @@ class TestWorkflowExecutionWithQueuePosition:
             workflow_registry._workflows["test_workflow"] = mock_workflow_class
 
             with TestClient(app, raise_server_exceptions=False) as client:
+                app.state.redis_sync_client = mock_sync_instance
+                app.state.inference_queue = mock_queue
                 yield client, mock_queue, mock_sync_instance
 
             # Cleanup
@@ -993,8 +978,6 @@ class TestWorkflowExecutionWithQueuePosition:
 
     def test_execute_workflow_includes_queue_position(self, client):
         """Test that POST /v1/infer/{workflow_name} includes queue position"""
-        from unittest.mock import patch
-
         test_client, mock_queue, mock_redis = client
 
         # Setup mock job
@@ -1008,11 +991,9 @@ class TestWorkflowExecutionWithQueuePosition:
         # Redis llen returns 0 (the queue size before the job is fully committed)
         mock_redis.llen = MagicMock(return_value=0)
 
-        # Patch the inference_queue at module level
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = test_client.post(
-                "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
-            )
+        response = test_client.post(
+            "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -1024,8 +1005,6 @@ class TestWorkflowExecutionWithQueuePosition:
 
     def test_execute_workflow_position_with_existing_jobs(self, client):
         """Test that position is correct when there are existing jobs in queue"""
-        from unittest.mock import patch
-
         test_client, mock_queue, mock_redis = client
 
         # Setup mock job
@@ -1039,11 +1018,9 @@ class TestWorkflowExecutionWithQueuePosition:
         # Redis llen returns 2 (the queue size before the job is fully committed)
         mock_redis.llen = MagicMock(return_value=2)
 
-        # Patch the inference_queue at module level
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = test_client.post(
-                "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
-            )
+        response = test_client.post(
+            "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -1055,8 +1032,6 @@ class TestWorkflowExecutionWithQueuePosition:
 
     def test_execute_workflow_position_with_five_existing_jobs(self, client):
         """Test that position is correct with multiple existing jobs in queue"""
-        from unittest.mock import patch
-
         test_client, mock_queue, mock_redis = client
 
         # Setup mock job
@@ -1070,11 +1045,9 @@ class TestWorkflowExecutionWithQueuePosition:
         # Redis llen returns 5 (the queue size before the job is fully committed)
         mock_redis.llen = MagicMock(return_value=5)
 
-        # Patch the inference_queue at module level
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = test_client.post(
-                "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
-            )
+        response = test_client.post(
+            "/v1/infer/test_workflow", json={"parameters": {"test_param": "value"}}
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -1098,7 +1071,6 @@ class TestWorkflowExecutionWithQueuePosition:
         # Mock Redis response for queued execution
         import json
         from datetime import datetime, timezone
-        from unittest.mock import patch
 
         execution_data = {
             "workflow_name": "test_workflow",
@@ -1109,9 +1081,7 @@ class TestWorkflowExecutionWithQueuePosition:
         }
         mock_redis.get = MagicMock(return_value=json.dumps(execution_data).encode())
 
-        # Patch the inference_queue for get_queue_position to use
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = test_client.get(f"/v1/infer/test_workflow/{execution_id}/status")
+        response = test_client.get(f"/v1/infer/test_workflow/{execution_id}/status")
 
         assert response.status_code == 200
         data = response.json()
@@ -1133,7 +1103,6 @@ class TestWorkflowExecutionWithQueuePosition:
         # Mock Redis response with QUEUED status (worker hasn't updated it yet)
         import json
         from datetime import datetime, timezone
-        from unittest.mock import patch
 
         execution_data = {
             "workflow_name": "test_workflow",
@@ -1144,9 +1113,7 @@ class TestWorkflowExecutionWithQueuePosition:
         }
         mock_redis.get = MagicMock(return_value=json.dumps(execution_data).encode())
 
-        # Patch the inference_queue for get_queue_position to use
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = test_client.get(f"/v1/infer/test_workflow/{execution_id}/status")
+        response = test_client.get(f"/v1/infer/test_workflow/{execution_id}/status")
 
         assert response.status_code == 200
         data = response.json()
@@ -1401,11 +1368,13 @@ class TestAdmissionControl:
     def test_admission_control_redis_none_returns_503(self, client_for_admission):
         """When redis_sync_client is None, execute returns 503."""
         client, mock_sync_redis, mock_queue = client_for_admission
-        with patch("earth2studio.serve.server.main.redis_sync_client", None):
-            response = client.post(
-                "/v1/infer/admit_wf",
-                json={"parameters": {}},
-            )
+        from earth2studio.serve.server.main import app
+
+        app.state.redis_sync_client = None
+        response = client.post(
+            "/v1/infer/admit_wf",
+            json={"parameters": {}},
+        )
         assert response.status_code == 503
         assert "Redis" in response.json().get("detail", "")
 
@@ -1494,6 +1463,8 @@ class TestExecuteWorkflowBranches:
 
             workflow_registry._workflows["exec_wf"] = ExecWorkflow
             with TestClient(app, raise_server_exceptions=False) as c:
+                app.state.redis_sync_client = mock_sync_instance
+                app.state.inference_queue = mock_queue
                 yield c, mock_sync_instance, mock_queue
             if "exec_wf" in workflow_registry._workflows:
                 del workflow_registry._workflows["exec_wf"]
@@ -1527,11 +1498,13 @@ class TestExecuteWorkflowBranches:
     def test_execute_workflow_inference_queue_none_503(self, client_exec):
         """When inference_queue is None, returns 503."""
         client, mock_redis, mock_queue = client_exec
-        with patch("earth2studio.serve.server.main.inference_queue", None):
-            response = client.post(
-                "/v1/infer/exec_wf",
-                json={"parameters": {}},
-            )
+        from earth2studio.serve.server.main import app
+
+        app.state.inference_queue = None
+        response = client.post(
+            "/v1/infer/exec_wf",
+            json={"parameters": {}},
+        )
         assert response.status_code == 503
         assert "queue" in response.json().get("detail", "").lower()
 
@@ -1540,11 +1513,10 @@ class TestExecuteWorkflowBranches:
         client, mock_redis, mock_queue = client_exec
         # 5 queue checks in admission control + 1 for queue position lookup
         mock_redis.llen.side_effect = [0, 0, 0, 0, 0, RuntimeError("redis error")]
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = client.post(
-                "/v1/infer/exec_wf",
-                json={"parameters": {}},
-            )
+        response = client.post(
+            "/v1/infer/exec_wf",
+            json={"parameters": {}},
+        )
         assert response.status_code == 500
         assert "queue position" in response.json().get(
             "detail", ""
@@ -1554,11 +1526,10 @@ class TestExecuteWorkflowBranches:
         """When enqueue raises, returns 500."""
         client, mock_redis, mock_queue = client_exec
         mock_queue.enqueue.side_effect = RuntimeError("RQ enqueue failed")
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = client.post(
-                "/v1/infer/exec_wf",
-                json={"parameters": {}},
-            )
+        response = client.post(
+            "/v1/infer/exec_wf",
+            json={"parameters": {}},
+        )
         assert response.status_code == 500
         assert "enqueue" in response.json().get("detail", "").lower()
 
@@ -1598,14 +1569,13 @@ class TestExecuteWorkflowBranches:
         mock_queue.enqueue = MagicMock(return_value=mock_job)
         mock_redis.llen = MagicMock(return_value=0)
         # Registry may contain other workflows from app init; isolate to one exposed name.
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            with patch.object(
-                workflow_registry,
-                "list_workflows",
-                return_value={"exec_wf": "For execute tests"},
-            ):
-                r_default = client.post("/v1/infer", json={"parameters": {}})
-            r_named = client.post("/v1/infer/exec_wf", json={"parameters": {}})
+        with patch.object(
+            workflow_registry,
+            "list_workflows",
+            return_value={"exec_wf": "For execute tests"},
+        ):
+            r_default = client.post("/v1/infer", json={"parameters": {}})
+        r_named = client.post("/v1/infer/exec_wf", json={"parameters": {}})
         assert r_default.status_code == 200
         assert r_named.status_code == 200
         assert r_default.json()["status"] == r_named.json()["status"] == "queued"
@@ -2039,12 +2009,14 @@ class TestGetWorkflowResultFileBranches:
         """When redis_client (async) is None for file request, returns 503."""
         client, mock_async, mock_sync, _, WorkflowStatus = client_file
         exec_data = self._exec_data()
+        from earth2studio.serve.server.main import app
+
+        app.state.redis_client = None
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", None):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get("/v1/infer/file_wf/exec_1/results/out.nc")
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file_wf/exec_1/results/out.nc")
         assert response.status_code == 503
 
     def test_get_workflow_result_file_zip_not_in_redis_404(self, client_file):
@@ -2053,14 +2025,11 @@ class TestGetWorkflowResultFileBranches:
         exec_data = self._exec_data()
         mock_async.get = AsyncMock(return_value=None)
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
-                    mock_wf = MagicMock()
-                    mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                    mock_reg.get_workflow_class.return_value = mock_wf
-                    response = client.get(
-                        "/v1/infer/file_wf/exec_1/results/file_wf:exec_1"
-                    )
+            with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
+                mock_wf = MagicMock()
+                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+                mock_reg.get_workflow_class.return_value = mock_wf
+                response = client.get("/v1/infer/file_wf/exec_1/results/file_wf:exec_1")
         assert response.status_code == 404
         assert "Zip" in response.json().get("detail", {}).get("error", "")
 
@@ -2070,11 +2039,10 @@ class TestGetWorkflowResultFileBranches:
         exec_data = self._exec_data()
         mock_async.get = AsyncMock(return_value=None)
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get("/v1/infer/file_wf/exec_1/results/somefile.txt")
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file_wf/exec_1/results/somefile.txt")
         assert response.status_code == 404
         assert "Output directory" in response.json().get("detail", {}).get("error", "")
 
@@ -2089,15 +2057,14 @@ class TestGetWorkflowResultFileBranches:
         inner.write_text("data")
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                # Path ../output/inner.txt from output_dir resolves to output_dir/inner.txt
-                # Use path that clearly escapes: .. with resolved path outside
-                response = client.get(
-                    "/v1/infer/file_wf/exec_1/results/..%2F..%2F..%2Fetc%2Fpasswd"
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            # Path ../output/inner.txt from output_dir resolves to output_dir/inner.txt
+            # Use path that clearly escapes: .. with resolved path outside
+            response = client.get(
+                "/v1/infer/file_wf/exec_1/results/..%2F..%2F..%2Fetc%2Fpasswd"
+            )
         # Path traversal must not succeed: either 403 (access denied) or 404
         assert response.status_code in (403, 404)
         if response.status_code == 403:
@@ -2111,13 +2078,10 @@ class TestGetWorkflowResultFileBranches:
         output_dir.mkdir()
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get(
-                    "/v1/infer/file_wf/exec_1/results/nonexistent.txt"
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file_wf/exec_1/results/nonexistent.txt")
         assert response.status_code == 404
         assert "File not found" in response.json().get("detail", {}).get("error", "")
 
@@ -2131,11 +2095,10 @@ class TestGetWorkflowResultFileBranches:
         subdir.mkdir()
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get("/v1/infer/file_wf/exec_1/results/subdir")
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file_wf/exec_1/results/subdir")
         assert response.status_code == 400
         assert "Not a file" in response.json().get("detail", {}).get("error", "")
 
@@ -2149,11 +2112,10 @@ class TestGetWorkflowResultFileBranches:
         out_file.write_text("hello world")
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get("/v1/infer/file_wf/exec_1/results/data.txt")
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file_wf/exec_1/results/data.txt")
         assert response.status_code == 200
         assert response.text == "hello world"
         accept_ranges = response.headers.get("accept-ranges") or response.headers.get(
@@ -2171,14 +2133,13 @@ class TestGetWorkflowResultFileBranches:
         out_file.write_text("hello world")
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get(
-                    "/v1/infer/file_wf/exec_1/results/data.txt",
-                    headers={"Range": "bytes=0-4"},
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get(
+                "/v1/infer/file_wf/exec_1/results/data.txt",
+                headers={"Range": "bytes=0-4"},
+            )
         assert response.status_code == 206
         assert response.content == b"hello"
         accept_ranges = response.headers.get("accept-ranges") or response.headers.get(
@@ -2476,26 +2437,24 @@ class TestExecuteWorkflowAdditionalBranches:
         client, mock_redis, mock_queue, _ = client_exec2
         # 5 queue checks in admission control + 1 for queue position lookup
         mock_redis.llen.side_effect = [0, 0, 0, 0, 0, RuntimeError("redis error")]
-        with patch("earth2studio.serve.server.main.inference_queue", mock_queue):
-            response = client.post(
-                "/v1/infer/exec2_wf",
-                json={"parameters": {}},
-            )
+        response = client.post(
+            "/v1/infer/exec2_wf",
+            json={"parameters": {}},
+        )
         assert response.status_code == 500
 
     def test_execute_redis_none_during_queue_position_503(self, client_exec2):
         """When redis_sync_client is None at queue position check, returns 503."""
         client, mock_redis, mock_queue, wf_class = client_exec2
+        from earth2studio.serve.server.main import app
+
+        app.state.redis_sync_client = None
         with patch("earth2studio.serve.server.main.check_admission_control"):
             with patch.object(wf_class, "_save_execution_data"):
-                with patch("earth2studio.serve.server.main.redis_sync_client", None):
-                    with patch(
-                        "earth2studio.serve.server.main.inference_queue", mock_queue
-                    ):
-                        response = client.post(
-                            "/v1/infer/exec2_wf",
-                            json={"parameters": {}},
-                        )
+                response = client.post(
+                    "/v1/infer/exec2_wf",
+                    json={"parameters": {}},
+                )
         assert response.status_code == 503
         assert "Redis" in response.json().get("detail", "")
 
@@ -2580,14 +2539,14 @@ class TestGetWorkflowResultFileAdditionalBranches:
         """When filepath == request_id but redis_client is None, returns 503."""
         client, mock_async, tmp_path, _ = client_file2
         exec_data = self._completed_exec_data()
+        from earth2studio.serve.server.main import app
+
+        app.state.redis_client = None
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", None):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get(
-                    "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1")
         assert response.status_code == 503
 
     def test_get_result_file_zip_not_on_disk_404(self, client_file2):
@@ -2596,14 +2555,13 @@ class TestGetWorkflowResultFileAdditionalBranches:
         exec_data = self._completed_exec_data()
         mock_async.get = AsyncMock(return_value="missing_zip.zip")
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
-                    mock_wf = MagicMock()
-                    mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                    mock_reg.get_workflow_class.return_value = mock_wf
-                    response = client.get(
-                        "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
-                    )
+            with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
+                mock_wf = MagicMock()
+                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+                mock_reg.get_workflow_class.return_value = mock_wf
+                response = client.get(
+                    "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
+                )
         assert response.status_code == 404
         assert "disk" in response.json().get("detail", {}).get("error", "").lower()
 
@@ -2615,14 +2573,13 @@ class TestGetWorkflowResultFileAdditionalBranches:
         zip_file.write_bytes(b"PK\x03\x04fake_zip_content")
         mock_async.get = AsyncMock(return_value="results.zip")
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
-                    mock_wf = MagicMock()
-                    mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                    mock_reg.get_workflow_class.return_value = mock_wf
-                    response = client.get(
-                        "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
-                    )
+            with patch("earth2studio.serve.server.main.RESULTS_ZIP_DIR", tmp_path):
+                mock_wf = MagicMock()
+                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+                mock_reg.get_workflow_class.return_value = mock_wf
+                response = client.get(
+                    "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
+                )
         assert response.status_code == 200
         assert 'results.zip"' in response.headers.get("content-disposition", "")
 
@@ -2636,14 +2593,11 @@ class TestGetWorkflowResultFileAdditionalBranches:
         data_file.write_text("contents")
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                # filepath starts with output dir name (exec_1/data.txt)
-                response = client.get(
-                    "/v1/infer/file2_wf/exec_1/results/exec_1/data.txt"
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            # filepath starts with output dir name (exec_1/data.txt)
+            response = client.get("/v1/infer/file2_wf/exec_1/results/exec_1/data.txt")
         assert response.status_code == 200
         assert response.text == "contents"
 
@@ -2657,14 +2611,13 @@ class TestGetWorkflowResultFileAdditionalBranches:
         unknown_file.write_bytes(b"\x00\x01\x02\x03")
         mock_async.get = AsyncMock(return_value=str(output_dir))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                with patch("mimetypes.guess_type", return_value=(None, None)):
-                    response = client.get(
-                        "/v1/infer/file2_wf/exec_1/results/data.unknownext99999"
-                    )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            with patch("mimetypes.guess_type", return_value=(None, None)):
+                response = client.get(
+                    "/v1/infer/file2_wf/exec_1/results/data.unknownext99999"
+                )
         assert response.status_code == 200
         assert "octet-stream" in response.headers.get("content-type", "")
 
@@ -2674,13 +2627,10 @@ class TestGetWorkflowResultFileAdditionalBranches:
         exec_data = self._completed_exec_data()
         mock_async.get = AsyncMock(side_effect=RuntimeError("unexpected redis error"))
         with patch("earth2studio.serve.server.main.workflow_registry") as mock_reg:
-            with patch("earth2studio.serve.server.main.redis_client", mock_async):
-                mock_wf = MagicMock()
-                mock_wf._get_execution_data = MagicMock(return_value=exec_data)
-                mock_reg.get_workflow_class.return_value = mock_wf
-                response = client.get(
-                    "/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1"
-                )
+            mock_wf = MagicMock()
+            mock_wf._get_execution_data = MagicMock(return_value=exec_data)
+            mock_reg.get_workflow_class.return_value = mock_wf
+            response = client.get("/v1/infer/file2_wf/exec_1/results/file2_wf:exec_1")
         assert response.status_code == 500
         assert "Failed to retrieve file" in response.json().get("detail", {}).get(
             "error", ""

--- a/test/serve/server/test_server_worker.py
+++ b/test/serve/server/test_server_worker.py
@@ -137,7 +137,7 @@ class TestRunCustomWorkflow:
                     "earth2studio.serve.server.worker.workflow_registry"
                 ) as mock_registry,
                 patch(
-                    "earth2studio.serve.server.worker._get_redis_client",
+                    "earth2studio.serve.server.worker.get_worker_redis_client",
                     return_value=MagicMock(),
                 ),
                 patch(
@@ -181,7 +181,7 @@ class TestRunCustomWorkflow:
                     "earth2studio.serve.server.worker.workflow_registry"
                 ) as mock_registry,
                 patch(
-                    "earth2studio.serve.server.worker._get_redis_client",
+                    "earth2studio.serve.server.worker.get_worker_redis_client",
                     return_value=MagicMock(),
                 ),
                 patch(
@@ -221,7 +221,7 @@ class TestRunCustomWorkflow:
                 "earth2studio.serve.server.worker.workflow_registry"
             ) as mock_registry,
             patch(
-                "earth2studio.serve.server.worker._get_redis_client",
+                "earth2studio.serve.server.worker.get_worker_redis_client",
                 return_value=MagicMock(),
             ),
         ):

--- a/test/serve/server/test_server_worker.py
+++ b/test/serve/server/test_server_worker.py
@@ -137,8 +137,8 @@ class TestRunCustomWorkflow:
                     "earth2studio.serve.server.worker.workflow_registry"
                 ) as mock_registry,
                 patch(
-                    "earth2studio.serve.server.worker.redis_client",
-                    MagicMock(),
+                    "earth2studio.serve.server.worker._get_redis_client",
+                    return_value=MagicMock(),
                 ),
                 patch(
                     "earth2studio.serve.server.worker.queue_next_stage",
@@ -181,8 +181,8 @@ class TestRunCustomWorkflow:
                     "earth2studio.serve.server.worker.workflow_registry"
                 ) as mock_registry,
                 patch(
-                    "earth2studio.serve.server.worker.redis_client",
-                    MagicMock(),
+                    "earth2studio.serve.server.worker._get_redis_client",
+                    return_value=MagicMock(),
                 ),
                 patch(
                     "earth2studio.serve.server.worker.queue_next_stage",
@@ -221,8 +221,8 @@ class TestRunCustomWorkflow:
                 "earth2studio.serve.server.worker.workflow_registry"
             ) as mock_registry,
             patch(
-                "earth2studio.serve.server.worker.redis_client",
-                MagicMock(),
+                "earth2studio.serve.server.worker._get_redis_client",
+                return_value=MagicMock(),
             ),
         ):
             mock_registry.get_workflow_class.return_value = mock_workflow_class


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Replaced module-level redis_client, redis_sync_client, and inference_queue globals in main.py with FastAPI app.state attributes initialized during the lifespan.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
