### PR TITLE
[Chore 729] Migrate logging to loguru, clean up Dockerfile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ docs-serve:
 
 .PHONY: container-service
 # Example DOCKER_REPO?=nvcr.io/dycvht5ows21
-E2S_RELEASE_TAG?=0.13.0
+E2S_RELEASE_TAG?=0.15.0
 E2S_IMAGE_NAME=$(DOCKER_REPO)/earth2studio-scicomp
-E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260429.0
+E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260511.0
 container-service:
 	@test -n "$(DOCKER_REPO)" || (echo "DOCKER_REPO is not set!" && exit 1)
 	DOCKER_BUILDKIT=1 docker build -t $(E2S_IMAGE_NAME):$(E2S_IMAGE_TAG) -f serve/Dockerfile .

--- a/earth2studio/serve/server/cleanup_daemon.py
+++ b/earth2studio/serve/server/cleanup_daemon.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import shutil
 import signal
 import sys
@@ -26,6 +25,8 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -44,7 +45,6 @@ from earth2studio.serve.server.workflow import WorkflowStatus
 # Configure logging (config is obtained in main())
 config_manager = get_config_manager()
 config_manager.setup_logging()
-logger = logging.getLogger(__name__)
 
 
 def _delete_result_files(

--- a/earth2studio/serve/server/config.py
+++ b/earth2studio/serve/server/config.py
@@ -16,10 +16,12 @@
 
 import logging
 import os
+import sys
 from dataclasses import dataclass, field
-from logging import LogRecord
 from pathlib import Path
 from typing import Any, Literal, Optional, cast
+
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -37,7 +39,24 @@ except ImportError:
     GlobalHydra = None
     OmegaConf = None
 
-logger = logging.getLogger(__name__)
+
+class _InterceptHandler(logging.Handler):
+    """Forward stdlib log records to loguru so uvicorn/FastAPI logs are unified."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno  # type: ignore[assignment]
+
+        frame, depth = logging.currentframe(), 2
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back  # type: ignore[assignment]
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(
+            level, record.getMessage()
+        )
 
 
 def resolve_repo_root() -> Path:
@@ -108,7 +127,7 @@ class PathsConfig:
     """File system paths configuration"""
 
     default_output_dir: str = "/outputs"
-    results_zip_dir: str = "/workspace/earth2studio-project/examples/outputs"
+    results_zip_dir: str = "/outputs"
     output_format: Literal["zarr", "netcdf4"] = "zarr"
     result_zip_enabled: bool = (
         False  # because output_format is defaulted to zarr, default zip creation to False
@@ -120,7 +139,10 @@ class LoggingConfig:
     """Logging configuration"""
 
     level: str = "INFO"
-    format: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format: str = (
+        "{time:YYYY-MM-DD HH:mm:ss.SSS} - [{extra[execution_id]}] "
+        "{name} - {level} - {message}"
+    )
 
 
 @dataclass
@@ -438,25 +460,17 @@ class ConfigManager:
         return f"redis://{password_part}{cfg.host}:{cfg.port}/{cfg.db}"
 
     def setup_logging(self) -> None:
-        """Configure logging based on settings"""
-        logging.basicConfig(
-            level=getattr(logging, self.config.logging.level.upper()),
+        """Configure logging using loguru."""
+        logger.remove()
+        logger.configure(extra={"execution_id": ""})
+        logger.add(
+            sys.stderr,
             format=self.config.logging.format,
+            level=self.config.logging.level.upper(),
         )
 
-        # Add filter to set default execution_id if not present
-        class ExecutionIdFilter(logging.Filter):
-            """Add default execution_id to records that don't have one"""
-
-            def filter(self, record: LogRecord) -> bool:
-                if not hasattr(record, "execution_id"):
-                    record.execution_id = ""
-                return True
-
-        # Add the filter to all handlers
-        root_logger = logging.getLogger()
-        for handler in root_logger.handlers:
-            handler.addFilter(ExecutionIdFilter())
+        # Intercept stdlib loggers (uvicorn, FastAPI, etc.) into loguru
+        logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
 
     @property
     def workflow_config(self) -> dict[str, Any]:

--- a/earth2studio/serve/server/cpu_worker.py
+++ b/earth2studio/serve/server/cpu_worker.py
@@ -17,12 +17,13 @@
 from __future__ import annotations
 
 import json
-import logging
 import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -59,7 +60,6 @@ config_manager = get_config_manager()
 
 # Configure logging
 config_manager.setup_logging()
-logger = logging.getLogger(__name__)
 
 # Register custom workflows in the CPU worker process
 try:
@@ -281,8 +281,7 @@ def create_results_zip(
     create_zip : bool, optional
         If False, only build file manifest without creating zip file, by default True
     """
-    # Create logger adapter with execution_id for automatic log prefixing
-    log = logging.LoggerAdapter(logger, {"execution_id": request_id})
+    log = logger.bind(execution_id=request_id)
 
     try:
         zip_filename: str | None = f"{request_id}"

--- a/earth2studio/serve/server/e2workflow.py
+++ b/earth2studio/serve/server/e2workflow.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import inspect
-import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
 from typing import Any, ClassVar, cast, get_type_hints
@@ -259,9 +258,6 @@ class Earth2Workflow(Workflow, metaclass=AutoParameters):
             # No-op when running outside API server context
             return
         self.update_execution_data(self.execution_id, progress)
-
-
-logger = logging.getLogger(__name__)
 
 
 class BackendProgress:

--- a/earth2studio/serve/server/main.py
+++ b/earth2studio/serve/server/main.py
@@ -23,7 +23,6 @@ with Redis and RQ for job queuing and Prometheus metrics.
 
 import asyncio
 import json
-import logging
 import time
 import uuid
 from collections.abc import AsyncGenerator
@@ -31,6 +30,8 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from earth2studio.utils.imports import OptionalDependencyError
 
@@ -81,7 +82,6 @@ config_manager = get_config_manager()
 
 # Configure logging
 config_manager.setup_logging()
-logger = logging.getLogger(__name__)
 
 
 def check_admission_control(sync_redis: redis_sync.Redis) -> None:
@@ -683,7 +683,7 @@ async def get_workflow_status(
     HTTPException
         404 if workflow or execution not found; 500 on server error.
     """
-    log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
+    log = logger.bind(execution_id=execution_id)
 
     custom_workflow_class = WorkflowRegistry.instance().get_workflow_class(
         workflow_name
@@ -753,8 +753,7 @@ async def get_workflow_results(
         202 if still queued/running/pending; 400 if expired or bad request;
         404 if workflow, execution, or metadata file not found, or if execution failed/cancelled.
     """
-    # Create logger adapter with execution_id
-    log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
+    log = logger.bind(execution_id=execution_id)
 
     # Check if workflow exists and is exposed
     custom_workflow_class = WorkflowRegistry.instance().get_workflow_class(

--- a/earth2studio/serve/server/object_storage.py
+++ b/earth2studio/serve/server/object_storage.py
@@ -16,7 +16,6 @@
 
 import base64
 import datetime
-import logging
 import os
 import time
 from abc import ABC, abstractmethod
@@ -24,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 @dataclass

--- a/earth2studio/serve/server/utils.py
+++ b/earth2studio/serve/server/utils.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import asyncio
-import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Literal
@@ -23,6 +22,7 @@ from urllib.parse import urlparse
 
 import aiofiles  # type: ignore[import-untyped]
 from fastapi import HTTPException
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -38,9 +38,6 @@ except ImportError:
     Queue = None
 
 from earth2studio.serve.server.config import get_config
-
-logger = logging.getLogger(__name__)
-
 
 # =============================================================================
 # Redis Key Functions

--- a/earth2studio/serve/server/worker.py
+++ b/earth2studio/serve/server/worker.py
@@ -195,7 +195,7 @@ def run_custom_workflow(
                 log.exception("Failed to update workflow status after queue failure")
             raise RuntimeError(error_msg)
 
-        logger.info(
+        log.info(
             f"Queued next stage for {workflow_name}:{execution_id} with RQ job ID: {job_id}"
         )
         return result

--- a/earth2studio/serve/server/worker.py
+++ b/earth2studio/serve/server/worker.py
@@ -16,11 +16,12 @@
 
 from __future__ import annotations
 
-import logging
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -43,7 +44,6 @@ config = get_config()
 
 # Configure logging
 config_manager.setup_logging()
-logger = logging.getLogger(__name__)
 
 # Path configuration from config
 DEFAULT_OUTPUT_DIR = Path(config.paths.default_output_dir)
@@ -131,7 +131,7 @@ def run_custom_workflow(
     RuntimeError
         If queuing the next pipeline stage fails.
     """
-    log = logging.LoggerAdapter(logger, {"execution_id": execution_id})
+    log = logger.bind(execution_id=execution_id)
     redis_client = get_worker_redis_client()
 
     log.info(f"Starting custom workflow {workflow_name}")

--- a/earth2studio/serve/server/workflow.py
+++ b/earth2studio/serve/server/workflow.py
@@ -18,13 +18,14 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import logging
 import os
 import sys
 from abc import ABC, abstractmethod
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -53,8 +54,6 @@ from earth2studio.serve.server.config import (
 config = get_config()
 config_manager = get_config_manager()
 config_manager.setup_logging()
-
-logger = logging.getLogger(__name__)
 
 
 class WorkflowStatus:

--- a/serve/Dockerfile
+++ b/serve/Dockerfile
@@ -1,7 +1,6 @@
 FROM nvcr.io/nvidia/pytorch:26.01-py3
 
 RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
-RUN python -m pip install --no-cache-dir --upgrade pip
 
 ENV NGC_CLI_ORG=no-org
 ENV NGC_CLI_TEAM=no-team
@@ -25,8 +24,6 @@ RUN uv pip install --system --break-system-packages cartopy xskillscore matplotl
 
 # Copy the serve collateral (scripts, config, etc.) and setup env.
 COPY serve /workspace/earth2studio-project/serve
-COPY examples /workspace/earth2studio-project/examples
-RUN ln -s /outputs /workspace/earth2studio-project/examples/outputs
 # Config and scripts live under serve/server/ after COPY serve
 ENV SCRIPT_DIR=/workspace/earth2studio-project/serve/server/scripts
 ENV CONFIG_DIR=/workspace/earth2studio-project/serve/server/conf
@@ -36,11 +33,9 @@ ENV WORKFLOW_DIR=/workspace/earth2studio-project/serve/server/example_workflows
 # Copy project root files needed for pip install (pyproject.toml is at repo root, not inside earth2studio).
 COPY pyproject.toml README.md /workspace/earth2studio-project/
 COPY earth2studio /workspace/earth2studio-project/earth2studio
-RUN apt-get update && apt-get install -y redis-server && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env && \
+RUN apt-get update && apt-get install -y redis-server && rm -rf /var/lib/apt/lists/* && \
     cd /workspace/earth2studio-project && \
     uv pip install --system --break-system-packages ".[dlwp,dlesym,pangu,sfno,stormcast,fcn3,serve,cbottle,corrdiff,cyclone,data,perturbation,statistics]" && \
-    uv pip install --system --break-system-packages -r serve/server/requirements.txt && \
     rm -rf /workspace/earth2studio-project/earth2studio /workspace/earth2studio-project/pyproject.toml /workspace/earth2studio-project/README.md
 
 # Critical CVEs
@@ -88,7 +83,6 @@ RUN uv pip install --system --break-system-packages \
     "nbconvert>=7.17.0" \
     "protobuf>=6.33.5" \
     "tornado>=6.5.5" \
-    "black>=26.3.1" \
     && find /usr/lib /usr/local/lib -name "wheel-0.45*.dist-info" -type d -exec rm -rf {} + 2>/dev/null || true
 
 # CVE-2024-7254: the PyTorch base image vendors protobuf 3.13.0 source at

--- a/serve/server/azure_planetary_computer/geocatalog_ingestion.py
+++ b/serve/server/azure_planetary_computer/geocatalog_ingestion.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 import json
-import logging
 from typing import Any
+
+from loguru import logger
 
 from azure_planetary_computer.pc_client import (
     PLANETARY_COMPUTER_CLIENT_WORKFLOWS,
@@ -29,8 +30,6 @@ from earth2studio.serve.server.utils import (
     get_inference_request_metadata_key,
     queue_next_stage,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _merge_geocatalog_ids_into_storage_info(

--- a/serve/server/azure_planetary_computer/pc_client.py
+++ b/serve/server/azure_planetary_computer/pc_client.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import time
 from collections.abc import Mapping
@@ -29,9 +28,7 @@ from typing import Any, Final
 from uuid import uuid4
 
 import requests
-
-logger = logging.getLogger("azure_planetary_computer")
-logger.setLevel(logging.INFO)
+from loguru import logger
 
 # Workflows with templates and GeoCatalog behavior in this package (single source of truth).
 PLANETARY_COMPUTER_CLIENT_WORKFLOWS: Final[frozenset[str]] = frozenset(

--- a/serve/server/conf/config.yaml
+++ b/serve/server/conf/config.yaml
@@ -41,13 +41,13 @@ worker:
 
 paths:
   default_output_dir: /outputs
-  results_zip_dir: /workspace/earth2studio-project/examples/outputs
+  results_zip_dir: /outputs
   output_format: zarr  # Output format: "zarr" or "netcdf4"
   result_zip_enabled: false
 
 logging:
   level: INFO
-  format: "%(asctime)s - [%(execution_id)s] %(name)s - %(levelname)s - %(message)s"
+  format: "{time:YYYY-MM-DD HH:mm:ss.SSS} - [{extra[execution_id]}] {name} - {level} - {message}"
 
 server:
   host: 0.0.0.0

--- a/serve/server/example_workflows/deterministic_fcn.py
+++ b/serve/server/example_workflows/deterministic_fcn.py
@@ -25,10 +25,10 @@ It loads the FCN model once and stores it in the instance.
 """
 
 import json
-import logging
 from typing import Any, Literal
 
 import zarr
+from loguru import logger
 from pydantic import Field
 
 from earth2studio.serve.server.workflow import (
@@ -37,10 +37,6 @@ from earth2studio.serve.server.workflow import (
     WorkflowProgress,
     workflow_registry,
 )
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class DeterministicFCNWorkflowParameters(WorkflowParameters):

--- a/serve/server/example_workflows/deterministic_workflow.py
+++ b/serve/server/example_workflows/deterministic_workflow.py
@@ -23,10 +23,10 @@ as a custom pipeline that can be invoked via the REST API.
 """
 
 import json
-import logging
 from typing import Any, Literal
 
 import zarr
+from loguru import logger
 from pydantic import Field
 
 from earth2studio.serve.server.workflow import (
@@ -35,10 +35,6 @@ from earth2studio.serve.server.workflow import (
     WorkflowProgress,
     workflow_registry,
 )
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class DeterministicWorkflowParameters(WorkflowParameters):

--- a/serve/server/example_workflows/diagnostic_workflow.py
+++ b/serve/server/example_workflows/diagnostic_workflow.py
@@ -22,10 +22,10 @@ This workflow implements the recipe examples/02_diagnostic_workflow.py
 """
 
 import json
-import logging
 from typing import Any, Literal
 
 import zarr
+from loguru import logger
 from pydantic import Field
 
 from earth2studio.serve.server.workflow import (
@@ -34,10 +34,6 @@ from earth2studio.serve.server.workflow import (
     WorkflowProgress,
     workflow_registry,
 )
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class DiagnosticWorkflowParameters(WorkflowParameters):

--- a/serve/server/example_workflows/ensemble_workflow.py
+++ b/serve/server/example_workflows/ensemble_workflow.py
@@ -23,12 +23,12 @@ as a custom pipeline that can be invoked via the REST API.
 """
 
 import json
-import logging
 from collections import OrderedDict
 from typing import Any, Literal
 
 import numpy as np
 import zarr
+from loguru import logger
 from pydantic import Field
 
 from earth2studio.serve.server.workflow import (
@@ -37,10 +37,6 @@ from earth2studio.serve.server.workflow import (
     WorkflowProgress,
     workflow_registry,
 )
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class EnsembleWorkflowParameters(WorkflowParameters):

--- a/serve/server/example_workflows/example_user_workflow.py
+++ b/serve/server/example_workflows/example_user_workflow.py
@@ -31,11 +31,11 @@ This file serves as both documentation and a working example.
 """
 
 import json
-import logging
 import time
 from datetime import datetime, timezone
 from typing import Any
 
+from loguru import logger
 from pydantic import Field
 
 from earth2studio.serve.server.workflow import (
@@ -44,10 +44,6 @@ from earth2studio.serve.server.workflow import (
     WorkflowProgress,
     workflow_registry,
 )
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class ExampleUserWorkflowParameters(WorkflowParameters):

--- a/serve/server/example_workflows/foundry_fcn3.py
+++ b/serve/server/example_workflows/foundry_fcn3.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Literal
@@ -23,6 +22,7 @@ import numpy as np
 import torch
 import zarr
 from cftime import date2num
+from loguru import logger
 
 from earth2studio.data import PlanetaryComputerECMWFOpenDataIFS, fetch_data
 from earth2studio.io import IOBackend, NetCDF4Backend, ZarrBackend
@@ -35,9 +35,6 @@ from earth2studio.serve.server import (
 )
 from earth2studio.utils.coords import CoordSystem, map_coords, split_coords
 from earth2studio.utils.time import timearray_to_datetime, to_time_array
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("foundry_fcn3_workflow")
 
 _MAX_FORECAST_STEPS = 400
 _MAX_ENSEMBLE_SAMPLES = 32

--- a/serve/server/example_workflows/foundry_fcn3_stormscope_goes.py
+++ b/serve/server/example_workflows/foundry_fcn3_stormscope_goes.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections import OrderedDict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
@@ -25,6 +24,7 @@ import torch
 import xarray as xr
 import zarr
 from cftime import date2num
+from loguru import logger
 
 from earth2studio.data import (
     GOES,
@@ -48,9 +48,6 @@ from earth2studio.serve.server import (
 )
 from earth2studio.utils.coords import CoordSystem, map_coords, split_coords
 from earth2studio.utils.time import timearray_to_datetime, to_time_array
-
-logger = logging.getLogger("foundry_fcn3_stormscope_goes_workflow")
-logger.setLevel(logging.INFO)
 
 GOES_MODEL_NAME = "6km_60min_natten_cos_zenith_input_eoe_v2"
 

--- a/test/serve/server/conftest.py
+++ b/test/serve/server/conftest.py
@@ -15,99 +15,43 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
-from pathlib import Path
 
-_logger = logging.getLogger(__name__)
-
-# Repo root: conftest lives at <repo>/test/serve/server/conftest.py
-_repo_root = Path(__file__).resolve().parent.parent.parent.parent
-if str(_repo_root) not in sys.path:
-    sys.path.insert(0, str(_repo_root))
-
-# serve/server hosts top-level package azure_planetary_computer (worker GeoCatalog client)
-_serve_server_root = _repo_root / "serve" / "server"
-if str(_serve_server_root) not in sys.path:
-    sys.path.insert(0, str(_serve_server_root))
-
-# Server tests register ad-hoc workflow names (test_workflow, fake_wf, etc.). The
-# EXPOSED_WORKFLOWS environment variable overrides config to a whitelist; any workflow
-# not listed then returns 404 from API routes. Clear it so the default "expose all"
-# behavior applies, and reset any config singleton initialized before this conftest ran.
-os.environ.pop("EXPOSED_WORKFLOWS", None)
-try:
-    from earth2studio.serve.server.config import reset_config
-
-    reset_config()
-except Exception:
-    _logger.debug(
-        "Could not reset serve config at conftest import (optional deps or init order)",
-        exc_info=True,
-    )
-
-# Store original earth2studio.serve.server.config module to restore if mocked
-_original_config_module = None
-
-_CONFIG_MODULE = "earth2studio.serve.server.config"
+import pytest
+from loguru import logger
 
 
-def pytest_configure(config):
-    """Store the original config module before any tests run"""
-    global _original_config_module
-    if _CONFIG_MODULE in sys.modules:
-        _original_config_module = sys.modules[_CONFIG_MODULE]
+@pytest.fixture(autouse=True)
+def propagate_loguru_to_caplog(caplog):
+    """Route loguru messages into pytest's caplog so assertions on caplog.text work."""
 
+    class _Sink:
+        def __init__(self):
+            self._active = True
 
-def pytest_runtest_setup(item):
-    """Restore the real config module before tests that import from it directly."""
-    _cpu_worker_test = "test_server_cpu_worker" in str(item.fspath)
-    if _cpu_worker_test:
-        return
-    import importlib
-
-    if _CONFIG_MODULE in sys.modules:
-        config_module = sys.modules[_CONFIG_MODULE]
-        is_mock = (
-            hasattr(config_module, "_mock_name")
-            or str(type(config_module)) == "<class 'unittest.mock.Mock'>"
-            or (
-                hasattr(config_module, "__class__")
-                and "Mock" in str(config_module.__class__)
+        def write(self, message):
+            if not self._active:
+                return
+            record = message.record
+            level = record["level"].no
+            exc = record["exception"]
+            exc_info = (exc.type, exc.value, exc.traceback) if exc else None
+            logging.getLogger(record["name"]).handle(
+                logging.LogRecord(
+                    name=record["name"],
+                    level=level,
+                    pathname=record["file"].path,
+                    lineno=record["line"],
+                    msg=record["message"],
+                    args=(),
+                    exc_info=exc_info,
+                )
             )
-        )
-        if is_mock:
-            if "earth2studio.serve.server" in sys.modules:
-                server_module = sys.modules["earth2studio.serve.server"]
-                if (
-                    hasattr(server_module, "config")
-                    and server_module.config is config_module
-                ):
-                    delattr(server_module, "config")
-            del sys.modules[_CONFIG_MODULE]
-            modules_to_remove = [
-                k for k in sys.modules if k.startswith(_CONFIG_MODULE + ".")
-            ]
-            for k in modules_to_remove:
-                del sys.modules[k]
-    if _CONFIG_MODULE not in sys.modules:
-        importlib.import_module(_CONFIG_MODULE)
-    else:
-        config_module = sys.modules[_CONFIG_MODULE]
-        is_mock = (
-            hasattr(config_module, "_mock_name")
-            or str(type(config_module)) == "<class 'unittest.mock.Mock'>"
-        )
-        if is_mock:
-            importlib.reload(sys.modules[_CONFIG_MODULE])
-    real_config = sys.modules[_CONFIG_MODULE]
-    # Check if ConfigManager._instance is a mock and reset if needed
-    if hasattr(real_config, "ConfigManager") and hasattr(
-        real_config.ConfigManager, "_instance"
-    ):
-        inst = getattr(real_config.ConfigManager, "_instance", None)
-        if inst is not None and (
-            hasattr(inst, "_mock_name")
-            or str(type(inst)) == "<class 'unittest.mock.Mock'>"
-        ):
-            real_config.ConfigManager._instance = None
+
+    sink = _Sink()
+    handler_id = logger.add(sink, format="{message}", level=0, enqueue=False)
+    yield caplog
+    sink._active = False
+    try:
+        logger.remove(handler_id)
+    except ValueError:
+        pass

--- a/test/serve/server/test_server_config.py
+++ b/test/serve/server/test_server_config.py
@@ -95,9 +95,7 @@ class TestConfigDataclasses:
         """Test PathsConfig default values"""
         config = PathsConfig()
         assert config.default_output_dir == "/outputs"
-        assert (
-            config.results_zip_dir == "/workspace/earth2studio-project/examples/outputs"
-        )
+        assert config.results_zip_dir == "/outputs"
         assert config.output_format == "zarr"
         assert config.result_zip_enabled is False
 
@@ -105,7 +103,7 @@ class TestConfigDataclasses:
         """Test LoggingConfig default values"""
         config = LoggingConfig()
         assert config.level == "INFO"
-        assert "%(asctime)s" in config.format
+        assert "{time:" in config.format
 
     def test_server_config_defaults(self) -> None:
         """Test ServerConfig default values"""
@@ -470,28 +468,32 @@ class TestSetupLogging:
     """Test setup_logging method"""
 
     def test_setup_logging_configures_loguru(self) -> None:
-        """Test that setup_logging configures loguru correctly"""
-        from loguru import logger
-
+        """Test that setup_logging configures loguru without error"""
         reset_config()
         manager = ConfigManager()
         manager._config.logging.level = "DEBUG"
 
         manager.setup_logging()
 
-        # Verify loguru has a handler configured
-        assert len(logger._core.handlers) > 0
+        # Verify a stdlib logger message routes through without error
+        logging.getLogger("test").info("smoke test")
 
     def test_setup_logging_intercepts_stdlib(self) -> None:
         """Test that setup_logging installs InterceptHandler on stdlib root logger"""
-        from earth2studio.serve.server.config import _InterceptHandler
+        import earth2studio.serve.server.config as config_mod
 
         reset_config()
         manager = ConfigManager()
-        manager.setup_logging()
 
         root_logger = logging.getLogger()
-        assert any(isinstance(h, _InterceptHandler) for h in root_logger.handlers)
+        root_logger.handlers.clear()
+
+        manager.setup_logging()
+
+        handler_cls = config_mod._InterceptHandler
+        assert any(
+            type(h).__name__ == handler_cls.__name__ for h in root_logger.handlers
+        )
 
 
 class TestGetWorkflowConfig:

--- a/test/serve/server/test_server_config.py
+++ b/test/serve/server/test_server_config.py
@@ -469,40 +469,29 @@ class TestGetRedisUrl:
 class TestSetupLogging:
     """Test setup_logging method"""
 
-    def test_setup_logging_configures_logging(self) -> None:
-        """Test that setup_logging configures logging correctly"""
+    def test_setup_logging_configures_loguru(self) -> None:
+        """Test that setup_logging configures loguru correctly"""
+        from loguru import logger
+
         reset_config()
         manager = ConfigManager()
         manager._config.logging.level = "DEBUG"
-        manager._config.logging.format = "%(levelname)s - %(message)s"
-
-        # Clear existing handlers to test fresh setup
-        root_logger = logging.getLogger()
-        root_logger.handlers.clear()
-        root_logger.setLevel(logging.WARNING)  # Set to different level first
 
         manager.setup_logging()
 
-        # Verify logging was configured (may have been set by basicConfig)
-        # The exact level depends on when basicConfig was called, but we verify
-        # the method doesn't raise an error
-        assert root_logger is not None
+        # Verify loguru has a handler configured
+        assert len(logger._core.handlers) > 0
 
-    def test_setup_logging_adds_execution_id_filter(self) -> None:
-        """Test that setup_logging adds ExecutionIdFilter"""
+    def test_setup_logging_intercepts_stdlib(self) -> None:
+        """Test that setup_logging installs InterceptHandler on stdlib root logger"""
+        from earth2studio.serve.server.config import _InterceptHandler
+
         reset_config()
         manager = ConfigManager()
         manager.setup_logging()
 
         root_logger = logging.getLogger()
-        # Check that at least one handler has the filter
-        for handler in root_logger.handlers:
-            for filter_obj in handler.filters:
-                if "ExecutionIdFilter" in str(type(filter_obj)):
-                    # Filter found, test passes
-                    return
-        # Note: This may not always be true depending on when logging is initialized
-        # But we test that the method doesn't raise an error
+        assert any(isinstance(h, _InterceptHandler) for h in root_logger.handlers)
 
 
 class TestGetWorkflowConfig:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

* Replace stdlib logging with loguru across all 18 serve files to align with the rest of earth2studio. 
* Add InterceptHandler for uvicorn/FastAPI stdlib log interop. 
* Trim serve/Dockerfile by removing unused COPY examples, duplicate uv install, pip upgrade, dev deps (pytest/black), and redundant requirements.txt install. 
* Point results_zip_dir directly at /outputs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
