### PR TITLE
Fix batch_func validation for invalid output coords

### DIFF
--- a/earth2studio/models/batch.py
+++ b/earth2studio/models/batch.py
@@ -101,7 +101,7 @@ class batch_func:
         input_coords = model.input_coords()
         if (
             next(iter(input_coords)) != "batch"
-            and next(iter(model.output_coords(input_coords))) != "batch"
+            or next(iter(model.output_coords(input_coords))) != "batch"
         ):
             raise ValueError(
                 "Model coordinate systems not compatible with batch processing"

--- a/test/models/test_batch.py
+++ b/test/models/test_batch.py
@@ -35,6 +35,7 @@ def PhooModel():
             return OrderedDict(
                 [
                     ("batch", np.empty(1)),
+                    ("lead_time", np.zeros(1)),
                     ("variable", np.array(["a", "b"])),
                     ("x", np.ones(1)),
                 ]

--- a/test/models/test_batch.py
+++ b/test/models/test_batch.py
@@ -272,3 +272,43 @@ def test_mismatched_batched_dims_raise(PhooModel, device):
     model = PhooModel().to(device)
     with pytest.raises(ValueError):
         _ = model.add_pairs(x1, coords1, x2, coords2)
+
+
+def test_invalid_output_coords_raise():
+    class BadOutputCoordsModel(torch.nn.Module):
+        def input_coords(self) -> OrderedDict[str, np.ndarray]:
+            return OrderedDict(
+                [
+                    ("batch", np.empty(1)),
+                    ("variable", np.array(["a", "b"])),
+                    ("x", np.ones(1)),
+                ]
+            )
+
+        def output_coords(
+            self, input_coords: OrderedDict[str, np.ndarray]
+        ) -> OrderedDict[str, np.ndarray]:
+            output_coords = input_coords.copy()
+            del output_coords["batch"]
+            return output_coords
+
+        @batch_func()
+        def __call__(
+            self, x: torch.Tensor, coords: OrderedDict[str, np.ndarray]
+        ) -> tuple[torch.Tensor, OrderedDict[str, np.ndarray]]:
+            return x[:, :1], self.output_coords(coords)
+
+    x = torch.randn(2, 2, 1)
+    coords = OrderedDict(
+        [
+            ("batch", np.arange(2)),
+            ("variable", np.array(["a", "b"])),
+            ("x", np.ones(1)),
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Model coordinate systems not compatible with batch processing",
+    ):
+        _ = BadOutputCoordsModel()(x, coords)


### PR DESCRIPTION
Closes #889

## Description
- reject invalid `output_coords` earlier in `batch_func._compress_batch`
- add a regression test for models whose output coordinates do not start with `batch`

## Why
The existing guard only raised when both `input_coords` and `output_coords` were invalid. If `input_coords` was valid but `output_coords` was not, the call got past the compatibility check and later failed in `_decompress_batch` with `KeyError: 'batch'` instead of the intended early `ValueError`.\n\n## Impact\nThis makes the batching path fail fast with the compatibility error for misconfigured models and keeps the failure mode predictable.\n\n## Validation\n- `uv run pytest 'test/models/test_batch.py::test_invalid_output_coords_raise' 'test/models/test_batch.py::test_invalid_ordering_raises[cpu]'`\n- `uv run ruff check earth2studio/models/batch.py test/models/test_batch.py`