### PR TITLE
Add Earthmover Arraylake / Marketplace data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Earthmover Arraylake / Marketplace data sources (`Arraylake`,
+  `ArraylakeForecast`) that resolve Earth2Studio variables against any
+  subscribed Arraylake repository using ECMWF GRIB and CF metadata
 - Added AIFS 2.0 prognostic model (`AIFS2`) with wave and 10 hPa pressure level support
 - Added AIFS 2.0 ensemble prognostic model (`AIFS2ENS`) with stochastic noise injection
 - Added U-CAST prognostic model (`UCast`) with 1.5-degree global ERA5

--- a/docs/modules/datasources_analysis.rst
+++ b/docs/modules/datasources_analysis.rst
@@ -33,6 +33,7 @@ Used for fetching initial conditions for inference and validation data for scori
       :template: datasource.rst
 
       data.ARCO
+      data.Arraylake
       data.CDS
       data.CMIP6
       data.CMIP6MultiRealm

--- a/docs/modules/datasources_forecast.rst
+++ b/docs/modules/datasources_forecast.rst
@@ -25,6 +25,7 @@ Typically used in intercomparison workflows.
       data.AIFS_FX
       data.CAMS_FX
       data.AIFS_ENS_FX
+      data.ArraylakeForecast
       data.CFS_FX
       data.CFS_FX_Flux
       data.CFS_Reforecast_FX

--- a/earth2studio/data/__init__.py
+++ b/earth2studio/data/__init__.py
@@ -16,6 +16,7 @@
 
 from .ace2 import ACE2ERA5Data
 from .arco import ARCO
+from .arraylake import Arraylake, ArraylakeForecast
 from .base import DataSource, ForecastSource
 from .cams import CAMS_FX
 from .cbottle import CBottle3D

--- a/earth2studio/data/arraylake.py
+++ b/earth2studio/data/arraylake.py
@@ -1,0 +1,695 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Earthmover Arraylake / Marketplace data sources for Earth2Studio.
+
+``Arraylake`` (analysis) and ``ArraylakeForecast`` (forecast) connect Earth2Studio
+to versioned Zarr/Icechunk datasets hosted on `Arraylake
+<https://docs.earthmover.io>`_, including datasets obtained through the `Earthmover
+Data Marketplace <https://www.earthmover.io/marketplace>`_.
+
+Rather than hard-coding the variable names of any particular dataset, the connector
+locates Earth2Studio variables inside a repository using *established metadata
+conventions* (ECMWF ``GRIB_paramId`` / ``GRIB_shortName`` and CF ``standard_name`` /
+``units`` / vertical-level coordinates). See
+:mod:`earth2studio.lexicon.arraylake` for the standard crosswalk and resolution
+priority.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import numpy as np
+import xarray as xr
+from loguru import logger
+
+from earth2studio.data.utils import (
+    datasource_cache_root,
+    prep_data_inputs,
+    prep_forecast_inputs,
+)
+from earth2studio.lexicon.arraylake import ArraylakeLexicon, VariableSpec, make_modifier
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import (
+    LeadTimeArray,
+    TimeArray,
+    VariableArray,
+)
+
+try:
+    import arraylake
+except ImportError:
+    OptionalDependencyFailure("data")
+    arraylake = None  # type: ignore[assignment]
+
+
+# Candidate coordinate names for the various physical axes. Marketplace datasets
+# follow CF, so axis attributes are preferred, with these names as a fallback.
+_LAT_NAMES = ("latitude", "lat")
+_LON_NAMES = ("longitude", "lon")
+_TIME_NAMES = ("time", "valid_time", "init_time", "forecast_reference_time")
+_LEAD_NAMES = ("lead_time", "step", "prediction_timedelta", "forecast_period")
+_VERTICAL_NAMES = (
+    "pressure_level",
+    "isobaricInhPa",
+    "isobaric",
+    "level",
+    "plev",
+    "lev",
+)
+
+
+@dataclass
+class _Resolved:
+    """Result of resolving an Earth2Studio variable against a repository."""
+
+    spec: VariableSpec
+    dataset: xr.Dataset
+    var_name: str
+    level_selection: dict[str, float]
+    modifier: Callable
+    rule: str  # which metadata rule matched (for diagnostics)
+
+
+class _ArraylakeBase:
+    """Shared connection, indexing and metadata-resolution logic.
+
+    Concrete sources (:class:`Arraylake`, :class:`ArraylakeForecast`) add the
+    ``__call__`` / ``fetch`` methods with the appropriate Earth2Studio signature.
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        group: str | list[str] | None = None,
+        *,
+        branch: str = "main",
+        client: "arraylake.Client | None" = None,
+        cache: bool = True,
+        verbose: bool = True,
+    ) -> None:
+        self._repo_name = repo
+        if group is None or isinstance(group, str):
+            self._groups: list[str | None] = [group]
+        else:
+            self._groups = list(group)
+        self._branch = branch
+        self._client = client
+        self._cache = cache
+        self._verbose = verbose
+
+        # Populated lazily on first connect.
+        self._datasets: list[xr.Dataset] | None = None
+        # repo variable name -> (dataset, variable metadata)
+        self._index: dict[str, list[tuple[xr.Dataset, xr.DataArray]]] = {}
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+    def _make_client(self) -> "arraylake.Client":
+        """Create an Arraylake client, honoring explicit > token > cached login.
+
+        Returns
+        -------
+        arraylake.Client
+            Authenticated client. Uses an injected ``client``, else the
+            ``ARRAYLAKE_TOKEN`` environment variable, else the interactive /
+            cached login at ``~/.config/arraylake``.
+        """
+        if self._client is not None:
+            return self._client
+        token = os.environ.get("ARRAYLAKE_TOKEN")
+        if token:
+            return arraylake.Client(token=token)
+        return arraylake.Client()
+
+    def _connect(self) -> None:
+        """Open the repository's group(s) and build the resolution index."""
+        if self._datasets is not None:
+            return
+
+        client = self._make_client()
+        try:
+            repo = client.get_repo(self._repo_name)
+            session = repo.readonly_session(branch=self._branch)
+        except Exception as err:  # noqa: BLE001 - re-raised with guidance below
+            self._raise_access_error(err)
+
+        datasets: list[xr.Dataset] = []
+        for group in self._groups:
+            try:
+                ds = xr.open_zarr(session.store, group=group, decode_timedelta=True)
+            except Exception as err:  # noqa: BLE001
+                self._raise_access_error(err, group=group)
+            datasets.append(ds)
+
+        self._datasets = datasets
+        self._build_index()
+
+    def _raise_access_error(self, err: Exception, group: str | None = None) -> None:
+        """Translate access failures into actionable guidance.
+
+        Permission / not-found errors on a Marketplace repo usually mean the user
+        has not yet created a subscription on the listing page.
+        """
+        msg = str(err).lower()
+        loc = f"{self._repo_name}" + (f" (group {group!r})" if group else "")
+        if any(k in msg for k in ("403", "forbidden", "permission", "not authorized")):
+            raise PermissionError(
+                f"Access to Arraylake repo '{loc}' was denied. If this is an "
+                "Earthmover Marketplace dataset, you must first create a "
+                "subscription on the dataset's listing page "
+                "(https://www.earthmover.io/marketplace), then ensure you are "
+                "authenticated (run `al auth login` or set ARRAYLAKE_TOKEN)."
+            ) from err
+        if any(k in msg for k in ("404", "not found", "does not exist")):
+            raise ValueError(
+                f"Arraylake repo '{loc}' was not found. Check the 'org/repo' name "
+                "and (for Marketplace data) that your subscription is active."
+            ) from err
+        raise err
+
+    # ------------------------------------------------------------------
+    # Indexing
+    # ------------------------------------------------------------------
+    def _build_index(self) -> None:
+        """Index every data variable across opened groups by its native name."""
+        self._index = {}
+        for ds in self._datasets or []:
+            for name, da in ds.data_vars.items():
+                self._index.setdefault(str(name), []).append((ds, da))
+
+    # ------------------------------------------------------------------
+    # Coordinate helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _find_coord(ds: xr.Dataset, names: tuple[str, ...]) -> str | None:
+        """Find a coordinate/dimension by candidate names (case-insensitive)."""
+        lookup = {str(c).lower(): str(c) for c in ds.variables}
+        for n in names:
+            if n.lower() in lookup:
+                return lookup[n.lower()]
+        return None
+
+    @classmethod
+    def _vertical_coord(cls, da: xr.DataArray) -> str | None:
+        """Return the name of a vertical (pressure) coordinate on ``da``, if any.
+
+        Detected via CF ``axis='Z'`` / ``standard_name='air_pressure'`` first,
+        falling back to common coordinate names.
+        """
+        for coord in da.coords:
+            attrs = da[coord].attrs
+            if attrs.get("axis") == "Z" or attrs.get("standard_name") == "air_pressure":
+                return str(coord)
+        for coord in da.coords:
+            if str(coord).lower() in _VERTICAL_NAMES:
+                return str(coord)
+        return None
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+    def _candidate_rule(self, da: xr.DataArray, spec: VariableSpec) -> str | None:
+        """Return the matching rule name for ``da`` against ``spec``, else None.
+
+        Priority: ECMWF ``GRIB_paramId`` -> ``GRIB_shortName`` / cfVarName /
+        variable name -> CF ``standard_name``.
+        """
+        attrs = da.attrs
+        param_id = attrs.get("GRIB_paramId")
+        if param_id is not None and int(param_id) == spec.param_id:
+            return "paramId"
+        short = {
+            str(attrs.get("GRIB_shortName", "")),
+            str(attrs.get("GRIB_cfVarName", "")),
+            str(da.name),
+        }
+        if spec.short_name in short:
+            return "shortName"
+        sn = attrs.get("standard_name", "")
+        if spec.standard_name and sn == spec.standard_name:
+            return "standardName"
+        return None
+
+    def _resolve(self, variable: str) -> _Resolved:
+        """Resolve an Earth2Studio variable id to a repository variable.
+
+        Parameters
+        ----------
+        variable : str
+            Earth2Studio variable id (e.g. ``t2m``, ``z500``).
+
+        Returns
+        -------
+        _Resolved
+            The matched dataset, variable name, level selection and unit modifier.
+
+        Raises
+        ------
+        ValueError
+            If ``variable`` is unknown to Earth2Studio, or no repository variable
+            satisfies its metadata descriptor.
+        """
+        try:
+            spec = ArraylakeLexicon.spec(variable)
+        except KeyError:
+            raise ValueError(
+                f"'{variable}' is not a known Earth2Studio variable id."
+            ) from None
+
+        want_level = spec.level_type == "isobaric"
+        # Collect candidates by rule priority across all groups.
+        ranked: list[tuple[int, _Resolved]] = []
+        rule_order = {"paramId": 0, "shortName": 1, "standardName": 2}
+        for ds, da in (item for items in self._index.values() for item in items):
+            rule = self._candidate_rule(da, spec)
+            if rule is None:
+                continue
+            vcoord = self._vertical_coord(da)
+            if want_level and vcoord is None:
+                continue
+            if not want_level and vcoord is not None and ds[vcoord].size > 1:
+                # A multi-level field cannot satisfy a surface request.
+                continue
+
+            level_selection: dict[str, float] = {}
+            if want_level:
+                if vcoord is None or spec.level is None:
+                    continue
+                sel = self._level_value(ds[vcoord], spec.level)
+                if sel is None:
+                    continue
+                level_selection[vcoord] = sel
+
+            resolved = _Resolved(
+                spec=spec,
+                dataset=ds,
+                var_name=str(da.name),
+                level_selection=level_selection,
+                modifier=make_modifier(spec, da.attrs.get("units")),
+                rule=rule,
+            )
+            ranked.append((rule_order[rule], resolved))
+
+        if not ranked:
+            raise ValueError(self._unresolved_message(variable, spec))
+
+        ranked.sort(key=lambda t: t[0])
+        best_tier = ranked[0][0]
+        best = [r for tier, r in ranked if tier == best_tier]
+        distinct = {r.var_name for r in best}
+        if len(distinct) > 1:
+            # Several repo variables match equally well (typically by
+            # standard_name only, which cannot disambiguate e.g. wind height).
+            # Refuse to guess rather than return the wrong field.
+            raise ValueError(
+                f"Earth2Studio variable '{variable}' is ambiguous in repo "
+                f"'{self._repo_name}': it matched {sorted(distinct)} equally by "
+                f"'{best[0].rule}'. Add a distinguishing GRIB_paramId / "
+                "GRIB_shortName attribute or a height/level coordinate to the "
+                "dataset to resolve it unambiguously."
+            )
+        return best[0]
+
+    @staticmethod
+    def _level_value(coord: xr.DataArray, level_hpa: float) -> float | None:
+        """Return the coordinate value matching ``level_hpa`` (unit-aware), or None.
+
+        Handles pressure coordinates stored in hPa or Pa.
+        """
+        values = np.asarray(coord.values, dtype="float64")
+        unit = str(coord.attrs.get("units", "")).strip().lower()
+        target = level_hpa * 100.0 if unit in {"pa", "pascal", "pascals"} else level_hpa
+        match = np.isclose(values, target, rtol=1e-3, atol=1e-6)
+        if not match.any():
+            return None
+        return float(values[match][0])
+
+    def _unresolved_message(self, variable: str, spec: VariableSpec) -> str:
+        """Build a diagnostic error listing what was searched and what exists."""
+        available = sorted(self._index.keys())
+        preview = ", ".join(available[:40])
+        if len(available) > 40:
+            preview += ", ..."
+        return (
+            f"Could not resolve Earth2Studio variable '{variable}' in repo "
+            f"'{self._repo_name}'. Searched by GRIB_paramId={spec.param_id}, "
+            f"GRIB_shortName/cfVarName/name='{spec.short_name}', and "
+            f"standard_name='{spec.standard_name or '(none)'}'"
+            + (
+                f" at pressure level {int(spec.level)} hPa"
+                if spec.level_type == "isobaric" and spec.level is not None
+                else ""
+            )
+            + f". Available repo variables: {preview}. To make this dataset "
+            "resolvable, ensure variables carry GRIB_paramId / GRIB_shortName "
+            "or CF standard_name attributes."
+        )
+
+    # ------------------------------------------------------------------
+    # Per-variable fetch (shared by analysis & forecast)
+    # ------------------------------------------------------------------
+    def _select_variable(
+        self,
+        resolved: _Resolved,
+        time_sel: np.ndarray,
+        extra_sel: dict[str, np.ndarray] | None = None,
+    ) -> xr.DataArray:
+        """Select, normalize coords and apply the unit modifier for one variable.
+
+        Returns a DataArray with horizontal dims renamed to ``lat``/``lon`` and the
+        time (and optional lead-time) axis selected.
+        """
+        ds = resolved.dataset
+        da = ds[resolved.var_name]
+
+        lat = self._find_coord(ds, _LAT_NAMES)
+        lon = self._find_coord(ds, _LON_NAMES)
+        if lat is None or lon is None:
+            raise ValueError(
+                f"Repo '{self._repo_name}' variable '{resolved.var_name}' has no "
+                "recognizable latitude/longitude coordinates."
+            )
+        if ds[lat].ndim != 1 or ds[lon].ndim != 1:
+            raise ValueError(
+                f"Repo '{self._repo_name}' uses a non-regular (projected) grid "
+                f"(latitude/longitude are {ds[lat].ndim}-D). Earth2Studio data "
+                "sources require a regular 1-D lat/lon grid; regrid the dataset "
+                "before use."
+            )
+
+        time_coord = self._find_coord(ds, _TIME_NAMES)
+        if time_coord is None:
+            raise ValueError(
+                f"Repo '{self._repo_name}' has no recognizable time coordinate."
+            )
+
+        selection: dict[str, np.ndarray | float] = {time_coord: time_sel}
+        selection.update(resolved.level_selection)
+        if extra_sel:
+            selection.update(extra_sel)
+        da = da.sel(selection)
+
+        # Apply metadata-driven unit conversion.
+        da = resolved.modifier(da)
+
+        # Drop the (now scalar) level coordinate and rename horizontal axes.
+        for coord in list(resolved.level_selection):
+            if coord in da.coords:
+                da = da.drop_vars(coord)
+        rename = {lat: "lat", lon: "lon", time_coord: "time"}
+        da = da.rename({k: v for k, v in rename.items() if k != v})
+        return da
+
+    # ------------------------------------------------------------------
+    # Cache property (Arraylake/Icechunk manages remote caching internally)
+    # ------------------------------------------------------------------
+    @property
+    def cache(self) -> str:
+        """Local cache location (Arraylake reads lazily via Icechunk)."""
+        cache_location = os.path.join(datasource_cache_root(), "arraylake")
+        if not self._cache:
+            cache_location = os.path.join(cache_location, "tmp")
+        return cache_location
+
+    def available(self, time: datetime | np.datetime64) -> bool:
+        """Check whether ``time`` is present in the repository's time axis.
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date time to check.
+
+        Returns
+        -------
+        bool
+            True if the timestamp is present in the repository's time coordinate.
+
+        Note
+        ----
+        Unlike most Earth2Studio sources this is an *instance* method, because
+        availability depends on the specific repository being wrapped.
+        """
+        self._connect()
+        t64 = np.datetime64(time)
+        for ds in self._datasets or []:
+            time_coord = self._find_coord(ds, _TIME_NAMES)
+            if time_coord is None:
+                continue
+            if (ds[time_coord].values.astype("datetime64[ns]") == t64).any():
+                return True
+        return False
+
+
+@check_optional_dependencies()
+class Arraylake(_ArraylakeBase):
+    """Earthmover Arraylake analysis/reanalysis data source.
+
+    Wraps a versioned Zarr/Icechunk dataset hosted on Arraylake (including
+    Earthmover Data Marketplace datasets) as an Earth2Studio
+    :class:`~earth2studio.data.base.DataSource`. Earth2Studio variables are located
+    by metadata (ECMWF ``GRIB_paramId`` / ``GRIB_shortName`` and CF
+    ``standard_name``); no per-dataset variable vocabulary is hard-coded.
+
+    Marketplace workflow
+    --------------------
+    1. Create a subscription to the dataset on its listing page at
+       https://www.earthmover.io/marketplace.
+    2. Authenticate: run ``al auth login`` (interactive, cached at
+       ``~/.config/arraylake``) or set the ``ARRAYLAKE_TOKEN`` environment
+       variable.
+    3. Pass the ``org/repo`` name to this data source.
+
+    Parameters
+    ----------
+    repo : str
+        Arraylake repository name as ``org/repo`` (e.g.
+        ``"vandelay-industries/era5"``).
+    group : str | list[str] | None, optional
+        Zarr group(s) within the repository to open. Pass a list to expose
+        variables that live in different groups (e.g. surface and pressure-level
+        groups) from one instance. By default the root group.
+    branch : str, optional
+        Repository branch to read, by default ``"main"``.
+    client : arraylake.Client, optional
+        Pre-authenticated Arraylake client. If omitted, a client is created using
+        ``ARRAYLAKE_TOKEN`` if set, else the cached interactive login.
+    cache : bool, optional
+        Retained for API compatibility; Arraylake reads lazily via Icechunk, by
+        default True.
+    verbose : bool, optional
+        Print progress, by default True.
+
+    Warning
+    -------
+    This is a remote data source and can download a large amount of data for large
+    requests.
+
+    Note
+    ----
+    Arraylake / Earthmover documentation:
+
+    - https://docs.earthmover.io
+    - https://www.earthmover.io/marketplace
+    """
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve analysis data for the given times and variables.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            Earth2Studio variable id(s).
+
+        Returns
+        -------
+        xr.DataArray
+            Data array with dimensions ``[time, variable, lat, lon]``.
+        """
+        time_list, variable_list = prep_data_inputs(time, variable)
+        self._connect()
+        self._validate_times(time_list)
+
+        time_sel = np.array(time_list, dtype="datetime64[ns]")
+        arrays = []
+        for v in variable_list:
+            resolved = self._resolve(v)
+            if self._verbose:
+                logger.debug(
+                    f"{v} -> {self._repo_name}:{resolved.var_name} "
+                    f"(matched by {resolved.rule})"
+                )
+            da = self._select_variable(resolved, time_sel)
+            arrays.append(da.transpose("time", "lat", "lon"))
+
+        out = xr.concat(arrays, dim="variable")
+        out = out.assign_coords(variable=variable_list).transpose(
+            "time", "variable", "lat", "lon"
+        )
+        return out.load()
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async interface to :meth:`__call__`.
+
+        Arraylake reads lazily through the Icechunk store, so this delegates to
+        the synchronous implementation.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            Earth2Studio variable id(s).
+
+        Returns
+        -------
+        xr.DataArray
+            Data array with dimensions ``[time, variable, lat, lon]``.
+        """
+        return self(time, variable)
+
+    def _validate_times(self, time_list: list[datetime]) -> None:
+        """Raise if any requested time is absent from the repository."""
+        missing = [t for t in time_list if not self.available(t)]
+        if missing:
+            raise ValueError(
+                f"Requested times not available in '{self._repo_name}': {missing}"
+            )
+
+
+@check_optional_dependencies()
+class ArraylakeForecast(_ArraylakeBase):
+    """Earthmover Arraylake forecast data source.
+
+    Like :class:`Arraylake` but for forecast datasets that carry a lead-time (step)
+    axis, exposed as an Earth2Studio
+    :class:`~earth2studio.data.base.ForecastSource`. Variable resolution is
+    identical (metadata-driven); see :class:`Arraylake` for the Marketplace
+    subscription workflow and constructor parameters.
+
+    Warning
+    -------
+    This is a remote data source and can download a large amount of data for large
+    requests.
+
+    Note
+    ----
+    Arraylake / Earthmover documentation:
+
+    - https://docs.earthmover.io
+    - https://www.earthmover.io/marketplace
+    """
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve forecast data for given init times, lead times and variables.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Forecast initialization timestamps (UTC).
+        lead_time : timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times.
+        variable : str | list[str] | VariableArray
+            Earth2Studio variable id(s).
+
+        Returns
+        -------
+        xr.DataArray
+            Data array with dimensions ``[time, lead_time, variable, lat, lon]``.
+        """
+        time_list, lead_list, variable_list = prep_forecast_inputs(
+            time, lead_time, variable
+        )
+        self._connect()
+
+        time_sel = np.array(time_list, dtype="datetime64[ns]")
+        lead_sel = np.array(lead_list, dtype="timedelta64[ns]")
+
+        arrays = []
+        for v in variable_list:
+            resolved = self._resolve(v)
+            lead_coord = self._find_coord(resolved.dataset, _LEAD_NAMES)
+            if lead_coord is None:
+                raise ValueError(
+                    f"Repo '{self._repo_name}' has no lead-time/step coordinate; "
+                    "use the Arraylake (analysis) data source instead."
+                )
+            if self._verbose:
+                logger.debug(
+                    f"{v} -> {self._repo_name}:{resolved.var_name} "
+                    f"(matched by {resolved.rule})"
+                )
+            da = self._select_variable(
+                resolved, time_sel, extra_sel={lead_coord: lead_sel}
+            )
+            da = da.rename({lead_coord: "lead_time"})
+            arrays.append(da.transpose("time", "lead_time", "lat", "lon"))
+
+        out = xr.concat(arrays, dim="variable")
+        out = out.assign_coords(variable=variable_list).transpose(
+            "time", "lead_time", "variable", "lat", "lon"
+        )
+        return out.load()
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async interface to :meth:`__call__`.
+
+        Arraylake reads lazily through the Icechunk store, so this delegates to
+        the synchronous implementation.
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Forecast initialization timestamps (UTC).
+        lead_time : timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times.
+        variable : str | list[str] | VariableArray
+            Earth2Studio variable id(s).
+
+        Returns
+        -------
+        xr.DataArray
+            Data array with dimensions ``[time, lead_time, variable, lat, lon]``.
+        """
+        return self(time, lead_time, variable)

--- a/earth2studio/lexicon/__init__.py
+++ b/earth2studio/lexicon/__init__.py
@@ -16,6 +16,7 @@
 
 from .ace import ACELexicon
 from .arco import ARCOLexicon
+from .arraylake import ArraylakeLexicon
 from .cams import CAMSGlobalLexicon
 from .cbottle import CBottleLexicon
 from .cds import CDSLexicon

--- a/earth2studio/lexicon/arraylake.py
+++ b/earth2studio/lexicon/arraylake.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metadata-driven lexicon for Arraylake / Earthmover Marketplace data.
+
+Unlike most Earth2Studio lexicons, the Arraylake connector does **not** hard-code
+the variable names of any single dataset. Earthmover Marketplace repositories use
+a variety of native naming schemes (ECMWF cfVarName like ``t2m``, GRIB short names
+like ``2t``, or descriptive CF names like ``temperature_2m``). What they share is
+adherence to *established metadata conventions* -- the ECMWF parameter database
+(``GRIB_paramId`` / ``GRIB_shortName``) and CF (``standard_name``, ``units``, and
+vertical-level coordinates).
+
+This module therefore stores a single, dataset-agnostic crosswalk from each
+Earth2Studio variable id to its ECMWF/CF descriptor (:class:`VariableSpec`). The
+data source (:mod:`earth2studio.data.arraylake`) resolves these descriptors against
+whatever metadata a given repository actually exposes, in priority order
+``GRIB_paramId`` -> ``GRIB_shortName`` / variable name -> ``standard_name``.
+
+Earth2Studio variable ids follow the ECMWF parameter database. See:
+
+- https://codes.ecmwf.int/grib/param-db/
+- https://cfconventions.org/
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .base import LexiconType
+
+#: Standard gravitational acceleration (m s-2), used to convert geopotential
+#: height (m) to geopotential (m2 s-2).
+GRAVITY = 9.80665
+
+
+@dataclass(frozen=True)
+class VariableSpec:
+    """Dataset-agnostic descriptor for an Earth2Studio variable.
+
+    The descriptor captures the identifiers that Marketplace repositories expose
+    through established metadata conventions, so a variable can be located in a
+    repository without knowing its native variable name in advance.
+
+    Parameters
+    ----------
+    e2s : str
+        Earth2Studio variable id (e.g. ``t2m``, ``z500``).
+    short_name : str
+        ECMWF GRIB short name / cfVarName (e.g. ``2t`` for ``t2m``, ``t`` for
+        ``t850``). Note these are *not* unique across vertical levels.
+    param_id : int
+        ECMWF parameter database id. Authoritative and unambiguous when present.
+    standard_name : str
+        CF ``standard_name`` for the field, or ``""`` when CF does not define one.
+    level_type : str
+        One of ``"surface"`` (single-level / height-above-ground) or
+        ``"isobaric"`` (pressure level).
+    level : float | None
+        Pressure level in hPa for ``isobaric`` variables, else ``None``.
+    canonical_units : str
+        The physical units Earth2Studio expects for this variable. Used together
+        with the repository variable's ``units`` attribute to choose a unit
+        conversion at resolution time.
+    """
+
+    e2s: str
+    short_name: str
+    param_id: int
+    standard_name: str
+    level_type: str
+    level: float | None
+    canonical_units: str
+
+
+# ---------------------------------------------------------------------------
+# Surface / single-level variables: (e2s, short_name, param_id, standard_name,
+# canonical_units)
+# ---------------------------------------------------------------------------
+_SURFACE: list[tuple[str, str, int, str, str]] = [
+    ("u10m", "10u", 165, "eastward_wind", "m s-1"),
+    ("v10m", "10v", 166, "northward_wind", "m s-1"),
+    ("u100m", "100u", 228246, "eastward_wind", "m s-1"),
+    ("v100m", "100v", 228247, "northward_wind", "m s-1"),
+    ("t2m", "2t", 167, "air_temperature", "K"),
+    ("d2m", "2d", 168, "dew_point_temperature", "K"),
+    ("fg10m", "10fg", 49, "wind_speed_of_gust", "m s-1"),
+    ("sst", "sst", 34, "sea_surface_temperature", "K"),
+    ("skt", "skt", 235, "surface_temperature", "K"),
+    ("sp", "sp", 134, "surface_air_pressure", "Pa"),
+    ("msl", "msl", 151, "air_pressure_at_mean_sea_level", "Pa"),
+    ("tcwv", "tcwv", 137, "atmosphere_mass_content_of_water_vapor", "kg m-2"),
+    ("tcw", "tcw", 136, "", "kg m-2"),
+    ("tcc", "tcc", 164, "cloud_area_fraction", "1"),
+    ("hcc", "hcc", 188, "", "1"),
+    ("mcc", "mcc", 187, "", "1"),
+    ("lcc", "lcc", 186, "", "1"),
+    ("tp", "tp", 228, "", "m"),
+    ("cp", "cp", 143, "lwe_thickness_of_convective_precipitation_amount", "m"),
+    ("lsp", "lsp", 142, "lwe_thickness_of_stratiform_precipitation_amount", "m"),
+    ("sd", "sd", 141, "lwe_thickness_of_surface_snow_amount", "m"),
+    ("sf", "sf", 144, "lwe_thickness_of_snowfall_amount", "kg m-2"),
+    ("ssrd", "ssrd", 169, "surface_downwelling_shortwave_flux_in_air", "J m-2"),
+    ("strd", "strd", 175, "surface_downwelling_longwave_flux_in_air", "J m-2"),
+    ("z", "z", 129, "geopotential", "m2 s-2"),
+    ("lsm", "lsm", 172, "land_binary_mask", "1"),
+    ("stl1", "stl1", 139, "surface_temperature", "K"),
+    ("stl2", "stl2", 170, "surface_temperature", "K"),
+    ("swvl1", "swvl1", 39, "volume_fraction_of_condensed_water_in_soil", "m3 m-3"),
+    ("swvl2", "swvl2", 40, "volume_fraction_of_condensed_water_in_soil", "m3 m-3"),
+]
+
+# ---------------------------------------------------------------------------
+# Pressure-level variables: (base, short_name, param_id, standard_name,
+# canonical_units). The Earth2Studio id is f"{base}{level}".
+# ---------------------------------------------------------------------------
+_PRESSURE: list[tuple[str, str, int, str, str]] = [
+    ("u", "u", 131, "eastward_wind", "m s-1"),
+    ("v", "v", 132, "northward_wind", "m s-1"),
+    ("t", "t", 130, "air_temperature", "K"),
+    ("z", "z", 129, "geopotential", "m2 s-2"),
+    ("q", "q", 133, "specific_humidity", "kg kg-1"),
+    ("r", "r", 157, "relative_humidity", "%"),
+    ("w", "w", 135, "lagrangian_tendency_of_air_pressure", "Pa s-1"),
+    ("d", "d", 155, "divergence_of_wind", "s-1"),
+    ("vo", "vo", 138, "atmosphere_relative_vorticity", "s-1"),
+]
+
+#: Pressure levels (hPa) for which pressure-level Earth2Studio ids are defined.
+PRESSURE_LEVELS: list[int] = [
+    10,
+    50,
+    100,
+    150,
+    200,
+    250,
+    300,
+    400,
+    500,
+    600,
+    700,
+    850,
+    925,
+    1000,
+]
+
+
+def _build_specs() -> dict[str, VariableSpec]:
+    """Build the full Earth2Studio id -> :class:`VariableSpec` crosswalk."""
+    specs: dict[str, VariableSpec] = {}
+    for e2s, short, pid, sn, units in _SURFACE:
+        specs[e2s] = VariableSpec(e2s, short, pid, sn, "surface", None, units)
+    for base, short, pid, sn, units in _PRESSURE:
+        for level in PRESSURE_LEVELS:
+            e2s = f"{base}{level}"
+            specs[e2s] = VariableSpec(
+                e2s, short, pid, sn, "isobaric", float(level), units
+            )
+    return specs
+
+
+def normalize_units(units: str | None) -> str:
+    """Normalize a CF/GRIB units string to a canonical comparison token.
+
+    Handles the common spelling variations seen across Marketplace datasets, e.g.
+    ``"m s**-1"`` and ``"m s-1"``, ``"(0 - 1)"`` and ``"1"``,
+    ``"degree_Celsius"`` and ``"degC"``.
+
+    Parameters
+    ----------
+    units : str | None
+        Raw ``units`` attribute value.
+
+    Returns
+    -------
+    str
+        Normalized units token (may be ``""`` if unknown / missing).
+    """
+    if not units:
+        return ""
+    u = units.strip().lower()
+    u = u.replace("**", "").replace("^", "")
+    u = u.replace(" ", "")
+    # Celsius spellings
+    if u in {"degree_celsius", "degreec", "degc", "celsius", "°c", "degreescelsius"}:
+        return "degc"
+    # Kelvin
+    if u in {"k", "kelvin"}:
+        return "k"
+    # Fraction (0-1)
+    if u in {"1", "(0-1)", "0-1", "fraction", "dimensionless", ""}:
+        return "1" if u != "" else ""
+    # Percent
+    if u in {"%", "percent"}:
+        return "percent"
+    # Water-equivalent depth
+    if u in {"mofwaterequivalent", "mwe"}:
+        return "m"
+    return u
+
+
+def make_modifier(spec: VariableSpec, src_units: str | None) -> Callable:
+    """Return a post-processing function aligning source values to E2S units.
+
+    The conversion is chosen purely from metadata: the repository variable's
+    ``units`` attribute compared against the variable's
+    :attr:`VariableSpec.canonical_units`. Supported conversions cover the cases
+    observed across Marketplace repositories; unknown mismatches fall through to
+    the identity (the data source logs a warning).
+
+    Parameters
+    ----------
+    spec : VariableSpec
+        The resolved variable descriptor.
+    src_units : str | None
+        The ``units`` attribute of the matched repository variable.
+
+    Returns
+    -------
+    Callable
+        ``Callable[[np.ndarray], np.ndarray]`` transforming raw values in place.
+    """
+    src = normalize_units(src_units)
+    dst = normalize_units(spec.canonical_units)
+
+    if src == dst or src == "":
+        return lambda x: x
+
+    # Temperature: Celsius -> Kelvin
+    if src == "degc" and dst == "k":
+        return lambda x: x + 273.15
+    if src == "k" and dst == "degc":
+        return lambda x: x - 273.15
+
+    # Geopotential height (m) -> geopotential (m2 s-2)
+    if spec.short_name == "z" and src == "m" and dst == "m2s-2":
+        return lambda x: x * GRAVITY
+    if spec.short_name == "z" and src == "m2s-2" and dst == "m":
+        return lambda x: x / GRAVITY
+
+    # Cloud cover / fractions: percent <-> 0-1
+    if src == "percent" and dst == "1":
+        return lambda x: x / 100.0
+    if src == "1" and dst == "percent":
+        return lambda x: x * 100.0
+
+    # Relative humidity stored as fraction -> percent
+    if dst == "percent" and src == "1":
+        return lambda x: x * 100.0
+
+    # Precip / snow water equivalent: kg m-2 (== mm) -> m
+    if src == "kgm-2" and dst == "m":
+        return lambda x: x / 1000.0
+    if src == "m" and dst == "kgm-2":
+        return lambda x: x * 1000.0
+
+    # Unknown mismatch: identity (data source emits a warning).
+    return lambda x: x
+
+
+class ArraylakeLexicon(metaclass=LexiconType):
+    """Lexicon for Earthmover Arraylake / Marketplace repositories.
+
+    This lexicon is metadata-driven: ``VOCAB`` encodes the Earth2Studio <-> ECMWF
+    standard crosswalk (it does **not** name the variables of any specific
+    repository). The :class:`~earth2studio.data.arraylake.Arraylake` data source
+    uses :attr:`SPECS` to locate the matching variable inside an opened repository
+    via its ``GRIB_paramId`` / ``GRIB_shortName`` / ``standard_name`` metadata.
+
+    Note
+    ----
+    Earth2Studio variable ids follow the ECMWF parameter database:
+
+    - https://codes.ecmwf.int/grib/param-db/
+    - https://cfconventions.org/
+    """
+
+    #: Earth2Studio id -> :class:`VariableSpec`.
+    SPECS: dict[str, VariableSpec] = _build_specs()
+
+    #: Earth2Studio id -> ``"{short_name}::{param_id}::{level_type}::{level}"``,
+    #: mirroring the ``::`` convention used by other Earth2Studio lexicons.
+    VOCAB: dict[str, str] = {
+        e2s: f"{s.short_name}::{s.param_id}::{s.level_type}::"
+        f"{'' if s.level is None else int(s.level)}"
+        for e2s, s in SPECS.items()
+    }
+
+    @classmethod
+    def get_item(cls, val: str) -> tuple[str, Callable]:
+        """Return the standard crosswalk key and an identity modifier.
+
+        Parameters
+        ----------
+        val : str
+            Earth2Studio variable id.
+
+        Returns
+        -------
+        tuple[str, Callable]
+            The ``::``-encoded ECMWF descriptor string and an identity modifier.
+
+        Note
+        ----
+        Unit normalization for Arraylake is metadata-driven and depends on the
+        *repository* variable's ``units`` attribute, which is not known here. The
+        actual modifier is built by :func:`make_modifier` inside the data source
+        once a repository variable has been matched; ``get_item`` therefore
+        returns the identity to satisfy the lexicon protocol.
+        """
+        return cls.VOCAB[val], (lambda x: x)
+
+    @classmethod
+    def spec(cls, val: str) -> VariableSpec:
+        """Return the :class:`VariableSpec` for an Earth2Studio variable id.
+
+        Parameters
+        ----------
+        val : str
+            Earth2Studio variable id.
+
+        Returns
+        -------
+        VariableSpec
+            The dataset-agnostic descriptor.
+
+        Raises
+        ------
+        KeyError
+            If ``val`` is not a known Earth2Studio variable id.
+        """
+        return cls.SPECS[val]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ Changelog = "https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 data = [
+    "arraylake>=1.0.0; python_version>='3.12'",
     "cdsapi>=0.7.5",
     "cfgrib>=0.9.10.3",
     "eccodes>=2.39.2",

--- a/test/data/test_arraylake.py
+++ b/test/data/test_arraylake.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from earth2studio.data import Arraylake, ArraylakeForecast
+from earth2studio.data.base import DataSource, ForecastSource
+from earth2studio.lexicon.arraylake import (
+    ArraylakeLexicon,
+    make_modifier,
+    normalize_units,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic datasets reproducing the three metadata conventions observed across
+# Earthmover Marketplace repositories. These let us exercise the metadata-driven
+# resolver without network access.
+# ---------------------------------------------------------------------------
+
+LAT = np.linspace(90, -90, 9)
+LON = np.linspace(0, 357.5, 10)
+TIMES = np.array(["2022-01-01T00:00:00", "2022-01-01T06:00:00"], dtype="datetime64[ns]")
+
+
+def _grid(extra_dims=()):
+    shape = tuple(d.size for _, d in extra_dims) + (LAT.size, LON.size)
+    return np.random.rand(*shape).astype("float32")
+
+
+def era5_surface() -> xr.Dataset:
+    """ERA5-style: ECMWF cfVarName variable names + full GRIB_* attrs (SI units)."""
+    coords = {"valid_time": ("valid_time", TIMES), "latitude": LAT, "longitude": LON}
+    dims = ("valid_time", "latitude", "longitude")
+    ds = xr.Dataset(
+        {
+            "t2m": (dims, _grid([("valid_time", xr.DataArray(TIMES))])),
+            "u10": (dims, _grid([("valid_time", xr.DataArray(TIMES))])),
+            "msl": (dims, _grid([("valid_time", xr.DataArray(TIMES))])),
+        },
+        coords=coords,
+    )
+    ds["t2m"].attrs = {
+        "GRIB_paramId": 167,
+        "GRIB_shortName": "2t",
+        "GRIB_cfVarName": "t2m",
+        "standard_name": "unknown",
+        "units": "K",
+    }
+    ds["u10"].attrs = {
+        "GRIB_paramId": 165,
+        "GRIB_shortName": "10u",
+        "GRIB_cfVarName": "u10",
+        "units": "m s**-1",
+    }
+    ds["msl"].attrs = {
+        "GRIB_paramId": 151,
+        "GRIB_shortName": "msl",
+        "standard_name": "air_pressure_at_mean_sea_level",
+        "units": "Pa",
+    }
+    return ds
+
+
+def era5_pressure() -> xr.Dataset:
+    """ERA5-style pressure group: single var + pressure_level coordinate."""
+    levels = np.array([1000.0, 850.0, 500.0, 250.0])
+    coords = {
+        "valid_time": ("valid_time", TIMES),
+        "pressure_level": ("pressure_level", levels),
+        "latitude": LAT,
+        "longitude": LON,
+    }
+    coords_da = xr.DataArray(levels, dims="pressure_level")
+    dims = ("valid_time", "pressure_level", "latitude", "longitude")
+    ds = xr.Dataset(
+        {
+            "t": (dims, _grid([("valid_time", TIMES), ("pressure_level", coords_da)])),
+            "z": (dims, _grid([("valid_time", TIMES), ("pressure_level", coords_da)])),
+        },
+        coords=coords,
+    )
+    ds["pressure_level"].attrs = {
+        "standard_name": "air_pressure",
+        "units": "hPa",
+        "axis": "Z",
+    }
+    ds["t"].attrs = {
+        "GRIB_paramId": 130,
+        "GRIB_shortName": "t",
+        "standard_name": "air_temperature",
+        "units": "K",
+    }
+    # z stored as geopotential (m2 s-2) -> should resolve with identity modifier
+    ds["z"].attrs = {
+        "GRIB_paramId": 129,
+        "GRIB_shortName": "z",
+        "standard_name": "geopotential",
+        "units": "m**2 s**-2",
+    }
+    return ds
+
+
+def ifs_forecast() -> xr.Dataset:
+    """IFS-style: ECMWF GRIB short names as variable names, step (lead) axis."""
+    steps = np.array([0, 6, 12], dtype="timedelta64[h]").astype("timedelta64[ns]")
+    coords = {
+        "time": ("time", TIMES),
+        "step": ("step", steps),
+        "latitude": LAT,
+        "longitude": LON,
+    }
+    dims = ("time", "step", "latitude", "longitude")
+    data = np.random.rand(TIMES.size, steps.size, LAT.size, LON.size).astype("float32")
+    ds = xr.Dataset(
+        {"2t": (dims, data.copy()), "msl": (dims, data.copy())}, coords=coords
+    )
+    ds["2t"].attrs = {"long_name": "2 metre temperature", "units": "K"}
+    ds["msl"].attrs = {
+        "standard_name": "air_pressure_at_mean_sea_level",
+        "long_name": "Mean sea level pressure",
+        "units": "Pa",
+    }
+    return ds
+
+
+def hrrr_celsius() -> xr.Dataset:
+    """HRRR-style: descriptive names, CF standard_name, Celsius units, lat/lon grid.
+
+    (A regular lat/lon variant; the real HRRR archive is on a projected grid,
+    which is covered separately in the projected-grid test.)
+    """
+    coords = {"time": ("time", TIMES), "latitude": LAT, "longitude": LON}
+    dims = ("time", "latitude", "longitude")
+    ds = xr.Dataset({"temperature_2m": (dims, _grid([("time", TIMES)]))}, coords=coords)
+    ds["temperature_2m"].attrs = {
+        "standard_name": "air_temperature",
+        "long_name": "2 metre temperature",
+        "units": "degree_Celsius",
+    }
+    return ds
+
+
+def projected_grid() -> xr.Dataset:
+    """Projected (Lambert) grid: 2-D lat/lon over y/x dims."""
+    y = np.arange(6)
+    x = np.arange(7)
+    lat2d = np.random.rand(y.size, x.size)
+    lon2d = np.random.rand(y.size, x.size)
+    dims = ("time", "y", "x")
+    ds = xr.Dataset(
+        {"temperature_2m": (dims, np.random.rand(TIMES.size, y.size, x.size))},
+        coords={
+            "time": ("time", TIMES),
+            "latitude": (("y", "x"), lat2d),
+            "longitude": (("y", "x"), lon2d),
+            "y": y,
+            "x": x,
+        },
+    )
+    ds["temperature_2m"].attrs = {"standard_name": "air_temperature", "units": "K"}
+    return ds
+
+
+def ambiguous_winds() -> xr.Dataset:
+    """Two surface vars share standard_name eastward_wind (10 m vs 80 m).
+
+    Mirrors HRRR, where height is encoded in the variable name, not metadata.
+    """
+    coords = {"time": ("time", TIMES), "latitude": LAT, "longitude": LON}
+    dims = ("time", "latitude", "longitude")
+    ds = xr.Dataset(
+        {
+            "wind_u_10m": (dims, _grid([("time", TIMES)])),
+            "wind_u_80m": (dims, _grid([("time", TIMES)])),
+        },
+        coords=coords,
+    )
+    ds["wind_u_10m"].attrs = {"standard_name": "eastward_wind", "units": "m s-1"}
+    ds["wind_u_80m"].attrs = {"standard_name": "eastward_wind", "units": "m s-1"}
+    return ds
+
+
+class _FakeSession:
+    def __init__(self, datasets):
+        self.store = object()
+        self._datasets = datasets
+
+
+class _FakeRepo:
+    def __init__(self, datasets):
+        self._datasets = datasets
+
+    def readonly_session(self, branch="main"):
+        return _FakeSession(self._datasets)
+
+
+def _patch_open(monkeypatch, datasets):
+    """Patch arraylake client + xr.open_zarr to serve `datasets` per group order."""
+    import earth2studio.data.arraylake as almod
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, name):
+            return _FakeRepo(datasets)
+
+    monkeypatch.setattr(almod.arraylake, "Client", _FakeClient)
+
+    calls = {"i": 0}
+
+    def fake_open_zarr(store, group=None, **kwargs):
+        ds = datasets[calls["i"]]
+        calls["i"] += 1
+        return ds
+
+    monkeypatch.setattr(almod.xr, "open_zarr", fake_open_zarr)
+
+
+# ---------------------------------------------------------------------------
+# Lexicon / unit-conversion unit tests (no network, no mocking)
+# ---------------------------------------------------------------------------
+
+
+def test_arraylake_lexicon_specs():
+    # Pressure-level id encodes variable + level; surface ids are distinct.
+    assert ArraylakeLexicon.spec("t850").param_id == 130
+    assert ArraylakeLexicon.spec("t850").level == 850
+    assert ArraylakeLexicon.spec("z500").short_name == "z"
+    # The classic name collision: E2S u10 (10 hPa) != ECMWF u10 (10 m wind).
+    assert ArraylakeLexicon.spec("u10").level_type == "isobaric"
+    assert ArraylakeLexicon.spec("u10m").level_type == "surface"
+    # The two must NOT share a paramId (131 = u on pressure level, 165 = 10 m wind).
+    assert (
+        ArraylakeLexicon.spec("u10").param_id != ArraylakeLexicon.spec("u10m").param_id
+    )
+    with pytest.raises(KeyError):
+        ArraylakeLexicon.spec("not_a_variable")
+
+
+def test_arraylake_unit_normalization():
+    assert normalize_units("m s**-1") == normalize_units("m s-1")
+    assert normalize_units("degree_Celsius") == "degc"
+    assert normalize_units("(0 - 1)") == "1"
+    assert normalize_units("percent") == "percent"
+
+
+def test_arraylake_make_modifier():
+    t2m = ArraylakeLexicon.spec("t2m")
+    celsius_to_k = make_modifier(t2m, "degree_Celsius")
+    assert np.isclose(celsius_to_k(np.array([0.0]))[0], 273.15)
+    # Geopotential height (m) -> geopotential (m2 s-2)
+    z500 = ArraylakeLexicon.spec("z500")
+    gh_mod = make_modifier(z500, "m")
+    assert np.isclose(gh_mod(np.array([1.0]))[0], 9.80665)
+    # Already geopotential -> identity
+    assert np.isclose(make_modifier(z500, "m2 s-2")(np.array([5.0]))[0], 5.0)
+    # Cloud cover percent -> fraction
+    tcc = ArraylakeLexicon.spec("tcc")
+    assert np.isclose(make_modifier(tcc, "percent")(np.array([50.0]))[0], 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Mocked resolution / fetch tests
+# ---------------------------------------------------------------------------
+
+
+def test_arraylake_protocol():
+    assert isinstance(Arraylake("org/repo"), DataSource)
+    assert isinstance(ArraylakeForecast("org/repo"), ForecastSource)
+
+
+def test_arraylake_call_mock_era5(monkeypatch):
+    _patch_open(monkeypatch, [era5_surface(), era5_pressure()])
+    ds = Arraylake("vandelay-industries/era5", group=["single", "pressure"])
+    out = ds(datetime(2022, 1, 1), ["t2m", "msl", "t850", "z500"])
+    assert list(out.dims) == ["time", "variable", "lat", "lon"]
+    assert out.shape == (1, 4, LAT.size, LON.size)
+    assert list(out.coords["variable"].values) == ["t2m", "msl", "t850", "z500"]
+    assert np.isfinite(out.values).all()
+
+
+def test_arraylake_call_mock_celsius_conversion(monkeypatch):
+    _patch_open(monkeypatch, [hrrr_celsius()])
+    ds = Arraylake("vandelay-industries/hrrr")
+    out = ds(datetime(2022, 1, 1), "t2m")
+    # degree_Celsius source values (in [0,1)) must be shifted to Kelvin range.
+    assert float(out.min()) > 200.0
+
+
+def test_arraylake_paramid_disambiguation(monkeypatch):
+    # u10m (10 m wind, paramId 165) must match cfVarName "u10", NOT be confused
+    # with the E2S "u10" (10 hPa wind). Resolver keys on paramId/shortName.
+    _patch_open(monkeypatch, [era5_surface()])
+    ds = Arraylake("vandelay-industries/era5", group="single")
+    out = ds(datetime(2022, 1, 1), "u10m")
+    assert out.shape == (1, 1, LAT.size, LON.size)
+
+
+def test_arraylake_forecast_mock_ifs(monkeypatch):
+    _patch_open(monkeypatch, [ifs_forecast()])
+    ds = ArraylakeForecast("vandelay-industries/ifs")
+    out = ds(
+        datetime(2022, 1, 1),
+        [timedelta(hours=0), timedelta(hours=6)],
+        ["t2m", "msl"],
+    )
+    assert list(out.dims) == ["time", "lead_time", "variable", "lat", "lon"]
+    assert out.shape == (1, 2, 2, LAT.size, LON.size)
+
+
+def test_arraylake_available(monkeypatch):
+    _patch_open(monkeypatch, [era5_surface()])
+    ds = Arraylake("vandelay-industries/era5", group="single")
+    assert ds.available(datetime(2022, 1, 1, 0))
+    assert not ds.available(datetime(1999, 1, 1, 0))
+
+
+def test_arraylake_exceptions(monkeypatch):
+    # Unknown E2S variable.
+    _patch_open(monkeypatch, [era5_surface()])
+    ds = Arraylake("vandelay-industries/era5", group="single")
+    with pytest.raises(ValueError, match="not a known Earth2Studio variable"):
+        ds(datetime(2022, 1, 1), "definitely_not_a_var")
+
+    # Variable not present in the repo (no matching metadata).
+    _patch_open(monkeypatch, [era5_surface()])
+    ds2 = Arraylake("vandelay-industries/era5", group="single")
+    with pytest.raises(ValueError, match="Could not resolve"):
+        ds2(datetime(2022, 1, 1), "q500")
+
+    # Time not available.
+    _patch_open(monkeypatch, [era5_surface()])
+    ds3 = Arraylake("vandelay-industries/era5", group="single")
+    with pytest.raises(ValueError, match="not available"):
+        ds3(datetime(1999, 1, 1), "t2m")
+
+
+def test_arraylake_ambiguous_resolution(monkeypatch):
+    # When only standard_name matches and multiple vars share it, refuse to guess.
+    _patch_open(monkeypatch, [ambiguous_winds()])
+    ds = Arraylake("vandelay-industries/hrrr")
+    with pytest.raises(ValueError, match="ambiguous"):
+        ds(datetime(2022, 1, 1), "u10m")
+
+
+def test_arraylake_projected_grid_error(monkeypatch):
+    _patch_open(monkeypatch, [projected_grid()])
+    ds = Arraylake("vandelay-industries/hrrr-analysis")
+    with pytest.raises(ValueError, match="projected"):
+        ds(datetime(2022, 1, 1), "t2m")
+
+
+def test_arraylake_subscription_error(monkeypatch):
+    import earth2studio.data.arraylake as almod
+
+    class _DeniedClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_repo(self, name):
+            raise RuntimeError("403 Forbidden: access denied")
+
+    monkeypatch.setattr(almod.arraylake, "Client", _DeniedClient)
+    ds = Arraylake("vandelay-industries/era5")
+    with pytest.raises(PermissionError, match="subscription"):
+        ds(datetime(2022, 1, 1), "t2m")
+
+
+def test_arraylake_auth_precedence(monkeypatch):
+    # Explicit client takes precedence; no network/credentials needed.
+    _patch_open(monkeypatch, [era5_surface()])
+    import earth2studio.data.arraylake as almod
+
+    sentinel = almod.arraylake.Client()
+    ds = Arraylake("vandelay-industries/era5", group="single", client=sentinel)
+    assert ds._make_client() is sentinel


### PR DESCRIPTION
Closes #928 

The approach was designed by me and mostly implemented by Claude Code.

## Summary

Adds two new data sources that connect Earth2Studio to versioned Zarr/Icechunk
datasets hosted on [Arraylake](https://docs.earthmover.io), including datasets
obtained through the [Earthmover Data Marketplace](https://app.earthmover.io/marketplace):

- **`Arraylake`** — a `DataSource` for analysis/reanalysis cubes (`[time, variable, lat, lon]`)
- **`ArraylakeForecast`** — a `ForecastSource` for forecast cubes with a lead-time axis (`[time, lead_time, variable, lat, lon]`)

Both wrap *any* subscribed Arraylake repository and require no per-dataset code.

## Motivation

A growing catalog of analysis-ready weather/climate datasets are available via the Earthmover Data Marketplace. We expect the volume and diversity of data to grow substantially over time. This data will be very useful to Earth2Studio.

In contrast to some other sources, the Data Marketplace is driven by providers. Therefore, the Earth2Studio connector must be non-dataset-specific.

## Design: metadata-driven variable resolution

Marketplace repositories use **different native variable-naming schemes** — ECMWF cfVarName (`t2m`, `u10`), ECMWF GRIB short names (`2t`, `10u`), or descriptive CF names (`temperature_2m`). Hard-coding a vocabulary per dataset does not scale.

Instead, the connector keeps **one dataset-agnostic crosswalk** from each Earth2Studio variable id to its ECMWF/CF descriptor (`{paramId, shortName, standard_name, level, canonical_units}`, in `earth2studio/lexicon/arraylake.py`) and
resolves it against whatever metadata a repository actually exposes, in priority order:

1. **`GRIB_paramId`** — authoritative and unambiguous
2. **`GRIB_shortName` / `GRIB_cfVarName` / variable name**
3. **CF `standard_name`** (+ vertical-level coordinate for pressure levels)

This avoids subtle name collisions — e.g. Earth2Studio `u10` means *u-wind at 10 hPa*, while an ERA5 repo's `u10` variable is *10 m u-wind* (cfVarName); keying on paramId resolves both correctly. **Unit normalization** is likewise metadata-driven from the `units` attribute (e.g. `degree_Celsius`→K, geopotential-height→geopotential ×g, cloud-cover `%`↔`0–1`). When only `standard_name` matches and several variables share it (so height/level cannot be distinguished), the resolver **refuses to guess** and raises an actionable error rather than returning the wrong field.

### Authentication & the Marketplace subscription workflow

Marketplace subscriptions are created in the Earthmover web app; once subscribed, `Client().get_repo("org/repo")` transparently resolves the subscription. Usage:

1. Subscribe to the dataset on its listing page (https://www.earthmover.io/marketplace).
2. Authenticate — `al auth login` (cached) **or** set `ARRAYLAKE_TOKEN`.
3. Pass `org/repo` to the data source.

Auth precedence is explicit `client=` → `ARRAYLAKE_TOKEN` → cached login. Access denials raise a clear "create a subscription first" error.

```python
from datetime import datetime
from earth2studio.data import Arraylake

ds = Arraylake("my-org/era5", group=["single/spatial", "pressure/spatial"])
da = ds(datetime(2022, 1, 1), ["t2m", "msl", "z500", "t850"])
# da.dims == ("time", "variable", "lat", "lon")
```

### Note on the output layout (`variable` as a dimension)

Per the Earth2Studio `DataSource` / `ForecastSource` protocol , a data source returns a single `xr.DataArray` with `variable` as a **dimension** whose coordinate is an array of Earth2Studio variable-id strings — i.e. `[time, variable, lat, lon]` (and `[time, lead_time, variable, lat, lon]` for forecasts). This is deliberately *not* the idiomatic xarray layout (a `Dataset` with one named `data_var` per field): E2S treats `variable` as a stacked **channel** axis that maps directly onto model input tensors `(batch, time, variable, lat, lon)`. This layout is the framework contract shared by every existing source (ARCO, GFS, IFS, …), not a choice of this connector; the connector resolves each requested variable independently and `concat`s them along the `variable` dimension to conform.

## Validation

Validated against three real Marketplace repositories with distinct conventions.
Coverage over the full 156-variable Earth2Studio vocabulary:

| Repository | Marketplace listing | Type | Resolved | Matched by |
|---|---|---|---|---|
| `era5` (`single/spatial` + `pressure/spatial`) | [ERA5 (earthmover-public)](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) | analysis | **114 / 156** | `GRIB_paramId` |
| `ifs` | [ECMWF IFS HRES (brightband)](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) | forecast | **14 / 156** | `GRIB_shortName` |
| `hrrr-analysis` | [NOAA HRRR analysis (dynamical)](https://app.earthmover.io/marketplace/6970589fe0cf33d466e36682) | analysis | **10 / 156** | `standard_name` |

Physical-value sanity check (ERA5, real fetch, single timestep) — all in correct
physical units:

| Variable | Min | Max | Unit |
|---|---|---|---|
| `t2m` | 226.24 | 310.37 | K |
| `msl` | 96 350.69 | 105 926.44 | Pa |
| `u10m` | −21.57 | 19.04 | m s⁻¹ |
| `z500` | 47 180.33 | 57 881.08 | m² s⁻² |
| `t850` | 234.64 | 300.06 | K |
| `q500` | 0.00 | 0.01 | kg kg⁻¹ |

`z500` in m² s⁻² confirms the connector correctly treats `z` as geopotential (not geopotential height) and applies the right modifier.

<img width="1200" height="560" alt="_sanity_era5" src="https://github.com/user-attachments/assets/fd82760b-8d93-44bc-9bd0-b92fca5d8466" />
<img width="800" height="320" alt="_sanity_ifs" src="https://github.com/user-attachments/assets/8f4ea3b7-20b4-4ca7-b3aa-0db9f4f260fe" />

### Key findings

- **ERA5** resolves cleanly and completely via `GRIB_paramId` (surface + all 13  pressure levels for u, v, t, z, q, r, w).
- **IFS** resolves via GRIB short names (its variable names *are* the short names);  exposed as a `ForecastSource` over the `step` (lead-time) axis.
- **HRRR-analysis** is partially resolvable and surfaces two real limitations: it  exposes no GRIB identifiers (only CF `standard_name`), and it is published on a  **projected (Lambert) grid** with 2-D lat/lon, which does not satisfy Earth2Studio's regular 1-D lat/lon contract — the connector raises a clear regridding error. The four near-surface wind variables are intentionally left unresolved because `standard_name` alone cannot distinguish 10 m from 80 m.

> **Recommendation to data publishers:** to make a dataset fully resolvable without any per-dataset code, publish variables with `GRIB_paramId`/`GRIB_shortName` attributes (ERA5 already does), CF `standard_name` plus an explicit height/level coordinate for surface fields, SI units, and a regular lat/lon representation.

## Tests

`test/data/test_arraylake.py` — 14 tests, all passing, no network required. Synthetic datasets reproduce all three metadata conventions plus edge cases:

- crosswalk specs, unit normalization, and modifier selection
- `DataSource` / `ForecastSource` protocol conformance
- mocked fetch for ERA5 (surface + pressure), IFS forecast, Celsius→K conversion
- `paramId` disambiguation, `available()`
- exceptions: unknown variable, unresolvable variable, time not available,  projected-grid error, ambiguous standard-name match, subscription/permission error, auth precedence

Slow (`--slow`) fetch/cache tests against real repositories could be added once a public or CI-accessible repository is designated.

## Documentation

- Class docstrings (Parameters, Marketplace subscription workflow, warnings,
  reference URLs)
- `data.Arraylake` added to `docs/modules/datasources_analysis.rst`
- `data.ArraylakeForecast` added to `docs/modules/datasources_forecast.rst`
- CHANGELOG entry

## Limitations / follow-ups

- Projected-grid datasets (e.g. HRRR) require regridding to a regular lat/lon grid;
  out of scope here (raises a clear error).
- Reads are lazy/synchronous via the Icechunk store rather than using the async
  `_sync_async`/`gather_with_concurrency` pattern, matching Arraylake's documented
  access model; a concurrency pass can follow if needed.


<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

- Adds `arraylake>=1.0.0` to the `data` optional-dependency extra, gated
  `; python_version>='3.12'` (the client requires Python ≥3.12). Pulls Icechunk +
  Zarr v3, already core to Earth2Studio.