### PR TITLE
Slight speed up of GDAS PrepBUFR decoding

### DIFF
--- a/earth2studio/data/gdas.py
+++ b/earth2studio/data/gdas.py
@@ -63,23 +63,13 @@ from earth2studio.data.utils_bufr import (
 from earth2studio.data.utils_bufr import (
     parse_prepbufr_messages as _bufr_parse_prepbufr_messages,
 )
-from earth2studio.data.utils_bufr import (
-    register_dx_tables as _bufr_register_dx_tables,
-)
 from earth2studio.lexicon.base import E2STUDIO_SCHEMA
 from earth2studio.lexicon.gdas import GDASObsConvLexicon
 from earth2studio.utils.imports import (
-    OptionalDependencyFailure,
     check_optional_dependencies,
 )
 from earth2studio.utils.time import normalize_time_tolerance, timearray_to_datetime
 from earth2studio.utils.type import TimeArray, TimeTolerance, VariableArray
-
-try:
-    from pybufrkit.decoder import Decoder as BufrDecoder
-except ImportError:
-    OptionalDependencyFailure("data")
-    BufrDecoder = None  # type: ignore[assignment,misc]
 
 NOMADS_BASE_URL = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/obsproc/prod"
 
@@ -1066,8 +1056,7 @@ def _init_decode_worker(
     as a module-level global.
     """
     global _worker_decoder  # noqa: PLW0603
-    _bufr_register_dx_tables(table_b, table_d)
-    _worker_decoder = BufrDecoder()
+    _worker_decoder = _bufr_create_decoder(table_b, table_d)
 
 
 def _decode_message_worker(
@@ -1136,7 +1125,7 @@ def _decode_message(
         Observation rows for this message.
     """
     try:
-        msg = decoder.process(msg_bytes)
+        msg = decoder.process(msg_bytes, wire_template_data=False)
     except Exception:
         return []
 

--- a/earth2studio/data/utils_bufr.py
+++ b/earth2studio/data/utils_bufr.py
@@ -45,6 +45,8 @@ except ImportError:
     BufrDecoder = None  # type: ignore[assignment,misc]
     TableGroupCacheManager = None  # type: ignore[assignment,misc]
 
+DEFAULT_COMPILED_TEMPLATE_CACHE_MAX = 200
+
 
 # ─────────────────────────────────────────────────────────────────────
 # PrepBUFR descriptor ID constants
@@ -356,6 +358,7 @@ def register_dx_tables(
 def create_decoder(
     table_b: dict[int, tuple[Any, ...]],
     table_d: dict[int, tuple[Any, ...]],
+    compiled_template_cache_max: int | None = DEFAULT_COMPILED_TEMPLATE_CACHE_MAX,
 ) -> Any:
     """Register custom NCEP tables and create a pybufrkit decoder.
 
@@ -365,6 +368,9 @@ def create_decoder(
         NCEP Table B entries.
     table_d : dict
         NCEP Table D entries.
+    compiled_template_cache_max : int or None
+        Maximum number of compiled BUFR templates to cache in pybufrkit.
+        Set to None to disable template compilation.
 
     Returns
     -------
@@ -372,7 +378,7 @@ def create_decoder(
         Configured decoder instance.
     """
     register_dx_tables(table_b, table_d)
-    return BufrDecoder()
+    return BufrDecoder(compiled_template_cache_max=compiled_template_cache_max)
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -442,10 +448,14 @@ def parse_prepbufr_messages(
         ctx = silence_bufr_noise() if silence_noise else contextlib.nullcontext()
         with ctx:
             try:
-                dx_decoder = BufrDecoder()
+                dx_decoder = BufrDecoder(
+                    compiled_template_cache_max=DEFAULT_COMPILED_TEMPLATE_CACHE_MAX
+                )
                 for dx_bytes in dx_messages:
                     try:
-                        dx_msg = dx_decoder.process(dx_bytes)
+                        dx_msg = dx_decoder.process(
+                            dx_bytes, wire_template_data=False
+                        )
                     except Exception:  # noqa: S112
                         logger.debug("Skipping unparseable DX-table message")
                         continue
@@ -486,8 +496,7 @@ def init_decode_worker(
         NCEP Table D entries.
     """
     global _worker_decoder  # noqa: PLW0603
-    register_dx_tables(table_b, table_d)
-    _worker_decoder = BufrDecoder()
+    _worker_decoder = create_decoder(table_b, table_d)
 
 
 def get_worker_decoder() -> Any:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Optimizations for prepbufr reading

## Description

This PR speeds up GDAS PrepBUFR decoding by reducing the amount of `pybufrkit` work needed for the observation extraction path.

## Changes

- Add a default `pybufrkit` compiled template cache size of `200`.
- Update decoder creation to pass `compiled_template_cache_max`.
- Decode DX-table and data messages with `wire_template_data=False`.


## Performance

Benchmarks used a cached GDAS PrepBUFR sample file of about 67 MB with roughly 5,440 BUFR messages.

Representative all-variable decode timings with `decode_workers=32`:

- Original pybufrkit path: ~49.8 s
- Low-risk pybufrkit changes: ~31.2 s

## Examples

Make sure to set the `decode_workers` accordingly

```python
from earth2studio.data import NomadsGDASObsConv
from datetime import datetime, timedelta

# Grab 24 hours of recent data
ds = NomadsGDASObsConv(
    time_tolerance=timedelta(minutes=12*60),  # ±12h window
    cache=True,
    decode_workers=32,
)

today = datetime.now() - timedelta(hours=18)

nomadsGDAS = ds(today, ['u', 'v', 'q', 't', 'pres'])
```

## Validation

The targeted decoder was compared against the generic pybufrkit decoder on the first 50 GDAS work messages in a sample file:

## Notes:

This PR does not add new runtime dependencies and does not modify `pybufrkit` itself. It keeps the existing `pybufrkit`-backed decoding path, but narrows the amount of decoded template data retained for GDAS observation extraction.

## Checklist

- [ x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
