### PR TITLE
Test util patches

### DIFF
--- a/earth2studio/utils/imports.py
+++ b/earth2studio/utils/imports.py
@@ -14,11 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
+import re
 import sys
 import tomllib
 from collections.abc import Callable
 from functools import lru_cache, wraps
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, requires, version
 from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar, cast
@@ -188,6 +189,10 @@ def check_optional_dependencies(
 def _find_pyproject_toml() -> Path:
     """Locate pyproject.toml relative to this module.
 
+    This only works for editable/source installs. For wheel installs,
+    use :func:`_parse_optional_dependencies` which prefers
+    ``importlib.metadata``.
+
     Returns
     -------
     Path
@@ -209,15 +214,58 @@ def _find_pyproject_toml() -> Path:
     )
 
 
+_EXTRA_RE = re.compile(r"""extra\s*==\s*['"]([^'"]+)['"]""")
+
+
 @lru_cache(maxsize=1)
-def _parse_optional_dependencies() -> dict[str, list[str]]:
-    """Parse and cache optional-dependencies from pyproject.toml.
+def _parse_optional_dependencies_from_metadata() -> dict[str, list[str]]:
+    """Parse optional-dependencies from installed package metadata.
+
+    Uses ``importlib.metadata.requires()`` which reads the ``.dist-info/METADATA``
+    file present in both editable and wheel installs.
 
     Returns
     -------
     dict[str, list[str]]
         Mapping of group name to list of package specs
     """
+    reqs = requires("earth2studio") or []
+    groups: dict[str, list[str]] = {}
+    for req_str in reqs:
+        # Each entry looks like: "package_spec; extra == 'group'"
+        # or just "package_spec" for core dependencies
+        parts = req_str.split(";", 1)
+        spec = parts[0].strip()
+        if len(parts) == 2:
+            marker = parts[1].strip()
+            m = _EXTRA_RE.search(marker)
+            if m:
+                group = m.group(1)
+                groups.setdefault(group, []).append(spec)
+        # Core deps (no extra marker) are not included in optional-dependencies
+    return groups
+
+
+@lru_cache(maxsize=1)
+def _parse_optional_dependencies() -> dict[str, list[str]]:
+    """Parse and cache optional-dependencies for the earth2studio package.
+
+    Prefers ``importlib.metadata`` (works for both wheel and editable installs).
+    Falls back to reading ``pyproject.toml`` directly if metadata is unavailable.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Mapping of group name to list of package specs
+    """
+    try:
+        deps = _parse_optional_dependencies_from_metadata()
+        if deps:
+            return deps
+    except PackageNotFoundError:
+        pass
+
+    # Fallback: read pyproject.toml (editable/source installs only)
     pyproject_path = _find_pyproject_toml()
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -69,6 +70,7 @@ _TEST_DEPENDENCIES: dict[str, list[str]] = {
     "test/models/dx/test_corrdiff.py": ["corrdiff"],
     "test/models/dx/test_corrdiff_cmip6.py": ["corrdiff"],
     "test/models/dx/test_corrdiff_taiwan.py": ["corrdiff"],
+    "test/models/dx/test_dlesym_v0_isccp_era5_precip.py": ["dlesym"],
     "test/models/dx/test_orbit2_precip.py": ["orbit"],
     "test/models/dx/test_precip_afno.py": ["precip-afno"],
     "test/models/dx/test_precip_afno_v2.py": ["precip-afno-v2"],
@@ -85,6 +87,7 @@ _TEST_DEPENDENCIES: dict[str, list[str]] = {
     "test/models/px/test_aurora.py": ["aurora"],
     "test/models/px/test_cbottle_video.py": ["cbottle"],
     "test/models/px/test_dlesym.py": ["dlesym"],
+    "test/models/px/test_dlesym_v0_isccp_era5.py": ["dlesym"],
     "test/models/px/test_dlwp.py": ["dlwp"],
     "test/models/px/test_fcn.py": ["fcn"],
     "test/models/px/test_fcn3.py": ["fcn3"],
@@ -153,6 +156,10 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
     for dep in _TEST_DEPENDENCIES[rel_str]:
         # Check if it's a group name (exists in pyproject.toml) or a package
         if not _group_available(dep) and not _package_available(dep):
+            print(
+                f"WARNING: Ignoring {rel_str}: missing dependency '{dep}'",
+                file=sys.stderr,
+            )
             return True
 
     return None
@@ -184,6 +191,25 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+
+    # Skip tests whose optional dependency groups are missing.
+    # pytest_ignore_collect handles directory traversal, this is for when individual
+    # files are targeted when testing
+    for item in items:
+        try:
+            rel_str = str(item.path.relative_to(Path.cwd()))
+        except ValueError:
+            continue
+        if rel_str not in _TEST_DEPENDENCIES:
+            continue
+        for dep in _TEST_DEPENDENCIES[rel_str]:
+            if not _group_available(dep) and not _package_available(dep):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"missing dependency '{dep}' for {rel_str}"
+                    )
+                )
+                break
 
     enable_packages = config.getoption("--package") or os.getenv(
         "EARTH2STUDIO_TEST_PACKAGES", ""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,9 +205,7 @@ def pytest_collection_modifyitems(config, items):
         for dep in _TEST_DEPENDENCIES[rel_str]:
             if not _group_available(dep) and not _package_available(dep):
                 item.add_marker(
-                    pytest.mark.skip(
-                        reason=f"missing dependency '{dep}' for {rel_str}"
-                    )
+                    pytest.mark.skip(reason=f"missing dependency '{dep}' for {rel_str}")
                 )
                 break
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

- Added dlesym_v0_isccp_era5 and dlesym_v0_isccp_era5_precip test files to the dependency skip map.
- Added dependency checking in pytest_collection_modifyitems to skip tests when their required dependency group is missing — this covers the case where files are specified explicitly on the command line (where pytest_ignore_collect is not invoked).
- Added WARNING messages printed to stderr during collection when tests are ignored due to missing dependencies.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
