### PR TITLE
Fix workflows after recent changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docs-serve:
 # Example DOCKER_REPO?=nvcr.io/dycvht5ows21
 E2S_RELEASE_TAG?=0.15.0
 E2S_IMAGE_NAME=$(DOCKER_REPO)/earth2studio-scicomp
-E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260511.0
+E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260512.0
 container-service:
 	@test -n "$(DOCKER_REPO)" || (echo "DOCKER_REPO is not set!" && exit 1)
 	DOCKER_BUILDKIT=1 docker build -t $(E2S_IMAGE_NAME):$(E2S_IMAGE_TAG) -f serve/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docs-serve:
 # Example DOCKER_REPO?=nvcr.io/dycvht5ows21
 E2S_RELEASE_TAG?=0.15.0
 E2S_IMAGE_NAME=$(DOCKER_REPO)/earth2studio-scicomp
-E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260512.1
+E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260512.2
 container-service:
 	@test -n "$(DOCKER_REPO)" || (echo "DOCKER_REPO is not set!" && exit 1)
 	DOCKER_BUILDKIT=1 docker build -t $(E2S_IMAGE_NAME):$(E2S_IMAGE_TAG) -f serve/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docs-serve:
 # Example DOCKER_REPO?=nvcr.io/dycvht5ows21
 E2S_RELEASE_TAG?=0.15.0
 E2S_IMAGE_NAME=$(DOCKER_REPO)/earth2studio-scicomp
-E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260512.0
+E2S_IMAGE_TAG=v$(E2S_RELEASE_TAG).20260512.1
 container-service:
 	@test -n "$(DOCKER_REPO)" || (echo "DOCKER_REPO is not set!" && exit 1)
 	DOCKER_BUILDKIT=1 docker build -t $(E2S_IMAGE_NAME):$(E2S_IMAGE_TAG) -f serve/Dockerfile .

--- a/earth2studio/serve/server/config.py
+++ b/earth2studio/serve/server/config.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Literal, Optional, cast
 
 from loguru import logger
+from tqdm import tqdm
 
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -461,8 +462,6 @@ class ConfigManager:
 
     def setup_logging(self) -> None:
         """Configure logging using loguru."""
-        from tqdm import tqdm
-
         logger.remove()
         logger.configure(extra={"execution_id": ""})
         logger.add(

--- a/earth2studio/serve/server/config.py
+++ b/earth2studio/serve/server/config.py
@@ -461,16 +461,23 @@ class ConfigManager:
 
     def setup_logging(self) -> None:
         """Configure logging using loguru."""
+        from tqdm import tqdm
+
         logger.remove()
         logger.configure(extra={"execution_id": ""})
         logger.add(
-            sys.stderr,
+            lambda msg: tqdm.write(msg, end="", file=sys.stderr),
             format=self.config.logging.format,
             level=self.config.logging.level.upper(),
+            colorize=False,
         )
 
         # Intercept stdlib loggers (uvicorn, FastAPI, etc.) into loguru
-        logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
+        logging.basicConfig(
+            handlers=[_InterceptHandler()],
+            level=logging.getLevelName(self.config.logging.level.upper()),
+            force=True,
+        )
 
     @property
     def workflow_config(self) -> dict[str, Any]:

--- a/serve/Dockerfile
+++ b/serve/Dockerfile
@@ -38,6 +38,10 @@ RUN apt-get update && apt-get install -y redis-server && rm -rf /var/lib/apt/lis
     uv pip install --system --break-system-packages ".[dlwp,dlesym,pangu,sfno,stormcast,fcn3,serve,cbottle,corrdiff,cyclone,data,perturbation,statistics]" && \
     rm -rf /workspace/earth2studio-project/earth2studio /workspace/earth2studio-project/pyproject.toml /workspace/earth2studio-project/README.md
 
+# Pin warp-lang below 1.12.0 — physicsnemo uses wp.context.Device which was
+# removed/changed in 1.12.0+, causing import failures at runtime.
+RUN uv pip install --system --break-system-packages "warp-lang<1.12.0"
+
 # Critical CVEs
 # Libtasn1: CVEs
 RUN apt-get update && apt-get install -y --only-upgrade libtasn1-6 && rm -rf /var/lib/apt/lists/*

--- a/serve/README.md
+++ b/serve/README.md
@@ -50,10 +50,10 @@ from earth2studio import run
 from earth2studio.data import GFS
 from earth2studio.io import IOBackend
 from earth2studio.models.px import DLWP, FCN
-from earth2studio.serve.server import Earth2Workflow, workflow_registry
+from earth2studio.serve.server import Earth2Workflow, WorkflowRegistry
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class DeterministicEarth2Workflow(Earth2Workflow):
     """
     Deterministic workflow with auto-registration

--- a/serve/server/README_earth2workflows.md
+++ b/serve/server/README_earth2workflows.md
@@ -17,7 +17,7 @@ This is a simplified example demonstrating the key concepts. For complete workin
 `example_workflows` directory.
 
 ```python
-from earth2studio.serve.server import workflow_registry, Earth2Workflow
+from earth2studio.serve.server import WorkflowRegistry, Earth2Workflow
 from earth2studio.io import IOBackend
 from datetime import datetime
 from earth2studio.data import GFS
@@ -25,7 +25,7 @@ from earth2studio.models.px import FCN
 from earth2studio import run
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class ExampleEarth2Workflow(Earth2Workflow):
     name = "example_earth2_workflow"
     description = "example workflow"
@@ -117,10 +117,12 @@ class. In this case, `__init__` has no arguments, so this model is empty.
 
 ## Registration
 
-The `@workflow_registry.register` decorator causes the workflow to be automatically added into the
-API registry when run under the API server. The class-level `name` and `description` attributes are
-used for registration. As with any `Workflow`, your `Earth2Workflow` must be in the directory
-indicated by the `WORKFLOW_DIR` environment variable in order to be discovered by the API server.
+The `@WorkflowRegistry.instance().register` decorator causes the workflow to be
+automatically added into the API registry when run under the API server. The
+class-level `name` and `description` attributes are used for registration. As
+with any `Workflow`, your `Earth2Workflow` must be in the directory indicated by
+the `WORKFLOW_DIR` environment variable in order to be discovered by the API
+server.
 
 ## REST API Usage
 

--- a/serve/server/README_workflows.md
+++ b/serve/server/README_workflows.md
@@ -193,7 +193,7 @@ class MyCustomWorkflow(Workflow):
 
 ### Step 3: Register Your Workflow
 
-The `@workflow_registry.register` decorator will ensure that your workflow gets added to the
+The `@WorkflowRegistry.instance().register` decorator will ensure that your workflow gets added to the
 workflow registry as long as it is found in a file within the directory set by the `WORKFLOW_DIR`
 environment variable.
 
@@ -316,7 +316,7 @@ class DeterministicWorkflowParameters(WorkflowParameters):
 ```python
 from earth2studio.serve.server.workflow import WorkflowProgress
 
-@workflow_registry.register()
+@WorkflowRegistry.instance().register
 class DeterministicWorkflow(Workflow):
     """Earth2Studio deterministic forecast workflow"""
 
@@ -732,7 +732,7 @@ To add your own custom workflows:
 3. **Start the server** - workflows are auto-registered:
 
 Your custom workflows will be registered alongside the built-in example workflows as long as they
-have the `@workflow_registry.register()` decorator.
+have the `@WorkflowRegistry.instance().register` decorator.
 
 ### Example Usage
 
@@ -808,7 +808,7 @@ class MyCustomProgress(WorkflowProgress):
     processing_stage: str = Field("initialization", description="Current processing stage")
     error_count: Optional[int] = Field(None, description="Number of errors encountered")
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class MyWorkflow(Workflow):
     name = "my_workflow"
 

--- a/serve/server/example_workflows/deterministic_earth2_workflow.py
+++ b/serve/server/example_workflows/deterministic_earth2_workflow.py
@@ -29,10 +29,10 @@ from earth2studio import run
 from earth2studio.data import GFS
 from earth2studio.io import IOBackend
 from earth2studio.models.px import DLWP, FCN
-from earth2studio.serve.server import Earth2Workflow, workflow_registry
+from earth2studio.serve.server import Earth2Workflow, WorkflowRegistry
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class DeterministicEarth2Workflow(Earth2Workflow):
     """
     Deterministic workflow with auto-registration

--- a/serve/server/example_workflows/deterministic_fcn.py
+++ b/serve/server/example_workflows/deterministic_fcn.py
@@ -35,7 +35,7 @@ from earth2studio.serve.server.workflow import (
     Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 
 
@@ -79,7 +79,7 @@ class DeterministicFCNWorkflowParameters(WorkflowParameters):
     )
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class DeterministicFCNWorkflow(Workflow):
     """
     Deterministic workflow that runs Earth2Studio deterministic forecasts.

--- a/serve/server/example_workflows/deterministic_workflow.py
+++ b/serve/server/example_workflows/deterministic_workflow.py
@@ -33,7 +33,7 @@ from earth2studio.serve.server.workflow import (
     Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 
 
@@ -82,7 +82,7 @@ class DeterministicWorkflowParameters(WorkflowParameters):
     )
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class DeterministicWorkflow(Workflow):
     """
     Deterministic workflow that runs Earth2Studio deterministic forecasts.

--- a/serve/server/example_workflows/diagnostic_workflow.py
+++ b/serve/server/example_workflows/diagnostic_workflow.py
@@ -32,7 +32,7 @@ from earth2studio.serve.server.workflow import (
     Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 
 
@@ -87,7 +87,7 @@ class DiagnosticWorkflowParameters(WorkflowParameters):
     )
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class DiagnosticWorkflow(Workflow):
     """
     Diagnostic workflow that runs Earth2Studio diagnostic forecasts.

--- a/serve/server/example_workflows/ensemble_workflow.py
+++ b/serve/server/example_workflows/ensemble_workflow.py
@@ -35,7 +35,7 @@ from earth2studio.serve.server.workflow import (
     Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 
 
@@ -109,7 +109,7 @@ class EnsembleWorkflowParameters(WorkflowParameters):
     )
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class EnsembleWorkflow(Workflow):
     """
     Ensemble workflow that runs Earth2Studio ensemble forecasts.

--- a/serve/server/example_workflows/example_user_workflow.py
+++ b/serve/server/example_workflows/example_user_workflow.py
@@ -42,7 +42,7 @@ from earth2studio.serve.server.workflow import (
     Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 
 
@@ -77,7 +77,7 @@ class ExampleUserWorkflowParameters(WorkflowParameters):
     )
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class ExampleUserWorkflow(Workflow):
     """
     Example user workflow demonstrating the workflow pattern.

--- a/serve/server/example_workflows/foundry_fcn3.py
+++ b/serve/server/example_workflows/foundry_fcn3.py
@@ -31,7 +31,7 @@ from earth2studio.serve.server import (
     Earth2Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 from earth2studio.utils.coords import CoordSystem, map_coords, split_coords
 from earth2studio.utils.time import timearray_to_datetime, to_time_array
@@ -40,7 +40,7 @@ _MAX_FORECAST_STEPS = 400
 _MAX_ENSEMBLE_SAMPLES = 32
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class FoundryFCN3Workflow(Earth2Workflow):
     """FCN3 ensemble inference workflow for Foundry using ECMWF IFS initial conditions."""
 

--- a/serve/server/example_workflows/foundry_fcn3_stormscope_goes.py
+++ b/serve/server/example_workflows/foundry_fcn3_stormscope_goes.py
@@ -44,7 +44,7 @@ from earth2studio.serve.server import (
     Earth2Workflow,
     WorkflowParameters,
     WorkflowProgress,
-    workflow_registry,
+    WorkflowRegistry,
 )
 from earth2studio.utils.coords import CoordSystem, map_coords, split_coords
 from earth2studio.utils.time import timearray_to_datetime, to_time_array
@@ -55,7 +55,7 @@ _MAX_FORECAST_STEPS = 32
 _MAX_ENSEMBLE_SAMPLES = 32
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class FoundryFCN3StormScopeGOESWorkflow(Earth2Workflow):
     """FCN3 (with interpolation) plus StormScope GOES diagnostic ensemble for Foundry."""
 

--- a/serve/server/example_workflows/stormcast_fcn3_workflow.py
+++ b/serve/server/example_workflows/stormcast_fcn3_workflow.py
@@ -28,10 +28,10 @@ from earth2studio.data import GFS, HRRR, InferenceOutputSource
 from earth2studio.io import IOBackend, NetCDF4Backend, XarrayBackend
 from earth2studio.models.dx import DerivedSurfacePressure
 from earth2studio.models.px import FCN3, DiagnosticWrapper, InterpModAFNO, StormCast
-from earth2studio.serve.server import Earth2Workflow, workflow_registry
+from earth2studio.serve.server import Earth2Workflow, WorkflowRegistry
 
 
-@workflow_registry.register
+@WorkflowRegistry.instance().register
 class StormCastFCN3Workflow(Earth2Workflow):
     name = "stormcast_fcn3_workflow"
     description = "StormCast + FCN3 workflow"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
This PR fixes three issues that surfaced after the recent loguru migration and WorkflowRegistry singleton changes were deployed:

1. Fix ImportError for workflow_registry in all example workflows

The previous PR removed the workflow_registry module-level instance from earth2studio.serve.server.workflow, replacing it with WorkflowRegistry.instance(). 

2. Pin warp-lang<1.12.0 in serve/Dockerfile

The stormcast_fcn3_workflow.py failed to import due to an incompatible warp-lang version. physicsnemo uses wp.context.Device which was changed in warp-lang 1.12.0+. Added a version pin after the main earth2studio install.

3. Fix tqdm progress bar rendering broken by loguru migration

The loguru setup_logging() wrote directly to sys.stderr, interleaving with tqdm's in-place progress bars during ensemble inference. This caused duplicated lines with excessive blank spacing. Fixed by routing loguru output through tqdm.write() which cooperates with active progress bars, and by setting the stdlib intercept handler level to match the configured level (instead of intercepting everything at level 0).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
