### PR TITLE
Fixing pressure in UFS to be Pa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed potential `uint16` underflow in UFS channel index expansion
 - S3 upload bug in server utilities
+- Fixed pres obs from UFS to be Pascal units
 
 ### Security
 

--- a/earth2studio/data/ufs.py
+++ b/earth2studio/data/ufs.py
@@ -548,6 +548,9 @@ class UFSObsConv(_UFSObsBase):
         # Convert hours offset to timedelta, and add to datetime of file
         if name == "Time":
             values = pd.to_timedelta(values, unit="h") + task.datetime_file
+        # GSI stores Pressure in hPa (mb), convert to Pa
+        elif name == "Pressure":
+            values = values * 100.0
         return values
 
     def _build_column_map(self, schema: pa.Schema) -> dict[str, str]:

--- a/earth2studio/lexicon/ufs.py
+++ b/earth2studio/lexicon/ufs.py
@@ -16,6 +16,7 @@
 
 from collections.abc import Callable
 
+import numpy as np
 import pandas as pd
 
 from .base import LexiconType
@@ -90,6 +91,12 @@ class GSIConventionalLexicon(metaclass=LexiconType):
 
             def mod(x: pd.DataFrame) -> pd.DataFrame:
                 return x[(x["elev"] >= 90) & (x["elev"] <= 110)]
+
+        elif val == "pres":
+            # GSI stores surface pressure observations in hPa (mb), convert to Pa
+            def mod(x: pd.DataFrame) -> pd.DataFrame:
+                x["observation"] = np.float32(x["observation"] * 100.0)
+                return x
 
         else:
 

--- a/earth2studio/lexicon/ufs.py
+++ b/earth2studio/lexicon/ufs.py
@@ -95,7 +95,7 @@ class GSIConventionalLexicon(metaclass=LexiconType):
         elif val == "pres":
             # GSI stores surface pressure observations in hPa (mb), convert to Pa
             def mod(x: pd.DataFrame) -> pd.DataFrame:
-                x["observation"] = np.float32(x["observation"] * 100.0)
+                x["observation"] = (x["observation"] * 100.0).astype(np.float32)
                 return x
 
         else:

--- a/earth2studio/models/da/healda.py
+++ b/earth2studio/models/da/healda.py
@@ -645,11 +645,16 @@ class HealDA(torch.nn.Module, AutoModelMixin):
         if unknown_vars:
             raise ValueError(f"Unknown conventional variable(s): {unknown_vars}")
 
-        # Earth2Studio default to always providing pressure in Pa, HealDA was trained on
-        # UFS data which by default is in mb/hPa. So we need to convert.
+        # HealDA expects pressure-like values in hPa. Earth2Studio/UFS feeds may
+        # provide Pa or hPa, so convert only values that are clearly in Pa.
         obs_hpa = df["observation"].values.astype(np.float64)
-        obs_hpa[df["variable"].values == "pres"] /= 100.0
-        pressure_hpa = (df["pres"].values.astype(np.float32) / 100.0).astype(np.float32)
+        is_pres_obs = df["variable"].values == "pres"
+        obs_pa_mask = is_pres_obs & np.isfinite(obs_hpa) & (obs_hpa > 2000.0)
+        obs_hpa[obs_pa_mask] /= 100.0
+
+        pressure_hpa = df["pres"].values.astype(np.float32)
+        pressure_pa_mask = np.isfinite(pressure_hpa) & (pressure_hpa > 2000.0)
+        pressure_hpa[pressure_pa_mask] /= 100.0
 
         return pd.DataFrame(
             {
@@ -855,21 +860,21 @@ class HealDA(torch.nn.Module, AutoModelMixin):
             obs = pd.concat(ordered_parts, ignore_index=True)
         else:
             obs = pd.DataFrame(
-                columns=[
-                    "lat",
-                    "lon",
-                    "obs_time_ns",
-                    "observation",
-                    "local_channel",
-                    "local_platform",
-                    "sensor",
-                    "obs_type",
-                    "height",
-                    "pressure",
-                    "scan_angle",
-                    "sat_zenith_angle",
-                    "sol_zenith_angle",
-                ]
+                {
+                    "lat": np.empty(0, dtype=np.float32),
+                    "lon": np.empty(0, dtype=np.float32),
+                    "obs_time_ns": np.empty(0, dtype="datetime64[ns]"),
+                    "observation": np.empty(0, dtype=np.float32),
+                    "local_channel": np.empty(0, dtype=np.int32),
+                    "local_platform": np.empty(0, dtype=np.int64),
+                    "sensor": np.empty(0, dtype=str),
+                    "obs_type": np.empty(0, dtype=np.int32),
+                    "height": np.empty(0, dtype=np.float32),
+                    "pressure": np.empty(0, dtype=np.float32),
+                    "scan_angle": np.empty(0, dtype=np.float32),
+                    "sat_zenith_angle": np.empty(0, dtype=np.float32),
+                    "sol_zenith_angle": np.empty(0, dtype=np.float32),
+                }
             )
 
         def to_dev(col: str) -> torch.Tensor:

--- a/earth2studio/models/da/healda.py
+++ b/earth2studio/models/da/healda.py
@@ -645,12 +645,18 @@ class HealDA(torch.nn.Module, AutoModelMixin):
         if unknown_vars:
             raise ValueError(f"Unknown conventional variable(s): {unknown_vars}")
 
+        # Earth2Studio default to always providing pressure in Pa, HealDA was trained on
+        # UFS data which by default is in mb/hPa. So we need to convert.
+        obs_hpa = df["observation"].values.astype(np.float64)
+        obs_hpa[df["variable"].values == "pres"] /= 100.0
+        pressure_hpa = (df["pres"].values.astype(np.float32) / 100.0).astype(np.float32)
+
         return pd.DataFrame(
             {
                 "lat": df["lat"].values.astype(np.float32),
                 "lon": df["lon"].values.astype(np.float32),
                 "obs_time_ns": df["time"].values.astype("datetime64[ns]"),
-                "observation": df["observation"].values.astype(np.float64),
+                "observation": obs_hpa,
                 "local_channel": df["variable"]
                 .map(CONV_VAR_CHANNEL)
                 .values.astype(np.int32),
@@ -658,7 +664,7 @@ class HealDA(torch.nn.Module, AutoModelMixin):
                 "sensor": "conv",
                 "obs_type": df["type"].fillna(0).values.astype(np.int32),
                 "height": df["elev"].values.astype(np.float32),
-                "pressure": df["pres"].values.astype(np.float32),
+                "pressure": pressure_hpa,
                 "scan_angle": np.float32(np.nan),
                 "sat_zenith_angle": np.float32(np.nan),
                 "sol_zenith_angle": np.float32(np.nan),

--- a/test/models/da/test_da_healda.py
+++ b/test/models/da/test_da_healda.py
@@ -131,7 +131,7 @@ def _build_model(device="cpu", lat_lon=False):
 
 
 def _build_raw_conv_df(n_obs=10, request_time=None):
-    """Raw input format matching conv_schema (time, variable, type, elev, pres)."""
+    """Raw input format matching conv_schema (time, variable, type, elev, pres in Pa)."""
     if request_time is None:
         request_time = np.array([np.datetime64("2024-01-01T12:00:00")])
     df = pd.DataFrame(
@@ -143,7 +143,7 @@ def _build_raw_conv_df(n_obs=10, request_time=None):
             "variable": "t",
             "type": "0",
             "elev": np.full(n_obs, 100.0, dtype=np.float32),
-            "pres": np.full(n_obs, 500.0, dtype=np.float32),
+            "pres": np.full(n_obs, 50000.0, dtype=np.float32),
         }
     )
     df.attrs = {"request_time": request_time}


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Closes: https://github.com/NVIDIA/earth2studio/issues/850
Unit issue in UFS not being Pa

Fixed plot:

<img width="1242" height="955" alt="image" src="https://github.com/user-attachments/assets/80cb3886-b2d7-424d-aae1-4410ae1bd4a5" />


NOTE: The one field that is very different still is rawinsonde from the scatter plots, seen here:

<img width="2068" height="519" alt="image" src="https://github.com/user-attachments/assets/2ebcd196-454d-45a0-b5e9-b2be04ace7d5" />

This is entirely just due to the order of the data... a 3d scatter to show the data aligns correctly

<img width="2013" height="943" alt="rawinsonde_3d_comparison" src="https://github.com/user-attachments/assets/f7c3ec43-5b86-45b1-bb8d-4c6eb44c7a19" />

<details>

<summary>radiosonde plot script</summary>

```python
"""3D scatter comparison: NNJA vs UFS type-120 rawinsonde observations.

Z-axis = pressure level (hPa), color = observation value (temperature in K).
"""

from datetime import datetime

import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

from earth2studio.data import NNJAObsConv, UFSObsConv

# Pick a time that both sources cover (UFS starts 1994, NNJA starts 1979)
# Using a 6-hour cycle time
TIME = datetime(2024, 1, 15, 0)
VARIABLE = "t"  # temperature (K after lexicon conversion)
OBS_TYPE = 120  # rawinsonde

print(f"Fetching UFS data for {TIME}, variable={VARIABLE}...")
ufs = UFSObsConv(cache=True, verbose=True)
df_ufs = ufs(TIME, VARIABLE)
print(f"  UFS total rows: {len(df_ufs)}")

print(f"Fetching NNJA data for {TIME}, variable={VARIABLE}...")
nnja = NNJAObsConv(cache=True, verbose=True)
df_nnja = nnja(TIME, VARIABLE)
print(f"  NNJA total rows: {len(df_nnja)}")

# Filter to type 120 (rawinsonde)
df_ufs_120 = df_ufs[df_ufs["type"] == OBS_TYPE].copy()
df_nnja_120 = df_nnja[df_nnja["type"] == OBS_TYPE].copy()
print(f"  UFS type 120 rows: {len(df_ufs_120)}")
print(f"  NNJA type 120 rows: {len(df_nnja_120)}")

# Pressure is in Pa after our conversion; convert back to hPa for z-axis display
df_ufs_120["pres_hpa"] = df_ufs_120["pres"] / 100.0
df_nnja_120["pres_hpa"] = df_nnja_120["pres"] / 100.0

# Drop NaN observations or pressure
df_ufs_120 = df_ufs_120.dropna(subset=["lat", "lon", "pres_hpa", "observation"])
df_nnja_120 = df_nnja_120.dropna(subset=["lat", "lon", "pres_hpa", "observation"])

print(f"  UFS type 120 after dropna: {len(df_ufs_120)}")
print(f"  NNJA type 120 after dropna: {len(df_nnja_120)}")

# Shared colorbar range
vmin = min(df_ufs_120["observation"].min(), df_nnja_120["observation"].min())
vmax = max(df_ufs_120["observation"].max(), df_nnja_120["observation"].max())

fig = plt.figure(figsize=(16, 7))

# --- UFS subplot ---
ax1 = fig.add_subplot(121, projection="3d")
sc1 = ax1.scatter(
    df_ufs_120["lon"],
    df_ufs_120["lat"],
    df_ufs_120["pres_hpa"],
    c=df_ufs_120["observation"],
    cmap="RdYlBu_r",
    vmin=vmin,
    vmax=vmax,
    s=3,
    alpha=0.6,
)
ax1.set_xlabel("Longitude")
ax1.set_ylabel("Latitude")
ax1.set_zlabel("Pressure (hPa)")
ax1.invert_zaxis()  # Higher pressure (surface) at bottom
ax1.set_title(f"UFS Type 120 Rawinsonde\n{TIME} | {VARIABLE} | N={len(df_ufs_120)}")

# --- NNJA subplot ---
ax2 = fig.add_subplot(122, projection="3d")
sc2 = ax2.scatter(
    df_nnja_120["lon"],
    df_nnja_120["lat"],
    df_nnja_120["pres_hpa"],
    c=df_nnja_120["observation"],
    cmap="RdYlBu_r",
    vmin=vmin,
    vmax=vmax,
    s=3,
    alpha=0.6,
)
ax2.set_xlabel("Longitude")
ax2.set_ylabel("Latitude")
ax2.set_zlabel("Pressure (hPa)")
ax2.invert_zaxis()
ax2.set_title(f"NNJA Type 120 Rawinsonde\n{TIME} | {VARIABLE} | N={len(df_nnja_120)}")

# Shared colorbar
fig.subplots_adjust(right=0.88)
cbar_ax = fig.add_axes([0.90, 0.15, 0.02, 0.7])
cbar = fig.colorbar(sc2, cax=cbar_ax)
cbar.set_label(f"Observation ({VARIABLE})")

plt.suptitle(
    f"3D Rawinsonde Comparison (Type {OBS_TYPE}): UFS vs NNJA\n{TIME.isoformat()}",
    fontsize=13,
    y=0.98,
)

plt.savefig("rawinsonde_3d_comparison.png", dpi=150, bbox_inches="tight")
print("\nSaved: rawinsonde_3d_comparison.png")
plt.show()
```

</details>


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
