### PR TITLE
fix: use sensor_index for HealDA satellite channels

### DIFF
--- a/earth2studio/models/da/healda.py
+++ b/earth2studio/models/da/healda.py
@@ -263,7 +263,7 @@ class HealDA(torch.nn.Module, AutoModelMixin):
                 "lon": np.empty(0, dtype=np.float32),
                 "observation": np.empty(0, dtype=np.float32),
                 "variable": np.array(list(SAT_SENSORS), dtype=str),
-                "channel_index": np.empty(0, dtype=np.uint16),  # UFS specific channels
+                "sensor_index": np.empty(0, dtype=np.uint16),
                 "satellite": np.empty(0, dtype=str),
                 "scan_angle": np.empty(0, dtype=np.float32),
                 "satellite_za": np.empty(0, dtype=np.float32),
@@ -591,7 +591,8 @@ class HealDA(torch.nn.Module, AutoModelMixin):
             Standardized DataFrame with unified column schema
         """
         stats = self._sensor_stats[sensor]
-        raw_ch = df["channel_index"].values.astype(int)
+        channel_col = "sensor_index" if "sensor_index" in df.columns else "channel_index"
+        raw_ch = df[channel_col].values.astype(int)
         platforms = SENSOR_PLATFORMS.get(sensor, [])
         platform_map = {name: i for i, name in enumerate(platforms)}
 
@@ -603,7 +604,7 @@ class HealDA(torch.nn.Module, AutoModelMixin):
         out_of_bounds = raw_ch[raw_ch > max_raw]
         if len(out_of_bounds) > 0:
             raise ValueError(
-                f"Sensor {sensor!r}: channel_index values {set(out_of_bounds.tolist())} "
+                f"Sensor {sensor!r}: {channel_col} values {set(out_of_bounds.tolist())} "
                 f"exceed max channel {max_raw} in stats table"
             )
 

--- a/earth2studio/models/da/healda.py
+++ b/earth2studio/models/da/healda.py
@@ -16,6 +16,7 @@
 
 import datetime as dt
 import math
+import warnings
 from collections import OrderedDict
 from collections.abc import Generator
 from typing import Any
@@ -591,7 +592,18 @@ class HealDA(torch.nn.Module, AutoModelMixin):
             Standardized DataFrame with unified column schema
         """
         stats = self._sensor_stats[sensor]
-        channel_col = "sensor_index" if "sensor_index" in df.columns else "channel_index"
+        if "sensor_index" in df.columns:
+            channel_col = "sensor_index"
+        elif "channel_index" in df.columns:
+            warnings.warn(
+                "HealDA satellite observations should provide 'sensor_index' with "
+                "the physical sensor channel. Falling back to 'channel_index' for "
+                "backward compatibility. For UFSObsSat this is the native GSI "
+                "Channel_Index pointer and may produce incorrect channel mappings."
+            )
+            channel_col = "channel_index"
+        else:
+            raise ValueError("Satellite observations must include 'sensor_index'.")
         raw_ch = df[channel_col].values.astype(int)
         platforms = SENSOR_PLATFORMS.get(sensor, [])
         platform_map = {name: i for i, name in enumerate(platforms)}
@@ -646,23 +658,20 @@ class HealDA(torch.nn.Module, AutoModelMixin):
         if unknown_vars:
             raise ValueError(f"Unknown conventional variable(s): {unknown_vars}")
 
-        # HealDA expects pressure-like values in hPa. Earth2Studio/UFS feeds may
-        # provide Pa or hPa, so convert only values that are clearly in Pa.
-        obs_hpa = df["observation"].values.astype(np.float64)
+        # HealDA v1 was trained with pressure values in hPa, while Earth2Studio
+        # conventional data sources provide pressure-like fields in Pa.
+        obs = df["observation"].values.astype(np.float64)
         is_pres_obs = df["variable"].values == "pres"
-        obs_pa_mask = is_pres_obs & np.isfinite(obs_hpa) & (obs_hpa > 2000.0)
-        obs_hpa[obs_pa_mask] /= 100.0
+        obs[is_pres_obs] /= 100.0  # Pa -> hPa
 
-        pressure_hpa = df["pres"].values.astype(np.float32)
-        pressure_pa_mask = np.isfinite(pressure_hpa) & (pressure_hpa > 2000.0)
-        pressure_hpa[pressure_pa_mask] /= 100.0
+        pressure = df["pres"].values.astype(np.float32) / np.float32(100.0)  # Pa -> hPa
 
         return pd.DataFrame(
             {
                 "lat": df["lat"].values.astype(np.float32),
                 "lon": df["lon"].values.astype(np.float32),
                 "obs_time_ns": df["time"].values.astype("datetime64[ns]"),
-                "observation": obs_hpa,
+                "observation": obs,
                 "local_channel": df["variable"]
                 .map(CONV_VAR_CHANNEL)
                 .values.astype(np.int32),
@@ -670,7 +679,7 @@ class HealDA(torch.nn.Module, AutoModelMixin):
                 "sensor": "conv",
                 "obs_type": df["type"].fillna(0).values.astype(np.int32),
                 "height": df["elev"].values.astype(np.float32),
-                "pressure": pressure_hpa,
+                "pressure": pressure,
                 "scan_angle": np.float32(np.nan),
                 "sat_zenith_angle": np.float32(np.nan),
                 "sol_zenith_angle": np.float32(np.nan),

--- a/test/models/da/test_da_healda.py
+++ b/test/models/da/test_da_healda.py
@@ -162,7 +162,7 @@ def _build_raw_sat_df(n_obs=10, request_time=None, sensor="atms"):
             "lon": np.random.uniform(0, 360, n_obs).astype(np.float32),
             "observation": np.random.uniform(200, 300, n_obs).astype(np.float32),
             "variable": sensor,
-            "channel_index": np.ones(n_obs, dtype=np.uint16),
+            "sensor_index": np.ones(n_obs, dtype=np.uint16),
             "satellite": "n20",
             "scan_angle": np.zeros(n_obs, dtype=np.float32),
             "satellite_za": np.full(n_obs, 30.0, dtype=np.float32),
@@ -343,7 +343,7 @@ def test_healda_input_coords():
     assert "time" in sat_schema
     assert "lat" in sat_schema
     assert "observation" in sat_schema
-    assert "channel_index" in sat_schema
+    assert "sensor_index" in sat_schema
 
 
 def test_healda_output_coords():


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Fix HealDA regressions: satellite channel selection after the `sensor_index` schema update and conv pressure handling.

`UFSObsSat.channel_index` now represents the UFS/GSI-native `Channel_Index` pointer, while `sensor_index` contains the dereferenced physical sensor channel. HealDA uses the channel value to select `raw_to_local`, normalization stats, and channel embeddings, so it should consume the `sensor_index` equivalent field.

### Regression

Original PR #743 rendered:

Conv+Sat - ERA5 | t2m MAE: 0.7998
Conv+Sat - ERA5 | z500 MAE: 51.1410
Sat - ERA5 | t2m MAE: 0.8491
Sat - ERA5 | z500 MAE: 164.9715
Conv - ERA5 | t2m MAE: 4.3307
Conv - ERA5 | z500 MAE: 570.8905

Running the example today against current code gives:

Conv+Sat - ERA5 | t2m MAE: 1.4210
Conv+Sat - ERA5 | z500 MAE: 208.3272
Sat - ERA5 | t2m MAE: 1.6925
Sat - ERA5 | z500 MAE: 536.9377
Conv - ERA5 | t2m MAE: 4.3268
Conv - ERA5 | z500 MAE: 560.6304

With this fix, the UFS baseline drops to:

Conv+Sat - ERA5 | t2m MAE: 0.8070
Conv+Sat - ERA5 | z500 MAE: 52.2973
Sat - ERA5 | t2m MAE: 0.8491
Sat - ERA5 | z500 MAE: 164.9715
Conv - ERA5 | t2m MAE: 4.3274
Conv - ERA5 | z500 MAE: 560.4365

There is another change to UFSObsConv due to trying to support both hpa and pa units of pressure (see the conv only z500 MAE originally and today is 570 vs 560 respectively):

 ```
       # HealDA expects pressure-like values in hPa. Earth2Studio/UFS feeds may
        # provide Pa or hPa, so convert only values that are clearly in Pa.
        obs_hpa = df["observation"].values.astype(np.float64)
        is_pres_obs = df["variable"].values == "pres"
        obs_pa_mask = is_pres_obs & np.isfinite(obs_hpa) & (obs_hpa > 2000.0)
        obs_hpa[obs_pa_mask] /= 100.0

        pressure_hpa = df["pres"].values.astype(np.float32)
        pressure_pa_mask = np.isfinite(pressure_hpa) & (pressure_hpa > 2000.0)
        pressure_hpa[pressure_pa_mask] /= 100.0
```

If low Pa value appears (say 1 hpa or 100 pa), it will be misinterpreted so the model will receive the wrong input. Instead we need to either have the units of pressure provided or require Pa throughout and unconditionally divide by 100, matching the unconditional multiply by 100. We go with the latter and remove the `np.isfinite(pressure_hpa) & (pressure_hpa > 2000.0)`

Removing the filtering here brings us back to the original skill:
Conv+Sat - ERA5 | t2m MAE: 0.7991
Conv+Sat - ERA5 | z500 MAE: 51.1295
Sat - ERA5 | t2m MAE: 0.8491
Sat - ERA5 | z500 MAE: 164.9715
Conv - ERA5 | t2m MAE: 4.3305
Conv - ERA5 | z500 MAE: 570.8226

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
