### PR TITLE
Add offline mode to CDS data source

### DIFF
--- a/earth2studio/data/cds.py
+++ b/earth2studio/data/cds.py
@@ -72,6 +72,11 @@ class CDS:
         Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
+    offline : bool, optional
+        When True, only read from cache and never connect to the CDS server.
+        Useful for environments without internet access where the cache has been
+        pre-populated. Raises FileNotFoundError if requested data is not in cache.
+        By default False.
 
     Warning
     -------
@@ -95,12 +100,22 @@ class CDS:
     CDS_LAT = np.linspace(90, -90, 721)
     CDS_LON = np.linspace(0, 359.75, 1440)
 
-    def __init__(self, cache: bool = True, verbose: bool = True):
+    def __init__(self, cache: bool = True, verbose: bool = True, offline: bool = False):
         self._cache = cache
         self._verbose = verbose
-        self.cds_client = cdsapi.Client(
-            debug=False, quiet=True, wait_until_complete=False
-        )
+        self._offline = offline
+        if offline and not cache:
+            logger.warning(
+                "CDS offline mode requires cache=True to retain data. "
+                "Setting cache=True."
+            )
+            self._cache = True
+        if offline:
+            self.cds_client = None
+        else:
+            self.cds_client = cdsapi.Client(
+                debug=False, quiet=True, wait_until_complete=False
+            )
 
     def __call__(
         self,
@@ -297,6 +312,15 @@ class CDS:
         cache_path = os.path.join(self.cache, filename)
 
         if not pathlib.Path(cache_path).is_file():
+            if self._offline:
+                raise FileNotFoundError(
+                    f"CDS offline mode: cached data not found for "
+                    f"dataset={dataset_name}, variable={variable}, "
+                    f"level={level}, time={time}. "
+                    f"Expected cache file: {cache_path}. "
+                    f"Run with offline=False and internet access to "
+                    f"populate the cache first."
+                )
             if variable == "total_precipitation_06":
                 # tp06 is a special case, its not in CDS but used by several models
                 # so this specific case handle for this one variable, so intercept this
@@ -317,6 +341,11 @@ class CDS:
                 }
                 if dataset_name == "reanalysis-era5-pressure-levels":
                     rbody["pressure_level"] = level
+                if self.cds_client is None:  # pragma: no cover
+                    raise RuntimeError(
+                        "CDS client is not initialized. "
+                        "Cannot download data in offline mode."
+                    )
                 r = self.cds_client.retrieve(dataset_name, rbody)
                 # Queue request
                 while True:

--- a/test/data/test_cds.py
+++ b/test/data/test_cds.py
@@ -15,11 +15,15 @@
 # limitations under the License.
 
 import datetime
+import hashlib
+import os
 import pathlib
 import shutil
+from unittest.mock import patch
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from earth2studio.data import CDS
 
@@ -148,3 +152,123 @@ def test_cds_available(time, variable):
     with pytest.raises(ValueError):
         ds = CDS()
         ds(time, variable)
+
+
+# ======================== Offline mode tests ========================
+
+
+def _compute_cache_filename(dataset_name: str, variable: str, level: list[str], time):
+    """Compute the SHA-256 cache filename matching CDS._download_cds_grib_cached."""
+    sha = hashlib.sha256(f"{dataset_name}_{variable}_{'_'.join(level)}_{time}".encode())
+    return sha.hexdigest()
+
+
+def _create_fake_grib_cache(cache_dir, dataset_name, variable, level, time):
+    """Create a fake grib file in cache for testing offline mode."""
+    filename = _compute_cache_filename(dataset_name, variable, level, time)
+    cache_path = os.path.join(cache_dir, filename)
+    # Create a minimal grib-like file (just needs to exist for cache hit check)
+    pathlib.Path(cache_path).touch()
+    return cache_path
+
+
+@patch("earth2studio.data.cds.cdsapi")
+def test_cds_offline_init(mock_cdsapi, tmp_path, monkeypatch):
+    """Test that offline mode does not create a cdsapi Client."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+    ds = CDS(offline=True)
+    assert ds._offline is True
+    assert ds.cds_client is None
+    mock_cdsapi.Client.assert_not_called()
+
+
+@patch("earth2studio.data.cds.cdsapi")
+def test_cds_offline_cache_override(mock_cdsapi, tmp_path, monkeypatch):
+    """Test that offline=True with cache=False auto-corrects to cache=True."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+    ds = CDS(cache=False, offline=True)
+    assert ds._cache is True
+    assert ds._offline is True
+
+
+@patch("earth2studio.data.cds.cdsapi")
+def test_cds_offline_cache_miss_raises(mock_cdsapi, tmp_path, monkeypatch):
+    """Test that offline mode raises FileNotFoundError on cache miss."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+    ds = CDS(offline=True)
+
+    time = datetime.datetime(year=2024, month=1, day=1, hour=0)
+    with pytest.raises(FileNotFoundError, match="CDS offline mode"):
+        ds(time, "t2m")
+
+
+@patch("earth2studio.data.cds.cdsapi")
+def test_cds_offline_cache_hit(mock_cdsapi, tmp_path, monkeypatch):
+    """Test that offline mode successfully reads from pre-populated cache."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    # Create the cache directory structure
+    cache_dir = tmp_path / "cds"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    time = datetime.datetime(year=2024, month=1, day=1, hour=0)
+
+    # t2m maps to reanalysis-era5-single-levels::2m_temperature::
+    dataset_name = "reanalysis-era5-single-levels"
+    cds_variable = "2m_temperature"
+    level = [""]
+
+    # Create a proper grib-like file with xarray data
+    lat = np.linspace(90, -90, 721)
+    lon = np.linspace(0, 359.75, 1440)
+    data = np.random.randn(721, 1440).astype(np.float32)
+    da = xr.DataArray(
+        data=data,
+        dims=["latitude", "longitude"],
+        coords={"latitude": lat, "longitude": lon},
+    )
+
+    # Write to cache path with the correct hash filename
+    filename = _compute_cache_filename(dataset_name, cds_variable, level, time)
+    cache_path = cache_dir / filename
+
+    # Save as netcdf since we'll mock cfgrib opening
+    da.to_netcdf(str(cache_path))
+
+    ds = CDS(offline=True)
+
+    # We need to mock xr.open_dataarray for cfgrib engine since we saved as netcdf
+    with patch("xarray.open_dataarray") as mock_open:
+        mock_open.return_value = da
+        result = ds(time, "t2m")
+
+    assert result.shape == (1, 1, 721, 1440)
+    assert result.coords["variable"].values[0] == "t2m"
+
+
+@patch("earth2studio.data.cds.cdsapi")
+def test_cds_offline_multiple_variables_partial_miss(
+    mock_cdsapi, tmp_path, monkeypatch
+):
+    """Test offline mode raises error when some variables are not cached."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    # Create the cache directory structure
+    cache_dir = tmp_path / "cds"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    time = datetime.datetime(year=2024, month=1, day=1, hour=0)
+
+    # Pre-populate cache for t2m but NOT for sp
+    dataset_name = "reanalysis-era5-single-levels"
+    cds_variable = "2m_temperature"
+    level = [""]
+    filename = _compute_cache_filename(dataset_name, cds_variable, level, time)
+    (cache_dir / filename).touch()
+
+    ds = CDS(offline=True)
+
+    # sp maps to reanalysis-era5-single-levels::surface_pressure::
+    # Since sp is not cached, this should raise FileNotFoundError
+    with pytest.raises(FileNotFoundError, match="CDS offline mode"):
+        ds(time, ["t2m", "sp"])


### PR DESCRIPTION
## Summary

Adds an `offline` parameter to the `CDS` data source class that enables inference on computing nodes without internet access by using pre-populated cache only.

## Motivation

Closes #905

Users working in air-gapped environments (e.g., HPC computing nodes) cannot connect to the CDS server. If they pre-populate the cache on a login node with internet access, they should be able to run inference on compute nodes without any network connectivity. Previously, the `CDS` class always created a `cdsapi.Client` during initialization, which requires valid credentials and could attempt network operations.

## Changes

- Added `offline: bool = False` parameter to `CDS.__init__`
- When `offline=True`:
  - The `cdsapi.Client` is **not** created (no credentials/network needed)
  - Cache hits return data normally (no behavior change)
  - Cache misses raise `FileNotFoundError` with a helpful message explaining how to populate the cache
  - `cache=False` is auto-corrected to `cache=True` with a warning (offline mode requires cache)
- Added runtime guard before `self.cds_client.retrieve()` to satisfy mypy type narrowing

## Usage

```python
from earth2studio.data import CDS

# On login node (with internet): populate cache
ds = CDS(cache=True)
data = ds(time, variables)  # Downloads and caches

# On compute node (no internet): use cached data
ds = CDS(offline=True)
data = ds(time, variables)  # Reads from cache only
```

## Tests

Added 5 new unit tests for offline mode:
- `test_cds_offline_init` - verifies no cdsapi.Client is created
- `test_cds_offline_cache_override` - verifies cache=False is corrected
- `test_cds_offline_cache_miss_raises` - verifies FileNotFoundError on miss
- `test_cds_offline_cache_hit` - verifies successful read from cache
- `test_cds_offline_multiple_variables_partial_miss` - verifies error on partial cache

All tests pass locally. All pre-commit hooks (black, ruff, mypy, etc.) pass.