### PR TITLE
fix: add fcn3 extra with torch dependency to resolve installation error (closes #876)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# !/usr/bin/env python
-from setuptools import setup
+#!/usr/bin/env python
+from setuptools import setup, find_packages
 
-setup()
+setup(
+    name="earth2studio",
+    version="0.14.0",
+    packages=find_packages(),
+    extras_require={
+        "fcn3": [
+            "torch>=2.0.0",
+            "torch-harmonics@git+https://github.com/NVIDIA/torch-harmonics.git@a632ca748a12bd9f74dbc1e00653317810991f74",
+        ],
+    },
+)


### PR DESCRIPTION
## What
The fcn3 installation fails because the 'fcn3' extra is missing from setup.py, causing torch-harmonics to be built before torch is installed. This leads to a build failure of torch-harmonics.

## Fix
Added 'extras_require' in setup.py for the 'fcn3' extra, specifying 'torch' as a prerequisite dependency before 'torch-harmonics'. This ensures torch is installed first, resolving the build order issue.

Closes #876