### PR TITLE
fix: use unique hash for temp cache directories in data sources

### DIFF
--- a/earth2studio/data/arco.py
+++ b/earth2studio/data/arco.py
@@ -20,6 +20,7 @@ import os
 import pathlib
 import re
 import shutil
+import uuid
 from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime
@@ -93,6 +94,7 @@ class ARCO:
 
         self._cache = cache
         self._verbose = verbose
+        self._tmp_cache_hash: str | None = None
 
         self.zarr_group: zarr.core.group.AsyncGroup | None = None
         self.level_coords = None
@@ -387,7 +389,12 @@ class ARCO:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "arco")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_arco")
+            if self._tmp_cache_hash is None:
+                # First access for temp cache: create a random suffix to avoid collisions
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_arco_{self._tmp_cache_hash}"
+            )
         return cache_location
 
     @classmethod

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import pathlib
 import shutil
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -121,6 +122,7 @@ class GEFS_FX:
         self._cache = cache
         self._verbose = verbose
         self._max_workers = max_workers
+        self._tmp_cache_hash: str | None = None
 
         if member not in self.GEFS_MEMBERS:
             raise ValueError(f"Invalid GEFS member {member}")
@@ -546,7 +548,12 @@ class GEFS_FX:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "gefs")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_gefs")
+            if self._tmp_cache_hash is None:
+                # First access for temp cache: create a random suffix to avoid collisions
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_gefs_{self._tmp_cache_hash}"
+            )
         return cache_location
 
     @classmethod

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import pathlib
 import shutil
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -112,6 +113,7 @@ class GFS:
     ):
         self._cache = cache
         self._verbose = verbose
+        self._tmp_cache_hash: str | None = None
 
         if source == "aws":
             self.uri_prefix = "noaa-gfs-bdp-pds"
@@ -507,7 +509,12 @@ class GFS:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "gfs")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_gfs")
+            if self._tmp_cache_hash is None:
+                # First access for temp cache: create a random suffix to avoid collisions
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_gfs_{self._tmp_cache_hash}"
+            )
         return cache_location
 
     @classmethod

--- a/earth2studio/data/goes.py
+++ b/earth2studio/data/goes.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import pathlib
 import shutil
+import uuid
 from datetime import datetime, timezone
 
 import numpy as np
@@ -200,6 +201,7 @@ class GOES:
         self._cache = cache
         self._verbose = verbose
         self._async_timeout = async_timeout
+        self._tmp_cache_hash: str | None = None
 
         # Stash the grid coords so they can be added to data arrays
         self._lat, self._lon = GOES.grid(satellite=satellite, scan_mode=scan_mode)
@@ -474,7 +476,12 @@ class GOES:
         """Return appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "goes")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_goes")
+            if self._tmp_cache_hash is None:
+                # First access for temp cache: create a random suffix to avoid collisions
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_goes_{self._tmp_cache_hash}"
+            )
         return cache_location
 
     @staticmethod

--- a/earth2studio/data/wb2.py
+++ b/earth2studio/data/wb2.py
@@ -20,6 +20,7 @@ import inspect
 import os
 import pathlib
 import shutil
+import uuid
 from datetime import datetime
 from typing import Literal
 
@@ -60,6 +61,7 @@ class _WB2Base:
 
         self._cache = cache
         self._verbose = verbose
+        self._tmp_cache_hash: str | None = None
         self.async_timeout = async_timeout
 
         # Check to see if there is a running loop (initialized in async)
@@ -258,7 +260,12 @@ class _WB2Base:
         """Get the appropriate cache location."""
         cache_location = os.path.join(datasource_cache_root(), "wb2era5")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_wb2era5")
+            if self._tmp_cache_hash is None:
+                # First access for temp cache: create a random suffix to avoid collisions
+                self._tmp_cache_hash = uuid.uuid4().hex[:8]
+            cache_location = os.path.join(
+                cache_location, f"tmp_wb2era5_{self._tmp_cache_hash}"
+            )
         return cache_location
 
     @classmethod


### PR DESCRIPTION
## Description

Add UUID-based hash suffix to temp cache paths to avoid collisions between concurrent instances when `cache=False`. This matches the pattern already used in the ISD data source.

When multiple data source instances are created with `cache=False`, they previously all used the same static temp directory (e.g., `tmp_gfs`), which could cause race conditions or data corruption when running in parallel.

## Changes

Updated the following data sources to use unique temp cache paths:
- `GFS` / `GFS_FX`: `tmp_gfs` → `tmp_gfs_{uuid}`
- `GEFS_FX` / `GEFS_FX_721x1440`: `tmp_gefs` → `tmp_gefs_{uuid}`
- `ARCO`: `tmp_arco` → `tmp_arco_{uuid}`
- `GOES`: `tmp_goes` → `tmp_goes_{uuid}`
- `WB2ERA5` (and variants): `tmp_wb2era5` → `tmp_wb2era5_{uuid}`

Each class now stores a `_tmp_cache_hash` instance variable that is lazily initialized on first access to the `cache` property when `cache=False`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md)
- [x] New features have been documented following the existing documentation style
- [x] Changes pass linting and formatting