### PR TITLE
Update install guide to 0.15.0 and add install step to release skill

### DIFF
--- a/.claude/skills/release-rebase/SKILL.md
+++ b/.claude/skills/release-rebase/SKILL.md
@@ -150,7 +150,20 @@ look correct.
 
 ---
 
-## Step 6 — Update Documentation Version Switcher
+## Step 6 — Update Install Guide Version Tag
+
+Update `docs/userguide/about/install.md` to reference the new released version tag.
+
+1. Replace all occurrences of the **previous** release tag (e.g., `@0.14.0`) with
+   the **new** release tag (e.g., `@0.15.0`) in the install guide.
+2. Update the Docker container tag (e.g., `nvcr.io/nvidia/pytorch:XX.YY-py3`) to
+   the latest recommended container version if it has changed.
+3. Show a `git diff docs/userguide/about/install.md` summary so the user can
+   verify the changes look correct.
+
+---
+
+## Step 7 — Update Documentation Version Switcher
 
 Update `docs/_static/switcher.json` to include the new released version.
 
@@ -164,7 +177,7 @@ Show the diff to the user for review.
 
 ---
 
-## Step 7 — Update README Latest News
+## Step 8 — Update README Latest News
 
 Update the "Latest News" section in `README.md` with highlights from the
 **released** version's CHANGELOG entry (the section just below the new blank
@@ -190,7 +203,7 @@ proceeding.
 
 ---
 
-## Step 8 — Commit and Push
+## Step 9 — Commit and Push
 
 Stage only the expected files and commit:
 
@@ -200,6 +213,7 @@ git add earth2studio/__init__.py
 git add examples/
 git add README.md
 git add docs/_static/switcher.json
+git add docs/userguide/about/install.md
 git commit -m "Update version to X.(Y+1).0a0"
 ```
 

--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -31,7 +31,7 @@ and it's recommended that users use an uv project for the best install experienc
 ```bash
 mkdir earth2studio-project && cd earth2studio-project
 uv init --python=3.13
-uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 :::{dropdown} uv Install
@@ -885,14 +885,14 @@ the following commands:
 ```bash
 mkdir earth2studio-project && cd earth2studio-project
 uv init --python=3.13
-uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 or if you are already inside an existing uv project:
 
 ```bash
 uv venv --python=3.13
-uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+uv add "earth2studio @ git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 (pytorch_container_environment)=
@@ -909,13 +909,13 @@ It is recommended to use the following commands to install using the container's
 interpreter:
 
 ```bash
-docker run -it -t nvcr.io/nvidia/pytorch:25.12-py3
+docker run -it -t nvcr.io/nvidia/pytorch:26.04-py3
 
 >>> apt-get update && apt-get install -y git make curl cmake python3-dev \
     libeccodes-tools libeccodes-dev
 >>> unset PIP_CONSTRAINT
 >>> curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env
->>> uv pip install --system --break-system-packages "earth2studio@git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+>>> uv pip install --system --break-system-packages "earth2studio@git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -928,7 +928,7 @@ do with pip, for example:
 ```bash
 uv pip install --system \
     --break-system-packages \
-    "earth2studio[aifs,data]@git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+    "earth2studio[aifs,data]@git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 :::
@@ -957,7 +957,7 @@ package tooling.
 conda create -n earth2studio python=3.13
 conda activate earth2studio
 
-uv pip install --system --break-system-packages "earth2studio@git+https://github.com/NVIDIA/earth2studio.git@0.14.0"
+uv pip install --system --break-system-packages "earth2studio@git+https://github.com/NVIDIA/earth2studio.git@0.15.0"
 ```
 
 # System Recommendations


### PR DESCRIPTION
## Changes

- Updated `docs/userguide/about/install.md` to reference release tag `0.15.0` (was `0.14.0`)
- Updated Docker container tag from `nvcr.io/nvidia/pytorch:25.12-py3` to `nvcr.io/nvidia/pytorch:26.04-py3`
- Added new Step 6 to the `release-rebase` skill to update the install guide version tag during releases
- Renumbered subsequent steps in the release skill accordingly
- Added `docs/userguide/about/install.md` to the commit step in the release skill