### PR TITLE
Fix API links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,11 +396,11 @@ Earth2Studio is provided under the Apache License 2.0, refer to the
 [e2studio_api_url]: https://nvidia.github.io/earth2studio/modules/
 [e2studio_customization_url]: https://nvidia.github.io/earth2studio/examples/extend/index.html
 [e2studio_px_url]: https://nvidia.github.io/earth2studio/userguide/components/prognostic.html
-[e2studio_px_api]: https://nvidia.github.io/earth2studio/modules/models.html#earth2studio-models-px-prognostic
+[e2studio_px_api]: https://nvidia.github.io/earth2studio/modules/models_px.html
 [e2studio_dx_url]: https://nvidia.github.io/earth2studio/userguide/components/diagnostic.html
-[e2studio_dx_api]: https://nvidia.github.io/earth2studio/modules/models.html#earth2studio-models-dx-diagnostic
+[e2studio_dx_api]: https://nvidia.github.io/earth2studio/modules/models_dx.html
 [e2studio_data_url]: https://nvidia.github.io/earth2studio/userguide/components/datasources.html
-[e2studio_data_api]: https://nvidia.github.io/earth2studio/modules/datasources.html
+[e2studio_data_api]: https://nvidia.github.io/earth2studio/modules/datasources_analysis.html
 [e2studio_io_url]: https://nvidia.github.io/earth2studio/userguide/components/io.html
 [e2studio_io_api]: https://nvidia.github.io/earth2studio/modules/io.html
 [e2studio_pb_url]: https://nvidia.github.io/earth2studio/userguide/components/perturbation.html


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Links to the API docs in the README.md were outdated.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
