### PR TITLE
Reject models whose output coords are missing the batch dimension

### DIFF
--- a/earth2studio/models/batch.py
+++ b/earth2studio/models/batch.py
@@ -101,7 +101,7 @@ class batch_func:
         input_coords = model.input_coords()
         if (
             next(iter(input_coords)) != "batch"
-            and next(iter(model.output_coords(input_coords))) != "batch"
+            or next(iter(model.output_coords(input_coords))) != "batch"
         ):
             raise ValueError(
                 "Model coordinate systems not compatible with batch processing"

--- a/test/models/test_batch.py
+++ b/test/models/test_batch.py
@@ -272,3 +272,40 @@ def test_mismatched_batched_dims_raise(PhooModel, device):
     model = PhooModel().to(device)
     with pytest.raises(ValueError):
         _ = model.add_pairs(x1, coords1, x2, coords2)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_invalid_output_coords_raises(device):
+    # A model whose input_coords start with "batch" but whose output_coords do
+    # not must be rejected early with a clear ValueError, rather than slipping
+    # through the compatibility guard and crashing later in _decompress_batch
+    # with KeyError("batch").
+    class BadOutputModel(torch.nn.Module):
+        def input_coords(self) -> OrderedDict:
+            return OrderedDict(
+                [
+                    ("batch", np.empty(1)),
+                    ("variable", np.array(["a"])),
+                    ("x", np.ones(1)),
+                ]
+            )
+
+        def output_coords(self, input_coords: OrderedDict) -> OrderedDict:
+            # Intentionally missing the leading "batch" dimension
+            return OrderedDict([("variable", np.array(["a"])), ("x", np.ones(1))])
+
+        @batch_func()
+        def __call__(self, x: torch.Tensor, coords: OrderedDict) -> tuple:
+            return x[:, :1], self.output_coords(coords)
+
+    coords = OrderedDict(
+        [
+            ("batch", np.arange(2)),
+            ("variable", np.array(["a"])),
+            ("x", np.ones(1)),
+        ]
+    )
+    x = torch.ones(2, 1, 1, device=device)
+    model = BadOutputModel().to(device)
+    with pytest.raises(ValueError):
+        _ = model(x, coords)


### PR DESCRIPTION
## Problem

`batch_func._compress_batch` checks coordinate-system compatibility with:

```python
if (
    next(iter(input_coords)) != "batch"
    and next(iter(model.output_coords(input_coords))) != "batch"
):
    raise ValueError("Model coordinate systems not compatible with batch processing")
```

Because the two conditions are combined with `and`, the guard only fires when **both** `input_coords` and `output_coords` are missing the leading `"batch"` key. A model with valid `input_coords` but malformed `output_coords` passes the check and then crashes later in `_decompress_batch` at `del out_coords["batch"]` with `KeyError('batch')`, instead of failing early with the intended `ValueError`. This matches #889.

## Fix

Change `and` to `or` so that either coordinate system missing the batch dimension is rejected up front with the clear `ValueError`.

## Testing

- Reproduced the original late `KeyError('batch')` on `main`, and confirmed the patched guard raises the early `ValueError` instead.
- Verified the happy path still works (a valid model is **not** over-rejected and preserves coord keys), and that the pre-existing bad-`input_coords` case still raises.
- Added `test_invalid_output_coords_raises` to `test/models/test_batch.py`.
- `ruff check` / `ruff format` clean on the changed files.

> Note: developed with AI assistance and verified locally as described above.

Fixes #889