### PR TITLE
feat: add GOESGLM data source

### DIFF
--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -1378,19 +1378,23 @@ Keep-a-Changelog format:
 ### Added
 
 - Added <SourceName> <source_type> for <brief description> (`ClassName`)
-- Added `SourceNameLexicon` for <source> variable mappings
 
 ### Dependencies
 
 - Added `<package>` to `data` optional dependency group (if applicable)
 ```
 
+> **One line per data source.** The lexicon ships with the source and
+> is implied by it — do NOT add a separate `Added <SourceName>Lexicon`
+> bullet. Reviewers have flagged this as noise. The CHANGELOG entry
+> should describe the user-facing capability, not the internal
+> implementation pieces.
+
 Look at existing entries for style reference. For example, recent
 additions look like:
 
 ```markdown
 - Added CAMS Global atmospheric composition forecast data source (`CAMS_FX`)
-- Added `CAMSGlobalLexicon` for CAMS variable mappings (AOD, total column gases)
 ```
 
 If no new dependencies were added, omit the Dependencies subsection
@@ -1435,6 +1439,50 @@ Fix all errors before proceeding. Re-run until clean.
 ## Step 12 — Write Pytest Unit Tests
 
 Create `test/data/test_<filename>.py` following the existing patterns.
+
+### 12.0. Canonical test names and ordering (REQUIRED)
+
+**Every test name in this file must use the prefix
+`test_<source_name>_` (lowercase, underscore-separated).** Do not
+invent ad-hoc names like `test_filename_start_parse` or
+`test_validate_time_and_available` — they fail to match the rest of
+the codebase and have been called out in reviews. Use the canonical
+suffixes below, in this order:
+
+| Section | Test name (suffix) | Purpose |
+|---|---|---|
+| Mock end-to-end | `*_call_mock` | Full `__call__` happy path, full schema |
+| Mock end-to-end | `*_call_mock_fields_subset` | `fields=` subset path |
+| Mock end-to-end | `*_call_mock_empty` | Empty discovery / empty result |
+| Mock end-to-end | `*_call_mock_bbox` | Spatial-filter path (DataFrameSource only) |
+| Network (slow, xfail) | `*_fetch` | Real-network smoke test |
+| Network (slow, xfail) | `*_cache` | `cache=True / False` toggle |
+| Unit — errors | `*_exceptions` | Constructor + call + `resolve_fields` errors, **one test**, multiple `pytest.raises` |
+| Unit — fields | `*_resolve_fields` | `resolve_fields(None/str/list/Schema)` |
+| Unit — availability | `*_available` | `available()` classmethod |
+| Unit — time check | `*_validate_time` | Internal time-window check (only if class has one) |
+| Unit — config | `*_tolerance_conversion` | `time_tolerance` normalisation |
+| Unit — routing | `*_satellite_routing` | Multi-platform / slot routing (sat sources only) |
+| Unit — parser | `*_parse_file` | Internal NetCDF/GRIB/BUFR parser |
+| Internal plumbing | `*_discover_files` | S3 listing + window filter (one test, mocked `fs._ls`) |
+| Internal plumbing | `*_fetch_remote_file` | S3 download path (one test, mocked `fs._cat_file`) |
+
+**Rules:**
+
+1. **Match the order above.** Reviewers scan the file top-to-bottom
+   and expect the mock tests first, network tests second, unit tests
+   third, internal plumbing last.
+2. **One test per concern.** Do not split happy-path/error/edge-case
+   into three separate functions for the same internal helper — fold
+   them into a single canonical test using multiple assertions or
+   `pytest.raises` blocks.
+3. **Do NOT test trivial helpers in isolation.** Filename parsing,
+   epoch-string conversion, and similar one-line helpers are exercised
+   transitively by the mock tests and parser test; a dedicated
+   `test_*_filename_parse` or `test_*_event_times_fallback` is noise
+   that reviewers will ask you to remove.
+4. **No docstrings on test functions** — the canonical name is the
+   only label needed.
 
 ### 12a. Test file structure for DataSource
 

--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -1451,40 +1451,20 @@ suffixes below, in this order:
 
 | Section | Test name (suffix) | Purpose |
 |---|---|---|
-| Mock end-to-end | `*_call_mock` | Full `__call__` happy path, full schema |
-| Mock end-to-end | `*_call_mock_fields_subset` | `fields=` subset path |
-| Mock end-to-end | `*_call_mock_empty` | Empty discovery / empty result |
-| Mock end-to-end | `*_call_mock_bbox` | Spatial-filter path (DataFrameSource only) |
 | Network (slow, xfail) | `*_fetch` | Real-network smoke test |
 | Network (slow, xfail) | `*_cache` | `cache=True / False` toggle |
+| Mock end-to-end | `*_call_mock` | Full `__call__` happy path, full schema |
 | Unit — errors | `*_exceptions` | Constructor + call + `resolve_fields` errors, **one test**, multiple `pytest.raises` |
-| Unit — fields | `*_resolve_fields` | `resolve_fields(None/str/list/Schema)` |
 | Unit — availability | `*_available` | `available()` classmethod |
 | Unit — time check | `*_validate_time` | Internal time-window check (only if class has one) |
-| Unit — config | `*_tolerance_conversion` | `time_tolerance` normalisation |
-| Unit — routing | `*_satellite_routing` | Multi-platform / slot routing (sat sources only) |
-| Unit — parser | `*_parse_file` | Internal NetCDF/GRIB/BUFR parser |
-| Internal plumbing | `*_discover_files` | S3 listing + window filter (one test, mocked `fs._ls`) |
-| Internal plumbing | `*_fetch_remote_file` | S3 download path (one test, mocked `fs._cat_file`) |
 
 **Rules:**
 
-1. **Match the order above.** Reviewers scan the file top-to-bottom
-   and expect the mock tests first, network tests second, unit tests
-   third, internal plumbing last.
-2. **One test per concern.** Do not split happy-path/error/edge-case
-   into three separate functions for the same internal helper — fold
-   them into a single canonical test using multiple assertions or
-   `pytest.raises` blocks.
-3. **Do NOT test trivial helpers in isolation.** Filename parsing,
-   epoch-string conversion, and similar one-line helpers are exercised
-   transitively by the mock tests and parser test; a dedicated
-   `test_*_filename_parse` or `test_*_event_times_fallback` is noise
-   that reviewers will ask you to remove.
-4. **No docstrings on test functions** — the canonical name is the
-   only label needed.
+1. **Match the order above following existing data sources**
+3. **Do NOT test trivial helpers in isolation**
+4. **No docstrings on test functions**
 
-### 12a. Test file structure for DataSource
+### 12a. Example test file structure for DataSource
 
 ```python
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.

--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -1461,8 +1461,8 @@ suffixes below, in this order:
 **Rules:**
 
 1. **Match the order above following existing data sources**
-3. **Do NOT test trivial helpers in isolation**
-4. **No docstrings on test functions**
+2. **Do NOT test trivial helpers in isolation**
+3. **No docstrings on test functions**
 
 ### 12a. Example test file structure for DataSource
 

--- a/.claude/skills/create-data-source/SKILL.md
+++ b/.claude/skills/create-data-source/SKILL.md
@@ -1454,7 +1454,7 @@ suffixes below, in this order:
 | Network (slow, xfail) | `*_fetch` | Real-network smoke test |
 | Network (slow, xfail) | `*_cache` | `cache=True / False` toggle |
 | Mock end-to-end | `*_call_mock` | Full `__call__` happy path, full schema |
-| Unit — errors | `*_exceptions` | Constructor + call + `resolve_fields` errors, **one test**, multiple `pytest.raises` |
+| Unit — errors | `*_exceptions` | Single error/exception test, multiple `pytest.raises` |
 | Unit — availability | `*_available` | `available()` classmethod |
 | Unit — time check | `*_validate_time` | Internal time-window check (only if class has one) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Himawari-8/9 AHI ISatSS L2 Full Disk satellite data source (`HimawariAHI`)
 - Added GHCN-Daily global station observation data frame source (`GHCNDaily`)
 - Added NNJA conventional (in-situ + GPS RO) observation data source (`NNJAObsConv`)
+- Added GOES Geostationary Lightning Mapper L2 LCFA event data source (`GOESGLM`)
+- Added `GOESGLMLexicon` and `flashe`/`flashc` vocab entries for GLM lightning events
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GHCN-Daily global station observation data frame source (`GHCNDaily`)
 - Added NNJA conventional (in-situ + GPS RO) observation data source (`NNJAObsConv`)
 - Added GOES Geostationary Lightning Mapper L2 LCFA event data source (`GOESGLM`)
-- Added `GOESGLMLexicon` and `flashe`/`flashc` vocab entries for GLM lightning events
 
 ### Changed
 

--- a/docs/modules/datasources_dataframe.rst
+++ b/docs/modules/datasources_dataframe.rst
@@ -21,6 +21,7 @@ Data sources that provide tabular data as DataFrames.
       :template: datasource.rst
 
       data.GHCNDaily
+      data.GOESGLM
       data.ISD
       data.JPSS_ATMS
       data.JPSS_CRIS

--- a/earth2studio/data/__init__.py
+++ b/earth2studio/data/__init__.py
@@ -27,6 +27,7 @@ from .gefs import GEFS_FX, GEFS_FX_721x1440
 from .gfs import GFS, GFS_FX
 from .ghcn import GHCNDaily
 from .goes import GOES
+from .goes_glm import GOESGLM
 from .himawari_ahi import HimawariAHI
 from .hrrr import HRRR, HRRR_FX
 from .isd import ISD

--- a/earth2studio/data/goes_glm.py
+++ b/earth2studio/data/goes_glm.py
@@ -83,6 +83,11 @@ _SLOT_HISTORY: dict[str, tuple[tuple[str, datetime, datetime], ...]] = {
 
 _GLM_MIN_DATE = datetime(2018, 2, 13)
 
+# Each LCFA file covers a ~20 s scan; widen the lower file-start bound by
+# this much so events at the leading edge of a tight tolerance window are
+# not silently dropped.
+_GLM_FILE_DURATION = timedelta(seconds=20)
+
 
 @dataclass(frozen=True)
 class _GOESGLMFile:
@@ -412,10 +417,11 @@ class GOESGLM:
                 for tmin, tmax, win_sat in windows:
                     if win_sat != sat:
                         continue
-                    # GLM files cover ~20 s; treat ``file_start`` as the
-                    # representative time and keep any file whose start
-                    # lies in the requested window.
-                    if tmin <= file_start <= tmax:
+                    # GLM files cover ~20 s; accept any file whose scan
+                    # starts within one file duration before ``tmin`` so
+                    # events at the leading edge of the window are not
+                    # silently dropped for tight tolerances.
+                    if tmin - _GLM_FILE_DURATION <= file_start <= tmax:
                         uri = (
                             f"s3://{key}"
                             if key.startswith(_BUCKETS[sat])
@@ -508,7 +514,10 @@ class GOESGLM:
 
     def _empty_result(self, schema: pa.Schema) -> pd.DataFrame:
         empty = pd.DataFrame(
-            {name: pd.Series(dtype=object) for name in self.SCHEMA.names}
+            {
+                f.name: pd.Series(dtype=_arrow_to_pandas_dtype(f.type))
+                for f in self.SCHEMA
+            }
         )
         empty.attrs["source"] = self.SOURCE_ID
         return empty[[name for name in schema.names if name in empty.columns]]
@@ -622,6 +631,20 @@ class GOESGLM:
                 )
             selected.append(cls.SCHEMA.field(name))
         return pa.schema(selected)
+
+
+def _arrow_to_pandas_dtype(arrow_type: pa.DataType) -> Any:
+    """Map a PyArrow type to a pandas/numpy dtype for empty-DataFrame stubs."""
+    if pa.types.is_timestamp(arrow_type):
+        unit = arrow_type.unit
+        return f"datetime64[{unit}]"
+    if pa.types.is_floating(arrow_type):
+        return np.dtype(arrow_type.to_pandas_dtype())
+    if pa.types.is_integer(arrow_type):
+        return np.dtype(arrow_type.to_pandas_dtype())
+    if pa.types.is_string(arrow_type):
+        return object
+    return object
 
 
 def _parse_filename_start(key: str) -> datetime | None:

--- a/earth2studio/data/goes_glm.py
+++ b/earth2studio/data/goes_glm.py
@@ -1,0 +1,727 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pathlib
+import shutil
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import s3fs
+from loguru import logger
+
+from earth2studio.data.utils import (
+    _sync_async,
+    async_retry,
+    datasource_cache_root,
+    gather_with_concurrency,
+    managed_session,
+    prep_data_inputs,
+)
+from earth2studio.lexicon import GOESGLMLexicon
+from earth2studio.lexicon.base import E2STUDIO_SCHEMA
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.time import normalize_time_tolerance
+from earth2studio.utils.type import TimeArray, TimeTolerance, VariableArray
+
+try:
+    import netCDF4
+except ImportError:
+    OptionalDependencyFailure("data")
+    netCDF4 = None  # type: ignore[assignment]
+
+
+_GLM_PREFIX = "GLM-L2-LCFA"
+
+_BUCKETS = {
+    "G16": "noaa-goes16",
+    "G17": "noaa-goes17",
+    "G18": "noaa-goes18",
+    "G19": "noaa-goes19",
+}
+
+# Each entry: (platform, start, end) - the platform is the active GOES
+# satellite for the slot during ``[start, end)``. Boundaries are inclusive
+# on the lower side and exclusive on the upper side. These dates reflect
+# the public AWS GLM-L2-LCFA archive coverage; explicit-satellite requests
+# outside a platform's window will simply return no events from S3.
+_SLOT_HISTORY: dict[str, tuple[tuple[str, datetime, datetime], ...]] = {
+    "east": (
+        ("G16", datetime(2018, 2, 13), datetime(2025, 4, 4)),
+        ("G19", datetime(2025, 4, 4), datetime.max),
+    ),
+    "west": (
+        ("G17", datetime(2018, 12, 10), datetime(2023, 1, 4)),
+        ("G18", datetime(2023, 1, 4), datetime.max),
+    ),
+}
+
+_GLM_MIN_DATE = datetime(2018, 2, 13)
+
+
+@dataclass(frozen=True)
+class _GOESGLMFile:
+    """One GLM L2 LCFA NetCDF file scheduled for download."""
+
+    s3_uri: str
+    satellite: str
+    file_start: datetime
+
+
+@check_optional_dependencies()
+class GOESGLM:
+    """NOAA GOES Geostationary Lightning Mapper (GLM) Level 2 Lightning
+    Cluster-Filter Algorithm (LCFA) event data source.
+
+    Returns per-event lightning observations from the GLM instrument on
+    GOES-16/17/18/19, served as point observations in a pandas
+    DataFrame. Each row corresponds to a single optical event detected
+    by GLM with a sub-second timestamp, latitude/longitude, and the
+    requested measurement (``flashe`` for optical energy in Joules,
+    ``flashc`` for a constant 1.0 per detected event suitable for
+    density aggregation).
+
+    Files in the public NOAA AWS bucket are NetCDFs produced at roughly
+    20 second cadence covering the GOES full-disk field of view. A
+    spatial bounding box can be supplied to restrict events at parse
+    time and reduce memory usage for large windows.
+
+    Parameters
+    ----------
+    satellite : str, optional
+        Source satellite selector. Pass ``"east"`` (default) or
+        ``"west"`` to auto-select the active GOES-East / GOES-West
+        platform for each requested timestamp; pass ``"G16"``,
+        ``"G17"``, ``"G18"`` or ``"G19"`` to pin a single platform.
+    bbox : tuple[float, float, float, float] | None, optional
+        ``(lat_min, lat_max, lon_min, lon_max)`` filter applied at
+        parse time. Coordinates use the GLM native convention
+        (latitude in ``[-90, 90]``, longitude in ``[-180, 180)``).
+        ``None`` (default) returns the full disk. For example, CONUS
+        is ``(24.5, 49.5, -125.0, -66.0)``.
+    time_tolerance : TimeTolerance, optional
+        Time tolerance window for selecting events around each
+        requested timestamp. Accepts a single value (symmetric ±
+        window) or a tuple ``(lower, upper)`` for asymmetric windows,
+        by default ``np.timedelta64(2, "m")``.
+    cache : bool, optional
+        Cache downloaded NetCDF files on local disk, by default True.
+    verbose : bool, optional
+        Show download progress bar, by default True.
+    async_timeout : int, optional
+        Total timeout in seconds for the entire fetch operation,
+        by default 600.
+    async_workers : int, optional
+        Maximum number of concurrent S3 fetch tasks, by default 24.
+    retries : int, optional
+        Number of retry attempts per failed fetch task with
+        exponential backoff, by default 3.
+
+    Warning
+    -------
+    GLM produces hundreds of files per hour. Large time windows can
+    download tens to hundreds of gigabytes of NetCDFs. Use ``bbox`` to
+    discard out-of-region events on parse and keep ``time_tolerance``
+    bounded.
+
+    Note
+    ----
+    Output longitudes are normalised to ``[0, 360)`` (Earth2Studio
+    convention). Each event's timestamp is computed from the file's
+    ``event_time_offset`` variable so per-event precision (~ms) is
+    preserved.
+
+    Note
+    ----
+    Additional information on the data repository:
+
+    - https://www.goes-r.gov/products/baseline-LCFA.html
+    - https://registry.opendata.aws/noaa-goes/
+    - https://www.ncei.noaa.gov/products/satellite/goes-glm
+
+    Example
+    -------
+    .. highlight:: python
+    .. code-block:: python
+
+        from datetime import datetime
+        import numpy as np
+        from earth2studio.data import GOESGLM
+
+        ds = GOESGLM(
+            satellite="east",
+            bbox=(24.5, 49.5, -125.0, -66.0),  # CONUS
+            time_tolerance=np.timedelta64(5, "m"),
+        )
+        df = ds(datetime(2024, 6, 1, 18, 0), ["flashe", "flashc"])
+
+    Badges
+    ------
+    region:na region:sa dataclass:observation product:insitu
+    """
+
+    SOURCE_ID = "earth2studio.data.goes_glm"
+    SCHEMA = pa.schema(
+        [
+            E2STUDIO_SCHEMA.field("time"),
+            E2STUDIO_SCHEMA.field("lat"),
+            E2STUDIO_SCHEMA.field("lon"),
+            E2STUDIO_SCHEMA.field("observation"),
+            E2STUDIO_SCHEMA.field("variable"),
+            pa.field(
+                "satellite",
+                pa.string(),
+                metadata={"description": "GOES satellite platform (G16/G17/G18/G19)"},
+            ),
+        ]
+    )
+
+    def __init__(
+        self,
+        satellite: str = "east",
+        bbox: tuple[float, float, float, float] | None = None,
+        time_tolerance: TimeTolerance = np.timedelta64(2, "m"),
+        cache: bool = True,
+        verbose: bool = True,
+        async_timeout: int = 600,
+        async_workers: int = 24,
+        retries: int = 3,
+    ) -> None:
+        sat = (
+            satellite.lower()
+            if satellite.lower() in ("east", "west")
+            else (satellite.upper())
+        )
+        if sat not in ("east", "west") and sat not in _BUCKETS:
+            raise ValueError(
+                f"Unknown satellite {satellite!r}; expected one of "
+                f"'east', 'west', {sorted(_BUCKETS)}"
+            )
+        self._satellite = sat
+
+        if bbox is not None:
+            lat_min, lat_max, lon_min, lon_max = bbox
+            if lat_min >= lat_max or lon_min >= lon_max:
+                raise ValueError(
+                    f"bbox bounds must be (lat_min < lat_max, lon_min < lon_max); "
+                    f"got {bbox}"
+                )
+        self._bbox = bbox
+
+        lower, upper = normalize_time_tolerance(time_tolerance)
+        self._tolerance_lower = pd.to_timedelta(lower).to_pytimedelta()
+        self._tolerance_upper = pd.to_timedelta(upper).to_pytimedelta()
+
+        self._cache = cache
+        self._verbose = verbose
+        self._async_workers = async_workers
+        self._retries = retries
+        self.async_timeout = async_timeout
+        self._tmp_cache_hash: str | None = None
+
+        self.fs: s3fs.S3FileSystem | None = None
+
+    async def _async_init(self) -> None:
+        """Async initialization of the anonymous S3 filesystem.
+
+        Note
+        ----
+        Async fsspec expects initialization inside the execution loop.
+        """
+        self.fs = s3fs.S3FileSystem(
+            anon=True,
+            client_kwargs={},
+            asynchronous=True,
+            skip_instance_cache=True,
+        )
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+        fields: str | list[str] | pa.Schema | None = None,
+    ) -> pd.DataFrame:
+        """Fetch GLM lightning events for a set of timestamps.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return events for (UTC). Timezone-aware
+            datetimes are converted to UTC automatically.
+        variable : str | list[str] | VariableArray
+            Variable ids defined in
+            :py:class:`earth2studio.lexicon.GOESGLMLexicon`
+            (``"flashe"`` and/or ``"flashc"``).
+        fields : str | list[str] | pa.Schema | None, optional
+            Output column subset. ``None`` (default) returns all
+            schema fields.
+
+        Returns
+        -------
+        pd.DataFrame
+            Event-level lightning observations with columns matching
+            the resolved schema.
+        """
+        try:
+            df = _sync_async(
+                self.fetch, time, variable, fields, timeout=self.async_timeout
+            )
+        finally:
+            if not self._cache:
+                shutil.rmtree(self.cache, ignore_errors=True)
+        return df
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+        fields: str | list[str] | pa.Schema | None = None,
+    ) -> pd.DataFrame:
+        """Async function to fetch GLM events.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return events for (UTC).
+        variable : str | list[str] | VariableArray
+            Variable ids defined in :py:class:`GOESGLMLexicon`.
+        fields : str | list[str] | pa.Schema | None, optional
+            Output column subset. ``None`` (default) returns all
+            schema fields.
+
+        Returns
+        -------
+        pd.DataFrame
+            Event-level lightning observations.
+        """
+        if self.fs is None:
+            await self._async_init()
+
+        time_list, variable_list = prep_data_inputs(time, variable)
+        self._validate_time(time_list)
+        for v in variable_list:
+            if v not in GOESGLMLexicon.VOCAB:
+                raise KeyError(
+                    f"Variable id {v!r} not found in GOESGLMLexicon. "
+                    f"Available: {list(GOESGLMLexicon.VOCAB)}"
+                )
+
+        schema = self.resolve_fields(fields)
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        files = await self._discover_files(time_list)
+        unique_uris = sorted({f.s3_uri for f in files})
+        logger.info(
+            f"[{self.SOURCE_ID}] discovered {len(unique_uris)} unique GLM "
+            f"files across {len(time_list)} requested times"
+        )
+
+        async with managed_session(self.fs):
+            coros = [
+                async_retry(
+                    self._fetch_remote_file,
+                    uri,
+                    retries=self._retries,
+                    backoff=1.0,
+                    task_timeout=120.0,
+                    exceptions=(OSError, IOError, TimeoutError, ConnectionError),
+                )
+                for uri in unique_uris
+            ]
+            await gather_with_concurrency(
+                coros,
+                max_workers=self._async_workers,
+                desc="Fetching GLM L2 LCFA files",
+                verbose=(not self._verbose),
+            )
+
+        return self._compile_dataframe(files, time_list, variable_list, schema)
+
+    async def _discover_files(self, time_list: list[datetime]) -> list[_GOESGLMFile]:
+        """List GLM L2 LCFA keys whose file-start times fall in any
+        requested ``[t-tol, t+tol]`` window.
+
+        Hourly S3 prefixes are listed once each (deduplicated) and the
+        per-file start timestamps are parsed from the LCFA filename
+        convention.
+        """
+        prefix_jobs: dict[tuple[str, str], None] = {}
+        windows: list[tuple[datetime, datetime, str]] = []
+        for t in time_list:
+            tmin = t + self._tolerance_lower
+            tmax = t + self._tolerance_upper
+            sat = self._satellite_for_time(t)
+            windows.append((tmin, tmax, sat))
+            # Cover any hours overlapping the window, including the one
+            # containing tmin even when tmax falls back into the prior
+            # bin (negative tolerance).
+            hr = tmin.replace(minute=0, second=0, microsecond=0)
+            stop = tmax if tmax >= tmin else tmin
+            while hr <= stop:
+                prefix_jobs[(sat, self._hour_prefix(sat, hr))] = None
+                hr += timedelta(hours=1)
+
+        async def _list_one(sat: str, prefix: str) -> list[tuple[str, str]]:
+            try:
+                keys = await self.fs._ls(  # type: ignore[union-attr]
+                    f"{_BUCKETS[sat]}/{prefix}", detail=False
+                )
+            except FileNotFoundError:
+                return []
+            return [(sat, k) for k in keys if k.endswith(".nc")]
+
+        listings = await gather_with_concurrency(
+            [_list_one(sat, prefix) for (sat, prefix) in prefix_jobs],
+            max_workers=self._async_workers,
+            desc="Listing GLM L2 LCFA prefixes",
+            verbose=(not self._verbose),
+        )
+
+        out: list[_GOESGLMFile] = []
+        seen_uris: set[str] = set()
+        for entries in listings:
+            for sat, key in entries:
+                file_start = _parse_filename_start(key)
+                if file_start is None:
+                    continue
+                for tmin, tmax, win_sat in windows:
+                    if win_sat != sat:
+                        continue
+                    # GLM files cover ~20 s; treat ``file_start`` as the
+                    # representative time and keep any file whose start
+                    # lies in the requested window.
+                    if tmin <= file_start <= tmax:
+                        uri = (
+                            f"s3://{key}"
+                            if key.startswith(_BUCKETS[sat])
+                            else (f"s3://{_BUCKETS[sat]}/{key}")
+                        )
+                        if uri in seen_uris:
+                            continue
+                        seen_uris.add(uri)
+                        out.append(
+                            _GOESGLMFile(
+                                s3_uri=uri,
+                                satellite=sat,
+                                file_start=file_start,
+                            )
+                        )
+                        break
+        return out
+
+    async def _fetch_remote_file(self, uri: str) -> None:
+        """Download one GLM NetCDF file into the cache directory."""
+        if self.fs is None:
+            raise ValueError("File system is not initialized")
+        cache_path = self._cache_path(uri)
+        if pathlib.Path(cache_path).is_file():
+            return
+        try:
+            data = await self.fs._cat_file(uri)
+        except FileNotFoundError:
+            logger.warning(f"GLM file {uri} not found, skipping")
+            return
+        with open(cache_path, "wb") as fh:
+            fh.write(data)
+
+    def _compile_dataframe(
+        self,
+        files: list[_GOESGLMFile],
+        time_list: list[datetime],
+        variable_list: list[str],
+        schema: pa.Schema,
+    ) -> pd.DataFrame:
+        """Parse each cached file once, filter per requested time, and
+        emit one long-format DataFrame across all variables and times.
+        """
+        # Parse all files (each only once); skip files whose cache is
+        # missing (download skipped due to FileNotFoundError).
+        events_by_file: dict[str, pd.DataFrame] = {}
+        for f in files:
+            local = self._cache_path(f.s3_uri)
+            if not pathlib.Path(local).is_file():
+                continue
+            events = _parse_glm_file(local, self._bbox)
+            if events is None or events.empty:
+                continue
+            events["satellite"] = f.satellite
+            events_by_file[f.s3_uri] = events
+
+        if not events_by_file:
+            return self._empty_result(schema)
+
+        frames: list[pd.DataFrame] = []
+        for t in time_list:
+            tmin = pd.Timestamp(t + self._tolerance_lower)
+            tmax = pd.Timestamp(t + self._tolerance_upper)
+            sat = self._satellite_for_time(t)
+            for events in events_by_file.values():
+                if events["satellite"].iloc[0] != sat:
+                    continue
+                mask = (events["time"] >= tmin) & (events["time"] <= tmax)
+                if not mask.any():
+                    continue
+                window = events.loc[mask]
+                for v in variable_list:
+                    sub = window[["time", "lat", "lon", "satellite"]].copy()
+                    if v == "flashe":
+                        sub["observation"] = window["event_energy"].astype(np.float32)
+                    else:  # flashc
+                        sub["observation"] = np.float32(1.0)
+                    sub["variable"] = v
+                    frames.append(sub)
+
+        if not frames:
+            return self._empty_result(schema)
+
+        df = pd.concat(frames, ignore_index=True)
+        # Normalise longitude from GLM's [-180, 180) to Earth2Studio's [0, 360)
+        df["lon"] = (df["lon"].astype(np.float32) + 360.0) % 360.0
+        df["lat"] = df["lat"].astype(np.float32)
+        df.attrs["source"] = self.SOURCE_ID
+        return df[[name for name in schema.names if name in df.columns]]
+
+    def _empty_result(self, schema: pa.Schema) -> pd.DataFrame:
+        empty = pd.DataFrame(
+            {name: pd.Series(dtype=object) for name in self.SCHEMA.names}
+        )
+        empty.attrs["source"] = self.SOURCE_ID
+        return empty[[name for name in schema.names if name in empty.columns]]
+
+    @classmethod
+    def _validate_time(cls, times: Iterable[datetime]) -> None:
+        """Verify date times fall within the GLM archive window.
+
+        Per-platform availability (G16/G17/G18/G19 cutovers) is enforced
+        downstream in :py:meth:`_satellite_for_time`; this classmethod
+        only screens out timestamps before the earliest archive date.
+        """
+        for t in times:
+            if t < _GLM_MIN_DATE:
+                raise ValueError(
+                    f"Requested datetime {t} is earlier than the GLM "
+                    f"archive start ({_GLM_MIN_DATE.isoformat()})."
+                )
+            now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+            if t > now_utc + timedelta(hours=1):
+                raise ValueError(
+                    f"Requested datetime {t} is in the future; "
+                    f"GLM L2 LCFA archive has no entries beyond now."
+                )
+
+    def _satellite_for_time(self, t: datetime) -> str:
+        """Resolve the configured satellite selector to a concrete
+        platform code for a given timestamp."""
+        if self._satellite in _BUCKETS:
+            return self._satellite
+        for sat, start, end in _SLOT_HISTORY[self._satellite]:
+            if start <= t < end:
+                return sat
+        raise ValueError(
+            f"No active GOES-{self._satellite} satellite known for "
+            f"{t.isoformat()}; check the SLOT_HISTORY in goes_glm.py."
+        )
+
+    @staticmethod
+    def _hour_prefix(sat: str, t: datetime) -> str:
+        doy = t.timetuple().tm_yday
+        return f"{_GLM_PREFIX}/{t.year:04d}/{doy:03d}/{t.hour:02d}/"
+
+    def _cache_path(self, s3_uri: str) -> str:
+        sha = hashlib.sha256(s3_uri.encode()).hexdigest()
+        return os.path.join(self.cache, sha + ".nc")
+
+    @property
+    def cache(self) -> str:
+        """Local cache directory for this data source."""
+        cache_location = os.path.join(datasource_cache_root(), "goes_glm")
+        if not self._cache:
+            if self._tmp_cache_hash is None:
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_goes_glm_{self._tmp_cache_hash}"
+            )
+        return cache_location
+
+    @classmethod
+    def available(cls, time: datetime | np.datetime64) -> bool:
+        """Check if the given date time is in the GLM archive window.
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date time to check.
+
+        Returns
+        -------
+        bool
+            ``True`` when ``time`` falls within the public GLM-L2-LCFA
+            archive window (irrespective of satellite slot). Per-slot
+            cutovers are enforced when the source is actually called.
+        """
+        if isinstance(time, np.datetime64):
+            time = time.astype("datetime64[ns]").astype("datetime64[us]").item()
+        try:
+            cls._validate_time([time])
+        except ValueError:
+            return False
+        return True
+
+    @classmethod
+    def resolve_fields(cls, fields: str | list[str] | pa.Schema | None) -> pa.Schema:
+        """Resolve a ``fields`` selector into a validated PyArrow schema."""
+        if fields is None:
+            return cls.SCHEMA
+        if isinstance(fields, str):
+            fields = [fields]
+        if isinstance(fields, pa.Schema):
+            for f in fields:
+                if f.name not in cls.SCHEMA.names:
+                    raise KeyError(
+                        f"Field '{f.name}' not in {cls.__name__} SCHEMA. "
+                        f"Available: {cls.SCHEMA.names}"
+                    )
+                expected = cls.SCHEMA.field(f.name).type
+                if f.type != expected:
+                    raise TypeError(
+                        f"Field '{f.name}' has type {f.type}, expected "
+                        f"{expected} from class SCHEMA"
+                    )
+            return fields
+        selected = []
+        for name in fields:
+            if name not in cls.SCHEMA.names:
+                raise KeyError(
+                    f"Field '{name}' not in {cls.__name__} SCHEMA. "
+                    f"Available: {cls.SCHEMA.names}"
+                )
+            selected.append(cls.SCHEMA.field(name))
+        return pa.schema(selected)
+
+
+def _parse_filename_start(key: str) -> datetime | None:
+    """Extract the start datetime from a GLM L2 LCFA S3 key or filename.
+
+    Filenames follow ``OR_GLM-L2-LCFA_<G16|G17|G18|G19>_s<YYYYJJJHHMMSSF>_e..._c....nc``
+    where ``F`` is a decisecond digit (rounded down here).
+    """
+    base = os.path.basename(key)
+    idx = base.find("_s")
+    if idx < 0:
+        return None
+    stamp = base[idx + 2 : idx + 2 + 13]
+    if len(stamp) != 13 or not stamp.isdigit():
+        return None
+    try:
+        return datetime.strptime(stamp, "%Y%j%H%M%S")
+    except ValueError:
+        return None
+
+
+def _parse_glm_file(
+    path: str,
+    bbox: tuple[float, float, float, float] | None,
+) -> pd.DataFrame | None:
+    """Parse a GLM L2 LCFA NetCDF file into a flat events DataFrame.
+
+    Returns ``None`` if the file has no events or all events fall
+    outside ``bbox``.
+    """
+    with netCDF4.Dataset(path) as ds:
+        if "event_lat" not in ds.variables:
+            return None
+        if ds.dimensions["number_of_events"].size == 0:
+            return None
+
+        lat = np.asarray(ds.variables["event_lat"][:], dtype=np.float32)
+        lon = np.asarray(ds.variables["event_lon"][:], dtype=np.float32)
+        energy = np.asarray(ds.variables["event_energy"][:], dtype=np.float32)
+
+        # Per-event timestamps from event_time_offset + units. Fall back
+        # to the file's time_coverage_start global attribute if the
+        # variable's units are missing or unparsable.
+        offset = np.asarray(ds.variables["event_time_offset"][:], dtype=np.float64)
+        units = getattr(ds.variables["event_time_offset"], "units", None)
+        times = _resolve_event_times(ds, offset, units)
+
+    if bbox is not None:
+        lat_min, lat_max, lon_min, lon_max = bbox
+        mask = (lat >= lat_min) & (lat <= lat_max) & (lon >= lon_min) & (lon <= lon_max)
+        if not mask.any():
+            return None
+        lat = lat[mask]
+        lon = lon[mask]
+        energy = energy[mask]
+        times = times[mask]
+
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime(times),
+            "lat": lat,
+            "lon": lon,
+            "event_energy": energy,
+        }
+    )
+
+
+def _resolve_event_times(ds: Any, offset: np.ndarray, units: str | None) -> np.ndarray:
+    """Convert per-event ``event_time_offset`` to a numpy datetime64
+    array, preferring CF ``num2date`` and falling back to the file's
+    ``time_coverage_start`` attribute when the variable units are
+    absent."""
+    if units:
+        try:
+            dates = cast(
+                np.ndarray,
+                netCDF4.num2date(
+                    offset,
+                    units,
+                    only_use_cftime_datetimes=False,
+                    only_use_python_datetimes=True,
+                ),
+            )
+            return np.asarray(
+                [np.datetime64(d, "us") for d in dates],
+                dtype="datetime64[us]",
+            )
+        except (ValueError, TypeError):
+            pass
+    epoch_str = getattr(ds, "time_coverage_start", None)
+    if not epoch_str:
+        raise ValueError(
+            "GLM file lacks both event_time_offset.units and "
+            "time_coverage_start; cannot resolve event timestamps."
+        )
+    # pd.Timestamp tolerates the trailing 'Z' and fractional seconds
+    # variants that real GLM files use; datetime.fromisoformat() does
+    # not on Python < 3.11.
+    epoch = pd.Timestamp(epoch_str).to_pydatetime().replace(tzinfo=None)
+    return np.asarray(
+        [np.datetime64(epoch + timedelta(seconds=float(s)), "us") for s in offset],
+        dtype="datetime64[us]",
+    )

--- a/earth2studio/data/goes_glm.py
+++ b/earth2studio/data/goes_glm.py
@@ -187,7 +187,7 @@ class GOESGLM:
 
     Badges
     ------
-    region:na region:sa dataclass:observation product:atmos product:insitu
+    region:na region:sa dataclass:observation product:sat
     """
 
     SOURCE_ID = "earth2studio.data.goes_glm"

--- a/earth2studio/data/goes_glm.py
+++ b/earth2studio/data/goes_glm.py
@@ -384,8 +384,10 @@ class GOESGLM:
             windows.append((tmin, tmax, sat))
             # Cover any hours overlapping the window, including the one
             # containing tmin even when tmax falls back into the prior
-            # bin (negative tolerance).
-            hr = tmin.replace(minute=0, second=0, microsecond=0)
+            # bin (negative tolerance). Start one file duration before
+            # tmin so the prefix listing matches the widened file-start
+            # acceptance bound used below.
+            hr = (tmin - _GLM_FILE_DURATION).replace(minute=0, second=0, microsecond=0)
             stop = tmax if tmax >= tmin else tmin
             while hr <= stop:
                 prefix_jobs[(sat, self._hour_prefix(sat, hr))] = None

--- a/earth2studio/data/goes_glm.py
+++ b/earth2studio/data/goes_glm.py
@@ -24,7 +24,6 @@ import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -123,12 +122,13 @@ class GOESGLM:
         ``"west"`` to auto-select the active GOES-East / GOES-West
         platform for each requested timestamp; pass ``"G16"``,
         ``"G17"``, ``"G18"`` or ``"G19"`` to pin a single platform.
-    bbox : tuple[float, float, float, float] | None, optional
-        ``(lat_min, lat_max, lon_min, lon_max)`` filter applied at
-        parse time. Coordinates use the GLM native convention
-        (latitude in ``[-90, 90]``, longitude in ``[-180, 180)``).
-        ``None`` (default) returns the full disk. For example, CONUS
-        is ``(24.5, 49.5, -125.0, -66.0)``.
+    lat_lon_bbox : tuple[float, float, float, float] | None, optional
+        Bounding box ``(lat_min, lon_min, lat_max, lon_max)`` in
+        degrees, applied at parse time. Accepts either ``[-180, 180)``
+        or ``[0, 360)`` longitude convention (auto-detected when
+        ``lon_max >= 180``). ``None`` (default) returns the full disk.
+        For example, CONUS in the ``[-180, 180)`` convention is
+        ``(24.5, -125.0, 49.5, -66.0)``.
     time_tolerance : TimeTolerance, optional
         Time tolerance window for selecting events around each
         requested timestamp. Accepts a single value (symmetric ±
@@ -150,9 +150,9 @@ class GOESGLM:
     Warning
     -------
     GLM produces hundreds of files per hour. Large time windows can
-    download tens to hundreds of gigabytes of NetCDFs. Use ``bbox`` to
-    discard out-of-region events on parse and keep ``time_tolerance``
-    bounded.
+    download tens to hundreds of gigabytes of NetCDFs. Use
+    ``lat_lon_bbox`` to discard out-of-region events on parse and
+    keep ``time_tolerance`` bounded.
 
     Note
     ----
@@ -180,14 +180,14 @@ class GOESGLM:
 
         ds = GOESGLM(
             satellite="east",
-            bbox=(24.5, 49.5, -125.0, -66.0),  # CONUS
+            lat_lon_bbox=(24.5, -125.0, 49.5, -66.0),  # CONUS
             time_tolerance=np.timedelta64(5, "m"),
         )
         df = ds(datetime(2024, 6, 1, 18, 0), ["flashe", "flashc"])
 
     Badges
     ------
-    region:na region:sa dataclass:observation product:insitu
+    region:na region:sa dataclass:observation product:atmos product:insitu
     """
 
     SOURCE_ID = "earth2studio.data.goes_glm"
@@ -209,7 +209,7 @@ class GOESGLM:
     def __init__(
         self,
         satellite: str = "east",
-        bbox: tuple[float, float, float, float] | None = None,
+        lat_lon_bbox: tuple[float, float, float, float] | None = None,
         time_tolerance: TimeTolerance = np.timedelta64(2, "m"),
         cache: bool = True,
         verbose: bool = True,
@@ -220,7 +220,7 @@ class GOESGLM:
         sat = (
             satellite.lower()
             if satellite.lower() in ("east", "west")
-            else (satellite.upper())
+            else satellite.upper()
         )
         if sat not in ("east", "west") and sat not in _BUCKETS:
             raise ValueError(
@@ -229,14 +229,7 @@ class GOESGLM:
             )
         self._satellite = sat
 
-        if bbox is not None:
-            lat_min, lat_max, lon_min, lon_max = bbox
-            if lat_min >= lat_max or lon_min >= lon_max:
-                raise ValueError(
-                    f"bbox bounds must be (lat_min < lat_max, lon_min < lon_max); "
-                    f"got {bbox}"
-                )
-        self._bbox = bbox
+        self._lat_lon_bbox = _normalize_lat_lon_bbox(lat_lon_bbox)
 
         lower, upper = normalize_time_tolerance(time_tolerance)
         self._tolerance_lower = pd.to_timedelta(lower).to_pytimedelta()
@@ -382,14 +375,8 @@ class GOESGLM:
             tmax = t + self._tolerance_upper
             sat = self._satellite_for_time(t)
             windows.append((tmin, tmax, sat))
-            # Cover any hours overlapping the window, including the one
-            # containing tmin even when tmax falls back into the prior
-            # bin (negative tolerance). Start one file duration before
-            # tmin so the prefix listing matches the widened file-start
-            # acceptance bound used below.
             hr = (tmin - _GLM_FILE_DURATION).replace(minute=0, second=0, microsecond=0)
-            stop = tmax if tmax >= tmin else tmin
-            while hr <= stop:
+            while hr <= tmax:
                 prefix_jobs[(sat, self._hour_prefix(sat, hr))] = None
                 hr += timedelta(hours=1)
 
@@ -413,7 +400,7 @@ class GOESGLM:
         seen_uris: set[str] = set()
         for entries in listings:
             for sat, key in entries:
-                file_start = _parse_filename_start(key)
+                file_start = self._parse_filename_start(key)
                 if file_start is None:
                     continue
                 for tmin, tmax, win_sat in windows:
@@ -467,14 +454,12 @@ class GOESGLM:
         """Parse each cached file once, filter per requested time, and
         emit one long-format DataFrame across all variables and times.
         """
-        # Parse all files (each only once); skip files whose cache is
-        # missing (download skipped due to FileNotFoundError).
         events_by_file: dict[str, pd.DataFrame] = {}
         for f in files:
             local = self._cache_path(f.s3_uri)
             if not pathlib.Path(local).is_file():
                 continue
-            events = _parse_glm_file(local, self._bbox)
+            events = self._parse_glm_file(local, self._lat_lon_bbox)
             if events is None or events.empty:
                 continue
             events["satellite"] = f.satellite
@@ -516,10 +501,7 @@ class GOESGLM:
 
     def _empty_result(self, schema: pa.Schema) -> pd.DataFrame:
         empty = pd.DataFrame(
-            {
-                f.name: pd.Series(dtype=_arrow_to_pandas_dtype(f.type))
-                for f in self.SCHEMA
-            }
+            {name: pd.Series(dtype="object") for name in self.SCHEMA.names}
         )
         empty.attrs["source"] = self.SOURCE_ID
         return empty[[name for name in schema.names if name in empty.columns]]
@@ -581,19 +563,19 @@ class GOESGLM:
 
     @classmethod
     def available(cls, time: datetime | np.datetime64) -> bool:
-        """Check if the given date time is in the GLM archive window.
+        """Check whether data is available for a given time.
+
+        Offline check against the GLM archive window; per-slot
+        platform cutovers are enforced when the source is called.
 
         Parameters
         ----------
         time : datetime | np.datetime64
-            Date time to check.
+            Date-time to check.
 
         Returns
         -------
         bool
-            ``True`` when ``time`` falls within the public GLM-L2-LCFA
-            archive window (irrespective of satellite slot). Per-slot
-            cutovers are enforced when the source is actually called.
         """
         if isinstance(time, np.datetime64):
             time = time.astype("datetime64[ns]").astype("datetime64[us]").item()
@@ -634,119 +616,108 @@ class GOESGLM:
             selected.append(cls.SCHEMA.field(name))
         return pa.schema(selected)
 
+    @classmethod
+    def _parse_filename_start(cls, key: str) -> datetime | None:
+        """Extract the file-start datetime from a GLM L2 LCFA S3 key.
 
-def _arrow_to_pandas_dtype(arrow_type: pa.DataType) -> Any:
-    """Map a PyArrow type to a pandas/numpy dtype for empty-DataFrame stubs."""
-    if pa.types.is_timestamp(arrow_type):
-        unit = arrow_type.unit
-        return f"datetime64[{unit}]"
-    if pa.types.is_floating(arrow_type):
-        return np.dtype(arrow_type.to_pandas_dtype())
-    if pa.types.is_integer(arrow_type):
-        return np.dtype(arrow_type.to_pandas_dtype())
-    if pa.types.is_string(arrow_type):
-        return object
-    return object
-
-
-def _parse_filename_start(key: str) -> datetime | None:
-    """Extract the start datetime from a GLM L2 LCFA S3 key or filename.
-
-    Filenames follow ``OR_GLM-L2-LCFA_<G16|G17|G18|G19>_s<YYYYJJJHHMMSSF>_e..._c....nc``
-    where ``F`` is a decisecond digit (rounded down here).
-    """
-    base = os.path.basename(key)
-    idx = base.find("_s")
-    if idx < 0:
-        return None
-    stamp = base[idx + 2 : idx + 2 + 13]
-    if len(stamp) != 13 or not stamp.isdigit():
-        return None
-    try:
-        return datetime.strptime(stamp, "%Y%j%H%M%S")
-    except ValueError:
-        return None
-
-
-def _parse_glm_file(
-    path: str,
-    bbox: tuple[float, float, float, float] | None,
-) -> pd.DataFrame | None:
-    """Parse a GLM L2 LCFA NetCDF file into a flat events DataFrame.
-
-    Returns ``None`` if the file has no events or all events fall
-    outside ``bbox``.
-    """
-    with netCDF4.Dataset(path) as ds:
-        if "event_lat" not in ds.variables:
+        Filenames follow
+        ``OR_GLM-L2-LCFA_<G16|G17|G18|G19>_s<YYYYJJJHHMMSSF>_e..._c....nc``
+        where ``F`` is a decisecond digit (rounded down here).
+        """
+        base = os.path.basename(key)
+        idx = base.find("_s")
+        if idx < 0:
             return None
-        if ds.dimensions["number_of_events"].size == 0:
+        stamp = base[idx + 2 : idx + 2 + 13]
+        if len(stamp) != 13 or not stamp.isdigit():
             return None
-
-        lat = np.asarray(ds.variables["event_lat"][:], dtype=np.float32)
-        lon = np.asarray(ds.variables["event_lon"][:], dtype=np.float32)
-        energy = np.asarray(ds.variables["event_energy"][:], dtype=np.float32)
-
-        # Per-event timestamps from event_time_offset + units. Fall back
-        # to the file's time_coverage_start global attribute if the
-        # variable's units are missing or unparsable.
-        offset = np.asarray(ds.variables["event_time_offset"][:], dtype=np.float64)
-        units = getattr(ds.variables["event_time_offset"], "units", None)
-        times = _resolve_event_times(ds, offset, units)
-
-    if bbox is not None:
-        lat_min, lat_max, lon_min, lon_max = bbox
-        mask = (lat >= lat_min) & (lat <= lat_max) & (lon >= lon_min) & (lon <= lon_max)
-        if not mask.any():
-            return None
-        lat = lat[mask]
-        lon = lon[mask]
-        energy = energy[mask]
-        times = times[mask]
-
-    return pd.DataFrame(
-        {
-            "time": pd.to_datetime(times),
-            "lat": lat,
-            "lon": lon,
-            "event_energy": energy,
-        }
-    )
-
-
-def _resolve_event_times(ds: Any, offset: np.ndarray, units: str | None) -> np.ndarray:
-    """Convert per-event ``event_time_offset`` to a numpy datetime64
-    array, preferring CF ``num2date`` and falling back to the file's
-    ``time_coverage_start`` attribute when the variable units are
-    absent."""
-    if units:
         try:
-            dates = cast(
-                np.ndarray,
-                netCDF4.num2date(
-                    offset,
-                    units,
-                    only_use_cftime_datetimes=False,
-                    only_use_python_datetimes=True,
-                ),
+            return datetime.strptime(stamp, "%Y%j%H%M%S")
+        except ValueError:
+            return None
+
+    @classmethod
+    def _parse_glm_file(
+        cls,
+        path: str,
+        lat_lon_bbox: tuple[float, float, float, float] | None,
+    ) -> pd.DataFrame | None:
+        """Parse a GLM L2 LCFA NetCDF file into a flat events DataFrame.
+
+        Returns ``None`` if the file has no events or all events fall
+        outside ``lat_lon_bbox``.
+        """
+        with netCDF4.Dataset(path) as ds:
+            if "event_lat" not in ds.variables:
+                return None
+            if ds.dimensions["number_of_events"].size == 0:
+                return None
+
+            lat = np.asarray(ds.variables["event_lat"][:], dtype=np.float32)
+            lon = np.asarray(ds.variables["event_lon"][:], dtype=np.float32)
+            energy = np.asarray(ds.variables["event_energy"][:], dtype=np.float32)
+            offset = np.asarray(ds.variables["event_time_offset"][:], dtype=np.float64)
+            epoch = (
+                pd.Timestamp(ds.time_coverage_start)
+                .to_pydatetime()
+                .replace(tzinfo=None)
             )
-            return np.asarray(
-                [np.datetime64(d, "us") for d in dates],
-                dtype="datetime64[us]",
-            )
-        except (ValueError, TypeError):
-            pass
-    epoch_str = getattr(ds, "time_coverage_start", None)
-    if not epoch_str:
-        raise ValueError(
-            "GLM file lacks both event_time_offset.units and "
-            "time_coverage_start; cannot resolve event timestamps."
+
+        times = np.asarray(
+            [np.datetime64(epoch + timedelta(seconds=float(s)), "us") for s in offset],
+            dtype="datetime64[us]",
         )
-    # pd.Timestamp tolerates the trailing 'Z' and fractional seconds
-    # variants that real GLM files use; datetime.fromisoformat() does
-    # not on Python < 3.11.
-    epoch = pd.Timestamp(epoch_str).to_pydatetime().replace(tzinfo=None)
-    return np.asarray(
-        [np.datetime64(epoch + timedelta(seconds=float(s)), "us") for s in offset],
-        dtype="datetime64[us]",
-    )
+
+        if lat_lon_bbox is not None:
+            lat_min, lon_min, lat_max, lon_max = lat_lon_bbox
+            mask = (
+                (lat >= lat_min)
+                & (lat <= lat_max)
+                & (lon >= lon_min)
+                & (lon <= lon_max)
+            )
+            if not mask.any():
+                return None
+            lat = lat[mask]
+            lon = lon[mask]
+            energy = energy[mask]
+            times = times[mask]
+
+        return pd.DataFrame(
+            {
+                "time": pd.to_datetime(times),
+                "lat": lat,
+                "lon": lon,
+                "event_energy": energy,
+            }
+        )
+
+
+def _normalize_lat_lon_bbox(
+    lat_lon_bbox: tuple[float, float, float, float] | None,
+) -> tuple[float, float, float, float] | None:
+    """Validate a ``(lat_min, lon_min, lat_max, lon_max)`` box.
+
+    Accepts either ``[-180, 180)`` or ``[0, 360)`` longitude
+    conventions and normalises to the native GLM ``[-180, 180)``
+    convention used by the on-disk event coordinates.
+    """
+    if lat_lon_bbox is None:
+        return None
+    lat_min, lon_min, lat_max, lon_max = lat_lon_bbox
+    if lat_min >= lat_max or lon_min >= lon_max:
+        raise ValueError(
+            "lat_lon_bbox bounds must be "
+            "(lat_min < lat_max, lon_min < lon_max); "
+            f"got {lat_lon_bbox}"
+        )
+    if lon_max >= 180.0:
+        lon_min = ((lon_min + 180.0) % 360.0) - 180.0
+        lon_max = ((lon_max + 180.0) % 360.0) - 180.0
+        if lon_min >= lon_max:
+            raise ValueError(
+                "lat_lon_bbox crosses the antimeridian after "
+                "normalising from [0, 360) to [-180, 180); split it "
+                f"into two boxes. Got {lat_lon_bbox}."
+            )
+    return (lat_min, lon_min, lat_max, lon_max)

--- a/earth2studio/lexicon/__init__.py
+++ b/earth2studio/lexicon/__init__.py
@@ -25,6 +25,7 @@ from .gefs import GEFSLexicon, GEFSLexiconSel
 from .gfs import GFSLexicon
 from .ghcn import GHCNLexicon
 from .goes import GOESLexicon
+from .goes_glm import GOESGLMLexicon
 from .himawari_ahi import HimawariAHILexicon
 from .hrrr import HRRRFXLexicon, HRRRLexicon
 from .isd import ISDLexicon

--- a/earth2studio/lexicon/base.py
+++ b/earth2studio/lexicon/base.py
@@ -69,6 +69,8 @@ E2STUDIO_VOCAB = {
     "rsut": "outgoing shortwave radiation (W m-2)",
     "rsds": "surface downwelling shortwave radiation (W m-2)",
     "refc": "Maximum/Composite radar reflectivity (dB)",
+    "flashe": "lightning flash event optical energy (J)",
+    "flashc": "lightning flash event count (per detected event, 1.0)",
     "aerot": "aerosol optical thickness",
     "snowc": "snow coverage (%)",
     "csnow": "categorical snow",

--- a/earth2studio/lexicon/goes_glm.py
+++ b/earth2studio/lexicon/goes_glm.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+from earth2studio.lexicon.base import LexiconType
+
+
+class GOESGLMLexicon(metaclass=LexiconType):
+    """Lexicon for GOES Geostationary Lightning Mapper (GLM) L2 LCFA events.
+
+    Each Earth2Studio variable maps to a column extracted (or synthesised)
+    from the per-event arrays of the GLM L2 Lightning Cluster-Filter
+    Algorithm NetCDF files.
+
+    - ``event_energy`` is the native GLM variable for the optical energy
+      of a single detected event (Joules).
+    - ``event_count`` is synthetic: the data source fills it with 1.0 per
+      event so users can sum or histogram to obtain per-cell flash
+      density during downstream regridding.
+
+    Note
+    ----
+    Variable reference:
+
+    - GLM Product Definition and User's Guide:
+      https://www.goes-r.gov/products/baseline-LCFA.html
+    """
+
+    VOCAB = {
+        "flashe": "event_energy",
+        "flashc": "event_count",
+    }
+
+    @classmethod
+    def get_item(cls, val: str) -> tuple[str, Callable]:
+        """Return the GLM field name and modifier function for a variable.
+
+        Parameters
+        ----------
+        val : str
+            Earth2Studio variable id.
+
+        Returns
+        -------
+        tuple[str, Callable]
+            ``(field_name, modifier)``. ``field_name`` is the native GLM
+            NetCDF variable name (for ``flashe``) or the synthetic key
+            ``"event_count"`` (for ``flashc``). ``modifier`` is the
+            identity function; values are returned in their physical
+            units (Joules for ``flashe``, dimensionless 1.0 for ``flashc``).
+        """
+        return cls.VOCAB[val], lambda x: x

--- a/test/data/test_goes_glm.py
+++ b/test/data/test_goes_glm.py
@@ -21,23 +21,18 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 import pytest
 
 from earth2studio.data import GOESGLM
-from earth2studio.data.goes_glm import (
-    _GOESGLMFile,
-    _parse_filename_start,
-    _parse_glm_file,
-)
+from earth2studio.data.goes_glm import _GOESGLMFile
 
 netCDF4 = pytest.importorskip("netCDF4", reason="netCDF4 not installed")
 
 
-# ----------------------------------------------------------------------
-# Helpers
-# ----------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic GLM L2 LCFA NetCDF files
+# ---------------------------------------------------------------------------
 def _write_glm_netcdf(
     path: pathlib.Path,
     lats: list[float],
@@ -57,212 +52,13 @@ def _write_glm_netcdf(
         en_v = ds.createVariable("event_energy", "f4", ("number_of_events",))
         en_v[:] = np.asarray(energies, dtype=np.float32)
         off_v = ds.createVariable("event_time_offset", "f8", ("number_of_events",))
-        off_v.units = f"seconds since {epoch.strftime('%Y-%m-%d %H:%M:%S')}"
         off_v[:] = np.asarray(offsets, dtype=np.float64)
 
 
-# ----------------------------------------------------------------------
-# Pure unit tests
-# ----------------------------------------------------------------------
-def test_filename_start_parse():
-    key = (
-        "noaa-goes16/GLM-L2-LCFA/2024/153/18/"
-        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
-    )
-    assert _parse_filename_start(key) == datetime(2024, 6, 1, 18, 0, 0)
-    assert _parse_filename_start("nope.nc") is None
-    assert _parse_filename_start("OR_GLM-L2-LCFA_G16_sbad__e__c.nc") is None
-
-
-def test_parse_glm_file(tmp_path):
-    f = tmp_path / "events.nc"
-    epoch = datetime(2024, 6, 1, 18, 0, 0)
-    _write_glm_netcdf(
-        f,
-        lats=[35.0, 40.0, 60.0],
-        lons=[-120.0, -100.0, 10.0],
-        energies=[1e-15, 2e-15, 3e-15],
-        offsets=[0.0, 5.123, 19.5],
-        epoch=epoch,
-    )
-    # Without bbox: 3 events
-    df = _parse_glm_file(str(f), bbox=None)
-    assert df is not None
-    assert len(df) == 3
-    # Sub-second precision preserved
-    assert df["time"].iloc[1] == pd.Timestamp(epoch + timedelta(seconds=5.123))
-    # With CONUS bbox: only 2 of 3 events
-    df_conus = _parse_glm_file(str(f), bbox=(24.5, 49.5, -125.0, -66.0))
-    assert df_conus is not None
-    assert len(df_conus) == 2
-    # All-out-of-box returns None
-    df_empty = _parse_glm_file(str(f), bbox=(-10.0, -5.0, -10.0, -5.0))
-    assert df_empty is None
-
-
-def test_satellite_routing():
-    ds = GOESGLM(satellite="east", cache=False, verbose=False)
-    # G16 era
-    assert ds._satellite_for_time(datetime(2024, 1, 1)) == "G16"
-    # G19 era
-    assert ds._satellite_for_time(datetime(2025, 6, 1)) == "G19"
-
-    ds_w = GOESGLM(satellite="west", cache=False, verbose=False)
-    assert ds_w._satellite_for_time(datetime(2020, 6, 1)) == "G17"
-    assert ds_w._satellite_for_time(datetime(2024, 6, 1)) == "G18"
-
-    ds_pin = GOESGLM(satellite="G16", cache=False, verbose=False)
-    assert ds_pin._satellite_for_time(datetime(2024, 1, 1)) == "G16"
-    # Pinning bypasses slot history (caller's responsibility)
-    assert ds_pin._satellite_for_time(datetime(2026, 1, 1)) == "G16"
-
-
-def test_constructor_validation():
-    with pytest.raises(ValueError):
-        GOESGLM(satellite="unknown")
-    with pytest.raises(ValueError):
-        GOESGLM(bbox=(50.0, 40.0, -120.0, -110.0))  # lat_min >= lat_max
-
-
-def test_tolerance_normalisation():
-    ds = GOESGLM(time_tolerance=np.timedelta64(2, "m"), cache=False, verbose=False)
-    assert ds._tolerance_lower == timedelta(minutes=-2)
-    assert ds._tolerance_upper == timedelta(minutes=2)
-    ds_asym = GOESGLM(
-        time_tolerance=(np.timedelta64(-30, "s"), np.timedelta64(90, "s")),
-        cache=False,
-        verbose=False,
-    )
-    assert ds_asym._tolerance_lower == timedelta(seconds=-30)
-    assert ds_asym._tolerance_upper == timedelta(seconds=90)
-
-
-def test_validate_time_and_available():
-    GOESGLM._validate_time([datetime(2024, 6, 1, 18, 0)])
-    with pytest.raises(ValueError):
-        GOESGLM._validate_time([datetime(1990, 1, 1)])
-
-    assert GOESGLM.available(datetime(2024, 6, 1, 18, 0))
-    assert not GOESGLM.available(datetime(1990, 1, 1))
-    assert GOESGLM.available(np.datetime64("2024-06-01T18:00"))
-
-
-def test_resolve_fields():
-    full = GOESGLM.resolve_fields(None)
-    assert full.names == GOESGLM.SCHEMA.names
-
-    subset = GOESGLM.resolve_fields(["time", "lat", "lon", "observation", "variable"])
-    assert subset.names == ["time", "lat", "lon", "observation", "variable"]
-
-    one = GOESGLM.resolve_fields("observation")
-    assert one.names == ["observation"]
-
-    with pytest.raises(KeyError):
-        GOESGLM.resolve_fields(["does_not_exist"])
-
-    bad_schema = pa.schema([pa.field("does_not_exist", pa.float32())])
-    with pytest.raises(KeyError):
-        GOESGLM.resolve_fields(bad_schema)
-
-    wrong_type = pa.schema([pa.field("time", pa.string())])
-    with pytest.raises(TypeError):
-        GOESGLM.resolve_fields(wrong_type)
-
-
-# ----------------------------------------------------------------------
-# Mock end-to-end test (no network)
-# ----------------------------------------------------------------------
-def test_goes_glm_mock_call(tmp_path):
-    """Exercise the full __call__ → fetch → compile path with mocked I/O.
-
-    A synthetic NetCDF is dropped into the deterministic cache path so the
-    real ``_parse_glm_file`` runs. ``_discover_files`` and
-    ``_fetch_remote_file`` are stubbed to avoid any S3 traffic.
-    """
-    epoch = datetime(2024, 6, 1, 18, 0, 0)
-    s3_uri = (
-        "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
-        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
-    )
-
-    async def _no_op_fetch(self, uri):  # type: ignore[no-untyped-def]
-        # File already placed in cache by the test; nothing to do.
-        return None
-
-    async def _fake_discover(self, time_list):  # type: ignore[no-untyped-def]
-        return [
-            _GOESGLMFile(
-                s3_uri=s3_uri,
-                satellite="G16",
-                file_start=epoch,
-            )
-        ]
-
-    ds = GOESGLM(
-        satellite="east",
-        time_tolerance=np.timedelta64(5, "m"),
-        cache=False,
-        verbose=False,
-    )
-    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
-    # Pre-populate the cache with the synthetic NetCDF at the expected path.
-    local_path = ds._cache_path(s3_uri)
-    _write_glm_netcdf(
-        pathlib.Path(local_path),
-        lats=[35.0, 40.0, 60.0],
-        lons=[-120.0, -100.0, 10.0],
-        energies=[1.5e-15, 2.5e-15, 3.5e-15],
-        offsets=[0.0, 30.0, 60.0],
-        epoch=epoch,
-    )
-
-    try:
-        with (
-            patch.object(GOESGLM, "_discover_files", _fake_discover),
-            patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
-        ):
-            df = ds(epoch, ["flashe", "flashc"])
-
-            # Default field set is the full schema.
-            assert list(df.columns) == ds.SCHEMA.names
-            # 3 events × 2 requested variables = 6 rows.
-            assert len(df) == 6
-            assert set(df["variable"]) == {"flashe", "flashc"}
-            # Longitude normalised to [0, 360)
-            assert (df["lon"] >= 0).all()
-            assert (df["lon"] < 360).all()
-            # CONUS lon -120 → 240, -100 → 260, 10 → 10
-            assert np.any(np.isclose(df["lon"].values, 240.0))
-            assert np.any(np.isclose(df["lon"].values, 260.0))
-            # flashc is constantly 1.0
-            flashc_rows = df[df["variable"] == "flashc"]
-            assert (flashc_rows["observation"].astype(float) == 1.0).all()
-            # flashe carries energy values
-            flashe_rows = df[df["variable"] == "flashe"]
-            assert flashe_rows["observation"].max() == pytest.approx(3.5e-15)
-            # Satellite column is the routed platform
-            assert set(df["satellite"]) == {"G16"}
-
-            # Subset fields path
-            subset = ds(
-                epoch,
-                ["flashe"],
-                fields=["time", "lat", "lon", "observation", "variable"],
-            )
-            assert list(subset.columns) == [
-                "time",
-                "lat",
-                "lon",
-                "observation",
-                "variable",
-            ]
-            assert (subset["variable"] == "flashe").all()
-    finally:
-        shutil.rmtree(ds.cache, ignore_errors=True)
-
-
-def test_goes_glm_bbox_filter_call(tmp_path):
-    """Mock-mode call with a CONUS bbox should drop out-of-region events."""
+# ---------------------------------------------------------------------------
+# Mock tests — exercise __call__ end-to-end without network
+# ---------------------------------------------------------------------------
+def test_goes_glm_call_mock(tmp_path):
     epoch = datetime(2024, 6, 1, 18, 0, 0)
     s3_uri = (
         "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
@@ -277,7 +73,110 @@ def test_goes_glm_bbox_filter_call(tmp_path):
 
     ds = GOESGLM(
         satellite="east",
-        bbox=(24.5, 49.5, -125.0, -66.0),
+        time_tolerance=np.timedelta64(5, "m"),
+        cache=False,
+        verbose=False,
+    )
+    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
+    _write_glm_netcdf(
+        pathlib.Path(ds._cache_path(s3_uri)),
+        lats=[35.0, 40.0, 60.0],
+        lons=[-120.0, -100.0, 10.0],
+        energies=[1.5e-15, 2.5e-15, 3.5e-15],
+        offsets=[0.0, 30.0, 60.0],
+        epoch=epoch,
+    )
+
+    try:
+        with (
+            patch.object(GOESGLM, "_discover_files", _fake_discover),
+            patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
+        ):
+            df = ds(epoch, ["flashe", "flashc"])
+
+            assert list(df.columns) == ds.SCHEMA.names
+            assert len(df) == 6  # 3 events x 2 variables
+            assert set(df["variable"].unique()) == {"flashe", "flashc"}
+            assert df["lat"].between(-90, 90).all()
+            assert df["lon"].between(0, 360).all()
+            assert set(df["satellite"].unique()) == {"G16"}
+            flashe = df[df["variable"] == "flashe"]
+            assert flashe["observation"].max() == pytest.approx(3.5e-15)
+            flashc = df[df["variable"] == "flashc"]
+            assert (flashc["observation"].astype(float) == 1.0).all()
+    finally:
+        shutil.rmtree(ds.cache, ignore_errors=True)
+
+
+def test_goes_glm_call_mock_fields_subset(tmp_path):
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    s3_uri = (
+        "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
+    )
+
+    async def _no_op_fetch(self, uri):  # type: ignore[no-untyped-def]
+        return None
+
+    async def _fake_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return [_GOESGLMFile(s3_uri=s3_uri, satellite="G16", file_start=epoch)]
+
+    ds = GOESGLM(
+        satellite="east",
+        time_tolerance=np.timedelta64(5, "m"),
+        cache=False,
+        verbose=False,
+    )
+    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
+    _write_glm_netcdf(
+        pathlib.Path(ds._cache_path(s3_uri)),
+        lats=[35.0],
+        lons=[-100.0],
+        energies=[2.5e-15],
+        offsets=[0.0],
+        epoch=epoch,
+    )
+    try:
+        subset = ["time", "lat", "lon", "observation", "variable"]
+        with (
+            patch.object(GOESGLM, "_discover_files", _fake_discover),
+            patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
+        ):
+            df = ds(epoch, ["flashe"], fields=subset)
+        assert list(df.columns) == subset
+        assert (df["variable"] == "flashe").all()
+    finally:
+        shutil.rmtree(ds.cache, ignore_errors=True)
+
+
+def test_goes_glm_call_mock_empty():
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+
+    async def _no_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return []
+
+    with patch.object(GOESGLM, "_discover_files", _no_discover):
+        df = ds(datetime(2024, 6, 1, 18, 0), ["flashe"])
+    assert df.empty
+    assert list(df.columns) == ds.SCHEMA.names
+
+
+def test_goes_glm_call_mock_bbox(tmp_path):
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    s3_uri = (
+        "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
+    )
+
+    async def _no_op_fetch(self, uri):  # type: ignore[no-untyped-def]
+        return None
+
+    async def _fake_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return [_GOESGLMFile(s3_uri=s3_uri, satellite="G16", file_start=epoch)]
+
+    ds = GOESGLM(
+        satellite="east",
+        lat_lon_bbox=(24.5, -125.0, 49.5, -66.0),  # CONUS
         time_tolerance=np.timedelta64(5, "m"),
         cache=False,
         verbose=False,
@@ -291,34 +190,141 @@ def test_goes_glm_bbox_filter_call(tmp_path):
         offsets=[0.0, 30.0, 60.0],
         epoch=epoch,
     )
+    try:
+        with (
+            patch.object(GOESGLM, "_discover_files", _fake_discover),
+            patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
+        ):
+            df = ds(epoch, ["flashe"])
+        assert len(df) == 2  # only the two CONUS events
+        assert df["lat"].max() < 50.0
+    finally:
+        shutil.rmtree(ds.cache, ignore_errors=True)
 
-    with (
-        patch.object(GOESGLM, "_discover_files", _fake_discover),
-        patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
-    ):
-        df = ds(epoch, ["flashe"])
 
-    # Only the two CONUS events survive bbox filter; one variable requested → 2 rows
-    assert len(df) == 2
-    # The 60N / 10E event is excluded
-    assert df["lat"].max() < 50.0
+# ---------------------------------------------------------------------------
+# Network integration tests (slow, xfail)
+# ---------------------------------------------------------------------------
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(120)
+def test_goes_glm_fetch():
+    ds = GOESGLM(
+        satellite="east",
+        lat_lon_bbox=(24.5, -125.0, 49.5, -66.0),
+        time_tolerance=np.timedelta64(1, "m"),
+        cache=False,
+        verbose=False,
+    )
+    df = ds(datetime(2024, 6, 1, 18, 0), ["flashe", "flashc"])
+    assert list(df.columns) == ds.SCHEMA.names
+    assert not df.empty
+    assert set(df["variable"].unique()).issubset({"flashe", "flashc"})
 
 
-def test_goes_glm_invalid_variable():
-    # Variable validation happens before any S3 access, so no patching needed.
+# ---------------------------------------------------------------------------
+# Unit tests — exceptions, resolve_fields, time/satellite/parse helpers
+# ---------------------------------------------------------------------------
+def test_goes_glm_exceptions():
+    with pytest.raises(ValueError):
+        GOESGLM(satellite="unknown")
+    with pytest.raises(ValueError):
+        GOESGLM(lat_lon_bbox=(50.0, -120.0, 40.0, -110.0))  # lat_min >= lat_max
+
     ds = GOESGLM(satellite="G16", cache=False, verbose=False)
     with pytest.raises(KeyError):
         ds(datetime(2024, 6, 1, 18, 0), ["not_a_var"])
+    with pytest.raises(KeyError):
+        GOESGLM.resolve_fields(["does_not_exist"])
+    with pytest.raises(TypeError):
+        GOESGLM.resolve_fields(pa.schema([pa.field("time", pa.string())]))
 
 
-# ----------------------------------------------------------------------
-# Tests for the internal S3 plumbing (mocked filesystem)
-# ----------------------------------------------------------------------
+def test_goes_glm_resolve_fields():
+    assert GOESGLM.resolve_fields(None).names == GOESGLM.SCHEMA.names
+    assert GOESGLM.resolve_fields("observation").names == ["observation"]
+    subset = ["time", "lat", "lon", "observation", "variable"]
+    assert GOESGLM.resolve_fields(subset).names == subset
+
+
+def test_goes_glm_available():
+    assert GOESGLM.available(datetime(2024, 6, 1, 18, 0))
+    assert GOESGLM.available(np.datetime64("2024-06-01T18:00"))
+    assert not GOESGLM.available(datetime(1990, 1, 1))
+
+
+def test_goes_glm_validate_time():
+    GOESGLM._validate_time([datetime(2024, 6, 1, 18, 0)])
+    with pytest.raises(ValueError):
+        GOESGLM._validate_time([datetime(1990, 1, 1)])
+
+
+def test_goes_glm_tolerance_conversion():
+    ds = GOESGLM(time_tolerance=np.timedelta64(2, "m"), cache=False, verbose=False)
+    assert ds._tolerance_lower == timedelta(minutes=-2)
+    assert ds._tolerance_upper == timedelta(minutes=2)
+    asym = GOESGLM(
+        time_tolerance=(np.timedelta64(-30, "s"), np.timedelta64(90, "s")),
+        cache=False,
+        verbose=False,
+    )
+    assert asym._tolerance_lower == timedelta(seconds=-30)
+    assert asym._tolerance_upper == timedelta(seconds=90)
+
+
+def test_goes_glm_satellite_routing():
+    ds_e = GOESGLM(satellite="east", cache=False, verbose=False)
+    assert ds_e._satellite_for_time(datetime(2024, 1, 1)) == "G16"
+    assert ds_e._satellite_for_time(datetime(2025, 6, 1)) == "G19"
+
+    ds_w = GOESGLM(satellite="west", cache=False, verbose=False)
+    assert ds_w._satellite_for_time(datetime(2020, 6, 1)) == "G17"
+    assert ds_w._satellite_for_time(datetime(2024, 6, 1)) == "G18"
+
+    ds_pin = GOESGLM(satellite="G16", cache=False, verbose=False)
+    assert ds_pin._satellite_for_time(datetime(2026, 1, 1)) == "G16"
+
+
+def test_goes_glm_lat_lon_bbox_accepts_360_convention():
+    # The GLM source filters in [-180, 180); a bbox passed in [0, 360]
+    # should be auto-normalised under the hood.
+    ds = GOESGLM(lat_lon_bbox=(24.5, 235.0, 49.5, 294.0), cache=False, verbose=False)
+    lat_min, lon_min, lat_max, lon_max = ds._lat_lon_bbox  # type: ignore[misc]
+    assert lat_min == 24.5 and lat_max == 49.5
+    assert lon_min == pytest.approx(-125.0)
+    assert lon_max == pytest.approx(-66.0)
+
+
+def test_goes_glm_parse_file(tmp_path):
+    f = tmp_path / "events.nc"
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    _write_glm_netcdf(
+        f,
+        lats=[35.0, 40.0, 60.0],
+        lons=[-120.0, -100.0, 10.0],
+        energies=[1e-15, 2e-15, 3e-15],
+        offsets=[0.0, 5.123, 19.5],
+        epoch=epoch,
+    )
+    df = GOESGLM._parse_glm_file(str(f), lat_lon_bbox=None)
+    assert df is not None and len(df) == 3
+    # CONUS bbox keeps 2 of 3 events
+    df_conus = GOESGLM._parse_glm_file(str(f), lat_lon_bbox=(24.5, -125.0, 49.5, -66.0))
+    assert df_conus is not None and len(df_conus) == 2
+    # All-out-of-box returns None
+    assert (
+        GOESGLM._parse_glm_file(str(f), lat_lon_bbox=(-10.0, -10.0, -5.0, -5.0)) is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal-plumbing tests (mocked S3 filesystem)
+# ---------------------------------------------------------------------------
 def _run(coro):
     return asyncio.run(coro)
 
 
-def test_discover_files_filters_window_and_dedups():
+def test_goes_glm_discover_files():
     ds = GOESGLM(
         satellite="east",
         time_tolerance=np.timedelta64(1, "m"),
@@ -326,9 +332,6 @@ def test_discover_files_filters_window_and_dedups():
         verbose=False,
     )
 
-    # Simulate s3fs._ls for one hour prefix returning a mix of valid GLM
-    # keys (one inside the window, one outside, one duplicate, plus a
-    # non-.nc entry that should be ignored).
     bucket_prefix = "noaa-goes16/GLM-L2-LCFA/2024/153/18/"
     keys = [
         bucket_prefix
@@ -339,124 +342,49 @@ def test_discover_files_filters_window_and_dedups():
         + "OR_GLM-L2-LCFA_G16_s20241531805000_e20241531805200_c20241531805220.nc",
         bucket_prefix + "junk.txt",
         bucket_prefix
-        + "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc",  # dup
+        + "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc",
     ]
-
     fake_fs = AsyncMock()
     fake_fs._ls = AsyncMock(return_value=keys)
     ds.fs = fake_fs
 
     files = _run(ds._discover_files([datetime(2024, 6, 1, 18, 0, 0)]))
-    # 2 keys fall inside [-1m, +1m]; the 18:05 file does not; junk.txt is
-    # ignored; duplicate collapsed.
     assert len(files) == 2
-    assert all(f.satellite == "G16" for f in files)
-    assert all(f.s3_uri.startswith("s3://noaa-goes16/") for f in files)
+    assert {f.satellite for f in files} == {"G16"}
+
+    # Missing prefix → empty result, no exception.
+    fake_fs._ls = AsyncMock(side_effect=FileNotFoundError())
+    assert _run(ds._discover_files([datetime(2024, 6, 1, 18, 0, 0)])) == []
 
 
-def test_discover_files_missing_prefix_returns_empty():
-    ds = GOESGLM(satellite="east", cache=False, verbose=False)
-    fake_fs = AsyncMock()
-    fake_fs._ls = AsyncMock(side_effect=FileNotFoundError("missing"))
-    ds.fs = fake_fs
-    files = _run(ds._discover_files([datetime(2024, 6, 1, 18, 0, 0)]))
-    assert files == []
-
-
-def test_fetch_remote_file_writes_cache_and_skips_existing(tmp_path):
+def test_goes_glm_fetch_remote_file(tmp_path):
     ds = GOESGLM(satellite="east", cache=False, verbose=False)
     fake_fs = AsyncMock()
     fake_fs._cat_file = AsyncMock(return_value=b"fake-netcdf-bytes")
     ds.fs = fake_fs
-
     pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
-    uri = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/file.nc"
-    _run(ds._fetch_remote_file(uri))
-    cached = pathlib.Path(ds._cache_path(uri))
-    assert cached.read_bytes() == b"fake-netcdf-bytes"
-    fake_fs._cat_file.assert_awaited_once_with(uri)
 
-    # Second call should not re-fetch
-    fake_fs._cat_file.reset_mock()
-    _run(ds._fetch_remote_file(uri))
-    fake_fs._cat_file.assert_not_called()
+    try:
+        uri = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/file.nc"
+        _run(ds._fetch_remote_file(uri))
+        assert pathlib.Path(ds._cache_path(uri)).read_bytes() == b"fake-netcdf-bytes"
+        fake_fs._cat_file.assert_awaited_once_with(uri)
 
-    # Missing file in S3 is swallowed (warn-only)
-    missing_uri = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/missing.nc"
-    fake_fs._cat_file = AsyncMock(side_effect=FileNotFoundError())
-    _run(ds._fetch_remote_file(missing_uri))
-    assert not pathlib.Path(ds._cache_path(missing_uri)).exists()
-    shutil.rmtree(ds.cache, ignore_errors=True)
+        # Second call is a no-op (cache hit).
+        fake_fs._cat_file.reset_mock()
+        _run(ds._fetch_remote_file(uri))
+        fake_fs._cat_file.assert_not_called()
 
+        # Missing file in S3 is swallowed (warn-only).
+        missing = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/missing.nc"
+        fake_fs._cat_file = AsyncMock(side_effect=FileNotFoundError())
+        _run(ds._fetch_remote_file(missing))
+        assert not pathlib.Path(ds._cache_path(missing)).exists()
+    finally:
+        shutil.rmtree(ds.cache, ignore_errors=True)
 
-def test_fetch_remote_file_requires_filesystem():
-    ds = GOESGLM(satellite="east", cache=False, verbose=False)
-    assert ds.fs is None
+    # Requires an initialised filesystem.
+    ds2 = GOESGLM(satellite="east", cache=False, verbose=False)
+    assert ds2.fs is None
     with pytest.raises(ValueError):
-        _run(ds._fetch_remote_file("s3://noaa-goes16/anything.nc"))
-
-
-def test_empty_dataframe_path():
-    """With no discovered files, the source returns an empty DF with the
-    requested fields."""
-    ds = GOESGLM(satellite="east", cache=False, verbose=False)
-
-    async def _no_discover(self, time_list):  # type: ignore[no-untyped-def]
-        return []
-
-    with patch.object(GOESGLM, "_discover_files", _no_discover):
-        df = ds(
-            datetime(2024, 6, 1, 18, 0),
-            ["flashe"],
-            fields=["time", "lat", "lon", "observation", "variable"],
-        )
-    assert list(df.columns) == ["time", "lat", "lon", "observation", "variable"]
-    assert df.empty
-    # Empty result still carries schema-typed columns, not all-object.
-    assert df["time"].dtype.kind == "M"
-    assert df["lat"].dtype == np.float32
-    assert df["lon"].dtype == np.float32
-    assert df["observation"].dtype == np.float32
-    assert df["variable"].dtype == object
-
-
-def test_resolve_event_times_fallback(tmp_path):
-    """When event_time_offset has no ``units`` attribute, the parser
-    falls back to ``time_coverage_start``."""
-    f = tmp_path / "events_no_units.nc"
-    epoch = datetime(2024, 6, 1, 18, 0, 0)
-    import netCDF4 as nc
-
-    with nc.Dataset(f, "w", format="NETCDF4") as ds:
-        ds.time_coverage_start = epoch.strftime("%Y-%m-%dT%H:%M:%S.0Z")
-        ds.createDimension("number_of_events", 1)
-        for name in ("event_lat", "event_lon", "event_energy"):
-            v = ds.createVariable(name, "f4", ("number_of_events",))
-            v[:] = np.array([10.0], dtype=np.float32)
-        # event_time_offset WITHOUT units → triggers fallback path
-        off = ds.createVariable("event_time_offset", "f8", ("number_of_events",))
-        off[:] = np.array([7.5], dtype=np.float64)
-
-    df = _parse_glm_file(str(f), bbox=None)
-    assert df is not None
-    assert df["time"].iloc[0] == pd.Timestamp(epoch + timedelta(seconds=7.5))
-
-
-# ----------------------------------------------------------------------
-# Real-S3 smoke test (network)
-# ----------------------------------------------------------------------
-@pytest.mark.slow
-@pytest.mark.xfail
-@pytest.mark.timeout(120)
-def test_goes_glm_real_fetch():
-    ds = GOESGLM(
-        satellite="east",
-        bbox=(24.5, 49.5, -125.0, -66.0),
-        time_tolerance=np.timedelta64(1, "m"),
-        cache=False,
-        verbose=False,
-    )
-    df = ds(datetime(2024, 6, 1, 18, 0), ["flashe", "flashc"])
-    assert list(df.columns) == ds.SCHEMA.names
-    assert not df.empty
-    assert set(df["variable"]).issubset({"flashe", "flashc"})
+        _run(ds2._fetch_remote_file("s3://noaa-goes16/anything.nc"))

--- a/test/data/test_goes_glm.py
+++ b/test/data/test_goes_glm.py
@@ -315,7 +315,7 @@ def test_goes_glm_invalid_variable():
 # Tests for the internal S3 plumbing (mocked filesystem)
 # ----------------------------------------------------------------------
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_discover_files_filters_window_and_dedups():
@@ -412,6 +412,12 @@ def test_empty_dataframe_path():
         )
     assert list(df.columns) == ["time", "lat", "lon", "observation", "variable"]
     assert df.empty
+    # Empty result still carries schema-typed columns, not all-object.
+    assert df["time"].dtype.kind == "M"
+    assert df["lat"].dtype == np.float32
+    assert df["lon"].dtype == np.float32
+    assert df["observation"].dtype == np.float32
+    assert df["variable"].dtype == object
 
 
 def test_resolve_event_times_fallback(tmp_path):

--- a/test/data/test_goes_glm.py
+++ b/test/data/test_goes_glm.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import pathlib
+import shutil
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from earth2studio.data import GOESGLM
+from earth2studio.data.goes_glm import (
+    _GOESGLMFile,
+    _parse_filename_start,
+    _parse_glm_file,
+)
+
+netCDF4 = pytest.importorskip("netCDF4", reason="netCDF4 not installed")
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+def _write_glm_netcdf(
+    path: pathlib.Path,
+    lats: list[float],
+    lons: list[float],
+    energies: list[float],
+    offsets: list[float],
+    epoch: datetime = datetime(2024, 6, 1, 18, 0, 0),
+) -> None:
+    """Write a minimal GLM L2 LCFA NetCDF that the source can parse."""
+    with netCDF4.Dataset(path, "w", format="NETCDF4") as ds:
+        ds.time_coverage_start = epoch.strftime("%Y-%m-%dT%H:%M:%S.0Z")
+        ds.createDimension("number_of_events", len(lats))
+        lat_v = ds.createVariable("event_lat", "f4", ("number_of_events",))
+        lat_v[:] = np.asarray(lats, dtype=np.float32)
+        lon_v = ds.createVariable("event_lon", "f4", ("number_of_events",))
+        lon_v[:] = np.asarray(lons, dtype=np.float32)
+        en_v = ds.createVariable("event_energy", "f4", ("number_of_events",))
+        en_v[:] = np.asarray(energies, dtype=np.float32)
+        off_v = ds.createVariable("event_time_offset", "f8", ("number_of_events",))
+        off_v.units = f"seconds since {epoch.strftime('%Y-%m-%d %H:%M:%S')}"
+        off_v[:] = np.asarray(offsets, dtype=np.float64)
+
+
+# ----------------------------------------------------------------------
+# Pure unit tests
+# ----------------------------------------------------------------------
+def test_filename_start_parse():
+    key = (
+        "noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
+    )
+    assert _parse_filename_start(key) == datetime(2024, 6, 1, 18, 0, 0)
+    assert _parse_filename_start("nope.nc") is None
+    assert _parse_filename_start("OR_GLM-L2-LCFA_G16_sbad__e__c.nc") is None
+
+
+def test_parse_glm_file(tmp_path):
+    f = tmp_path / "events.nc"
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    _write_glm_netcdf(
+        f,
+        lats=[35.0, 40.0, 60.0],
+        lons=[-120.0, -100.0, 10.0],
+        energies=[1e-15, 2e-15, 3e-15],
+        offsets=[0.0, 5.123, 19.5],
+        epoch=epoch,
+    )
+    # Without bbox: 3 events
+    df = _parse_glm_file(str(f), bbox=None)
+    assert df is not None
+    assert len(df) == 3
+    # Sub-second precision preserved
+    assert df["time"].iloc[1] == pd.Timestamp(epoch + timedelta(seconds=5.123))
+    # With CONUS bbox: only 2 of 3 events
+    df_conus = _parse_glm_file(str(f), bbox=(24.5, 49.5, -125.0, -66.0))
+    assert df_conus is not None
+    assert len(df_conus) == 2
+    # All-out-of-box returns None
+    df_empty = _parse_glm_file(str(f), bbox=(-10.0, -5.0, -10.0, -5.0))
+    assert df_empty is None
+
+
+def test_satellite_routing():
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+    # G16 era
+    assert ds._satellite_for_time(datetime(2024, 1, 1)) == "G16"
+    # G19 era
+    assert ds._satellite_for_time(datetime(2025, 6, 1)) == "G19"
+
+    ds_w = GOESGLM(satellite="west", cache=False, verbose=False)
+    assert ds_w._satellite_for_time(datetime(2020, 6, 1)) == "G17"
+    assert ds_w._satellite_for_time(datetime(2024, 6, 1)) == "G18"
+
+    ds_pin = GOESGLM(satellite="G16", cache=False, verbose=False)
+    assert ds_pin._satellite_for_time(datetime(2024, 1, 1)) == "G16"
+    # Pinning bypasses slot history (caller's responsibility)
+    assert ds_pin._satellite_for_time(datetime(2026, 1, 1)) == "G16"
+
+
+def test_constructor_validation():
+    with pytest.raises(ValueError):
+        GOESGLM(satellite="unknown")
+    with pytest.raises(ValueError):
+        GOESGLM(bbox=(50.0, 40.0, -120.0, -110.0))  # lat_min >= lat_max
+
+
+def test_tolerance_normalisation():
+    ds = GOESGLM(time_tolerance=np.timedelta64(2, "m"), cache=False, verbose=False)
+    assert ds._tolerance_lower == timedelta(minutes=-2)
+    assert ds._tolerance_upper == timedelta(minutes=2)
+    ds_asym = GOESGLM(
+        time_tolerance=(np.timedelta64(-30, "s"), np.timedelta64(90, "s")),
+        cache=False,
+        verbose=False,
+    )
+    assert ds_asym._tolerance_lower == timedelta(seconds=-30)
+    assert ds_asym._tolerance_upper == timedelta(seconds=90)
+
+
+def test_validate_time_and_available():
+    GOESGLM._validate_time([datetime(2024, 6, 1, 18, 0)])
+    with pytest.raises(ValueError):
+        GOESGLM._validate_time([datetime(1990, 1, 1)])
+
+    assert GOESGLM.available(datetime(2024, 6, 1, 18, 0))
+    assert not GOESGLM.available(datetime(1990, 1, 1))
+    assert GOESGLM.available(np.datetime64("2024-06-01T18:00"))
+
+
+def test_resolve_fields():
+    full = GOESGLM.resolve_fields(None)
+    assert full.names == GOESGLM.SCHEMA.names
+
+    subset = GOESGLM.resolve_fields(["time", "lat", "lon", "observation", "variable"])
+    assert subset.names == ["time", "lat", "lon", "observation", "variable"]
+
+    one = GOESGLM.resolve_fields("observation")
+    assert one.names == ["observation"]
+
+    with pytest.raises(KeyError):
+        GOESGLM.resolve_fields(["does_not_exist"])
+
+    bad_schema = pa.schema([pa.field("does_not_exist", pa.float32())])
+    with pytest.raises(KeyError):
+        GOESGLM.resolve_fields(bad_schema)
+
+    wrong_type = pa.schema([pa.field("time", pa.string())])
+    with pytest.raises(TypeError):
+        GOESGLM.resolve_fields(wrong_type)
+
+
+# ----------------------------------------------------------------------
+# Mock end-to-end test (no network)
+# ----------------------------------------------------------------------
+def test_goes_glm_mock_call(tmp_path):
+    """Exercise the full __call__ → fetch → compile path with mocked I/O.
+
+    A synthetic NetCDF is dropped into the deterministic cache path so the
+    real ``_parse_glm_file`` runs. ``_discover_files`` and
+    ``_fetch_remote_file`` are stubbed to avoid any S3 traffic.
+    """
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    s3_uri = (
+        "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
+    )
+
+    async def _no_op_fetch(self, uri):  # type: ignore[no-untyped-def]
+        # File already placed in cache by the test; nothing to do.
+        return None
+
+    async def _fake_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return [
+            _GOESGLMFile(
+                s3_uri=s3_uri,
+                satellite="G16",
+                file_start=epoch,
+            )
+        ]
+
+    ds = GOESGLM(
+        satellite="east",
+        time_tolerance=np.timedelta64(5, "m"),
+        cache=False,
+        verbose=False,
+    )
+    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
+    # Pre-populate the cache with the synthetic NetCDF at the expected path.
+    local_path = ds._cache_path(s3_uri)
+    _write_glm_netcdf(
+        pathlib.Path(local_path),
+        lats=[35.0, 40.0, 60.0],
+        lons=[-120.0, -100.0, 10.0],
+        energies=[1.5e-15, 2.5e-15, 3.5e-15],
+        offsets=[0.0, 30.0, 60.0],
+        epoch=epoch,
+    )
+
+    try:
+        with (
+            patch.object(GOESGLM, "_discover_files", _fake_discover),
+            patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
+        ):
+            df = ds(epoch, ["flashe", "flashc"])
+
+            # Default field set is the full schema.
+            assert list(df.columns) == ds.SCHEMA.names
+            # 3 events × 2 requested variables = 6 rows.
+            assert len(df) == 6
+            assert set(df["variable"]) == {"flashe", "flashc"}
+            # Longitude normalised to [0, 360)
+            assert (df["lon"] >= 0).all()
+            assert (df["lon"] < 360).all()
+            # CONUS lon -120 → 240, -100 → 260, 10 → 10
+            assert np.any(np.isclose(df["lon"].values, 240.0))
+            assert np.any(np.isclose(df["lon"].values, 260.0))
+            # flashc is constantly 1.0
+            flashc_rows = df[df["variable"] == "flashc"]
+            assert (flashc_rows["observation"].astype(float) == 1.0).all()
+            # flashe carries energy values
+            flashe_rows = df[df["variable"] == "flashe"]
+            assert flashe_rows["observation"].max() == pytest.approx(3.5e-15)
+            # Satellite column is the routed platform
+            assert set(df["satellite"]) == {"G16"}
+
+            # Subset fields path
+            subset = ds(
+                epoch,
+                ["flashe"],
+                fields=["time", "lat", "lon", "observation", "variable"],
+            )
+            assert list(subset.columns) == [
+                "time",
+                "lat",
+                "lon",
+                "observation",
+                "variable",
+            ]
+            assert (subset["variable"] == "flashe").all()
+    finally:
+        shutil.rmtree(ds.cache, ignore_errors=True)
+
+
+def test_goes_glm_bbox_filter_call(tmp_path):
+    """Mock-mode call with a CONUS bbox should drop out-of-region events."""
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    s3_uri = (
+        "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+        "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc"
+    )
+
+    async def _no_op_fetch(self, uri):  # type: ignore[no-untyped-def]
+        return None
+
+    async def _fake_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return [_GOESGLMFile(s3_uri=s3_uri, satellite="G16", file_start=epoch)]
+
+    ds = GOESGLM(
+        satellite="east",
+        bbox=(24.5, 49.5, -125.0, -66.0),
+        time_tolerance=np.timedelta64(5, "m"),
+        cache=False,
+        verbose=False,
+    )
+    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
+    _write_glm_netcdf(
+        pathlib.Path(ds._cache_path(s3_uri)),
+        lats=[35.0, 40.0, 60.0],
+        lons=[-120.0, -100.0, 10.0],
+        energies=[1.0e-15, 2.0e-15, 3.0e-15],
+        offsets=[0.0, 30.0, 60.0],
+        epoch=epoch,
+    )
+
+    with (
+        patch.object(GOESGLM, "_discover_files", _fake_discover),
+        patch.object(GOESGLM, "_fetch_remote_file", _no_op_fetch),
+    ):
+        df = ds(epoch, ["flashe"])
+
+    # Only the two CONUS events survive bbox filter; one variable requested → 2 rows
+    assert len(df) == 2
+    # The 60N / 10E event is excluded
+    assert df["lat"].max() < 50.0
+
+
+def test_goes_glm_invalid_variable():
+    # Variable validation happens before any S3 access, so no patching needed.
+    ds = GOESGLM(satellite="G16", cache=False, verbose=False)
+    with pytest.raises(KeyError):
+        ds(datetime(2024, 6, 1, 18, 0), ["not_a_var"])
+
+
+# ----------------------------------------------------------------------
+# Tests for the internal S3 plumbing (mocked filesystem)
+# ----------------------------------------------------------------------
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_discover_files_filters_window_and_dedups():
+    ds = GOESGLM(
+        satellite="east",
+        time_tolerance=np.timedelta64(1, "m"),
+        cache=False,
+        verbose=False,
+    )
+
+    # Simulate s3fs._ls for one hour prefix returning a mix of valid GLM
+    # keys (one inside the window, one outside, one duplicate, plus a
+    # non-.nc entry that should be ignored).
+    bucket_prefix = "noaa-goes16/GLM-L2-LCFA/2024/153/18/"
+    keys = [
+        bucket_prefix
+        + "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc",
+        bucket_prefix
+        + "OR_GLM-L2-LCFA_G16_s20241531800200_e20241531800400_c20241531800420.nc",
+        bucket_prefix
+        + "OR_GLM-L2-LCFA_G16_s20241531805000_e20241531805200_c20241531805220.nc",
+        bucket_prefix + "junk.txt",
+        bucket_prefix
+        + "OR_GLM-L2-LCFA_G16_s20241531800000_e20241531800200_c20241531800220.nc",  # dup
+    ]
+
+    fake_fs = AsyncMock()
+    fake_fs._ls = AsyncMock(return_value=keys)
+    ds.fs = fake_fs
+
+    files = _run(ds._discover_files([datetime(2024, 6, 1, 18, 0, 0)]))
+    # 2 keys fall inside [-1m, +1m]; the 18:05 file does not; junk.txt is
+    # ignored; duplicate collapsed.
+    assert len(files) == 2
+    assert all(f.satellite == "G16" for f in files)
+    assert all(f.s3_uri.startswith("s3://noaa-goes16/") for f in files)
+
+
+def test_discover_files_missing_prefix_returns_empty():
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+    fake_fs = AsyncMock()
+    fake_fs._ls = AsyncMock(side_effect=FileNotFoundError("missing"))
+    ds.fs = fake_fs
+    files = _run(ds._discover_files([datetime(2024, 6, 1, 18, 0, 0)]))
+    assert files == []
+
+
+def test_fetch_remote_file_writes_cache_and_skips_existing(tmp_path):
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+    fake_fs = AsyncMock()
+    fake_fs._cat_file = AsyncMock(return_value=b"fake-netcdf-bytes")
+    ds.fs = fake_fs
+
+    pathlib.Path(ds.cache).mkdir(parents=True, exist_ok=True)
+    uri = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/file.nc"
+    _run(ds._fetch_remote_file(uri))
+    cached = pathlib.Path(ds._cache_path(uri))
+    assert cached.read_bytes() == b"fake-netcdf-bytes"
+    fake_fs._cat_file.assert_awaited_once_with(uri)
+
+    # Second call should not re-fetch
+    fake_fs._cat_file.reset_mock()
+    _run(ds._fetch_remote_file(uri))
+    fake_fs._cat_file.assert_not_called()
+
+    # Missing file in S3 is swallowed (warn-only)
+    missing_uri = "s3://noaa-goes16/GLM-L2-LCFA/2024/153/18/missing.nc"
+    fake_fs._cat_file = AsyncMock(side_effect=FileNotFoundError())
+    _run(ds._fetch_remote_file(missing_uri))
+    assert not pathlib.Path(ds._cache_path(missing_uri)).exists()
+    shutil.rmtree(ds.cache, ignore_errors=True)
+
+
+def test_fetch_remote_file_requires_filesystem():
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+    assert ds.fs is None
+    with pytest.raises(ValueError):
+        _run(ds._fetch_remote_file("s3://noaa-goes16/anything.nc"))
+
+
+def test_empty_dataframe_path():
+    """With no discovered files, the source returns an empty DF with the
+    requested fields."""
+    ds = GOESGLM(satellite="east", cache=False, verbose=False)
+
+    async def _no_discover(self, time_list):  # type: ignore[no-untyped-def]
+        return []
+
+    with patch.object(GOESGLM, "_discover_files", _no_discover):
+        df = ds(
+            datetime(2024, 6, 1, 18, 0),
+            ["flashe"],
+            fields=["time", "lat", "lon", "observation", "variable"],
+        )
+    assert list(df.columns) == ["time", "lat", "lon", "observation", "variable"]
+    assert df.empty
+
+
+def test_resolve_event_times_fallback(tmp_path):
+    """When event_time_offset has no ``units`` attribute, the parser
+    falls back to ``time_coverage_start``."""
+    f = tmp_path / "events_no_units.nc"
+    epoch = datetime(2024, 6, 1, 18, 0, 0)
+    import netCDF4 as nc
+
+    with nc.Dataset(f, "w", format="NETCDF4") as ds:
+        ds.time_coverage_start = epoch.strftime("%Y-%m-%dT%H:%M:%S.0Z")
+        ds.createDimension("number_of_events", 1)
+        for name in ("event_lat", "event_lon", "event_energy"):
+            v = ds.createVariable(name, "f4", ("number_of_events",))
+            v[:] = np.array([10.0], dtype=np.float32)
+        # event_time_offset WITHOUT units → triggers fallback path
+        off = ds.createVariable("event_time_offset", "f8", ("number_of_events",))
+        off[:] = np.array([7.5], dtype=np.float64)
+
+    df = _parse_glm_file(str(f), bbox=None)
+    assert df is not None
+    assert df["time"].iloc[0] == pd.Timestamp(epoch + timedelta(seconds=7.5))
+
+
+# ----------------------------------------------------------------------
+# Real-S3 smoke test (network)
+# ----------------------------------------------------------------------
+@pytest.mark.slow
+@pytest.mark.xfail
+@pytest.mark.timeout(120)
+def test_goes_glm_real_fetch():
+    ds = GOESGLM(
+        satellite="east",
+        bbox=(24.5, 49.5, -125.0, -66.0),
+        time_tolerance=np.timedelta64(1, "m"),
+        cache=False,
+        verbose=False,
+    )
+    df = ds(datetime(2024, 6, 1, 18, 0), ["flashe", "flashc"])
+    assert list(df.columns) == ds.SCHEMA.names
+    assert not df.empty
+    assert set(df["variable"]).issubset({"flashe", "flashc"})


### PR DESCRIPTION
## Description

Add `GOESGLM` DataFrameSource for NOAA GOES-16/17/18/19 Geostationary
Lightning Mapper (GLM) Level 2 Lightning Cluster-Filter Algorithm
(LCFA) per-event observations from the public NOAA AWS Open Data
archive. Each row is a single optical event detected by GLM with a
sub-second timestamp, latitude/longitude, and either `flashe`
(optical energy in J) or `flashc` (constant 1.0 per event, for
density aggregation during downstream regridding).

### Data source details

| Property | Value |
|---|---|
| **Source type** | DataFrameSource |
| **Remote store** | https://registry.opendata.aws/noaa-goes/ (buckets `noaa-goes16/17/18/19`, prefix `GLM-L2-LCFA/`) |
| **Format** | NetCDF4 (~20s files, full-disk) |
| **Spatial resolution** | Per-event point observations (no grid); native GLM full-disk FOV |
| **Temporal resolution** | ~20s file cadence; per-event sub-second precision via `event_time_offset` |
| **Date range** | G16 2018-02-13→2025-04-04; G19 2025-04-04→present; G17 2018-12-10→2023-01-04; G18 2023-01-04→present |
| **Region** | GOES-East / GOES-West full disk (Americas) |
| **Authentication** | Anonymous (NOAA Open Data) |

### Data licensing

> **License**: NOAA Open Data (public domain, U.S. Government work)
> **URL**: https://registry.opendata.aws/noaa-goes/
>
> Open data, freely available for commercial and non-commercial use.
> Provided "as-is" by NOAA / NESDIS on AWS Open Data; no attribution
> required but recommended.

### Dependencies added

No new dependencies needed. `netCDF4` and `s3fs` are already in the
core `[project] dependencies`.

### Validation

Variable validation against real data (G16, CONUS bbox, 2024-06-01
18:00 UTC ±2 min):

| Variable | Rows | Valid % | Range |
|----------|------|---------|-------|
| `flashe` | 44,523 | 100% | 1.37e-15 – 1.57e-13 J |
| `flashc` | 44,523 | 100% | 1 – 1 (constant by design) |

All lexicon variables produce valid observations. See the
sanity-check comment below for a CONUS plot.

## Checklist

- [x] I am familiar with the [Contributing Guidelines][contrib].
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md][changelog] is up to date with these changes.
- [ ] An [issue][issues] is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot).

[contrib]: https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md
[changelog]: https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md
[issues]: https://github.com/NVIDIA/earth2studio/issues

## Dependencies

None.
