### PR TITLE
Fix MPI variable ordering in ACE2 by making variable lists deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ACE2 distributed inference failures caused by nondeterministic variable ordering
+  across MPI ranks.
+
 ### Security
 
 ### Dependencies

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -179,7 +179,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             self.lexicon.get_e2s_from_fme(v) for v in self._all_out_variables_fme
         ]
 
-        self._forcing_vars_fme = list(self.stepper._input_only_names)
+        self._forcing_vars_fme = sorted(self.stepper._input_only_names)
         if (
             "surface_temperature" in self._all_out_variables_fme
             and "surface_temperature" not in self._forcing_vars_fme
@@ -191,7 +191,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         self._forcing_vars_e2s = [
             self.lexicon.get_e2s_from_fme(v) for v in self._forcing_vars_fme
         ]
-        self._prog_vars_fme = list(self.stepper.prognostic_names)
+        self._prog_vars_fme = sorted(self.stepper.prognostic_names)
         self._prog_vars_e2s = [
             self.lexicon.get_e2s_from_fme(v) for v in self._prog_vars_fme
         ]


### PR DESCRIPTION
In earth2studio/models/px/ace2.py (ACE2.__init__), the code builds the forcing and prognostic variable lists as:

self._forcing_vars_fme = list(self.stepper._input_only_names)
self._prog_vars_fme = list(self.stepper.prognostic_names)

These are created from Python sets, so their iteration order differs across MPI ranks due to hash randomization. As a result, prognostic.input_coords()["variable"] is different on different ranks, causing

ValueError: Coordinate systems for required dim variable are not the same

when running with multiple MPI ranks.

Replacing list(...) with sorted(...) makes the ordering deterministic:

self._forcing_vars_fme = sorted(self.stepper._input_only_names)
self._prog_vars_fme = sorted(self.stepper.prognostic_names)

After this change, the variable ordering is identical on all MPI ranks and the model runs correctly.



