### PR TITLE
ACE2ERA5 Perf Improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed ACE2 distributed inference failures caused by nondeterministic variable ordering
   across MPI ranks.
-- Improved ACE2ERA5 inference performance by caching forcing values
+- Improved ACE2ERA5 inference performance by caching yearly forcing values
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed ACE2 distributed inference failures caused by nondeterministic variable ordering
   across MPI ranks.
+- Improved ACE2ERA5 inference performance by caching forcing values
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ACE2 distributed inference failures caused by nondeterministic variable ordering
   across MPI ranks.
 - Improved ACE2ERA5 inference performance by caching yearly forcing values
+- Fixed ACE2ERA5 forcing data retrieval for static variables requested across
+  multiple times.
 
 ### Security
 

--- a/earth2studio/data/ace2.py
+++ b/earth2studio/data/ace2.py
@@ -99,7 +99,6 @@ class ACE2ERA5Data:
         self.lon = ACE_GRID_LON
         self._co2_fn = co2_fn
         self._hf_fs = HfFileSystem()
-        self._dataset_cache: dict[str, xr.Dataset] = {}
 
     def __call__(
         self,
@@ -159,24 +158,18 @@ class ACE2ERA5Data:
             paths.append(path)
 
         # Open and concat across years
-        dsets = []
-        for path in paths:
-            if self._cache and path in self._dataset_cache:
-                dsets.append(self._dataset_cache[path])
-                continue
-
-            ds = xr.open_dataset(path, engine="netcdf4")
-            rename_coords = {
-                k: v
-                for k, v in {"latitude": "lat", "longitude": "lon"}.items()
-                if k in ds.coords
-            }
-            if rename_coords:
-                ds = ds.rename(rename_coords)
-            if self._cache:
-                self._dataset_cache[path] = ds
-            dsets.append(ds)
+        dsets = [xr.open_dataset(p, engine="netcdf4") for p in paths]
         ds = xr.concat(dsets, dim="time") if len(dsets) > 1 else dsets[0]
+
+        # Standardize lat/lon coord names
+        if "latitude" in ds.coords or "longitude" in ds.coords:
+            ds = ds.rename(
+                {
+                    k: v
+                    for k, v in {"latitude": "lat", "longitude": "lon"}.items()
+                    if k in ds.coords
+                }
+            )
 
         # Subset time and variables; select exact requested timestamps and order
         ds = ds.sel(time=time_list)
@@ -197,7 +190,6 @@ class ACE2ERA5Data:
                 )
             elif "time" in da.dims and self._mode == "forcing":
                 # CO2 is time-only
-                da = da.copy()
                 da = da.expand_dims({"lat": self.lat, "lon": self.lon})
                 da = da.transpose("time", "lat", "lon")
                 if self._co2_fn is not None:

--- a/earth2studio/data/ace2.py
+++ b/earth2studio/data/ace2.py
@@ -99,6 +99,7 @@ class ACE2ERA5Data:
         self.lon = ACE_GRID_LON
         self._co2_fn = co2_fn
         self._hf_fs = HfFileSystem()
+        self._dataset_cache: dict[str, xr.Dataset] = {}
 
     def __call__(
         self,
@@ -158,18 +159,24 @@ class ACE2ERA5Data:
             paths.append(path)
 
         # Open and concat across years
-        dsets = [xr.open_dataset(p, engine="netcdf4") for p in paths]
-        ds = xr.concat(dsets, dim="time") if len(dsets) > 1 else dsets[0]
+        dsets = []
+        for path in paths:
+            if self._cache and path in self._dataset_cache:
+                dsets.append(self._dataset_cache[path])
+                continue
 
-        # Standardize lat/lon coord names
-        if "latitude" in ds.coords or "longitude" in ds.coords:
-            ds = ds.rename(
-                {
-                    k: v
-                    for k, v in {"latitude": "lat", "longitude": "lon"}.items()
-                    if k in ds.coords
-                }
-            )
+            ds = xr.open_dataset(path, engine="netcdf4")
+            rename_coords = {
+                k: v
+                for k, v in {"latitude": "lat", "longitude": "lon"}.items()
+                if k in ds.coords
+            }
+            if rename_coords:
+                ds = ds.rename(rename_coords)
+            if self._cache:
+                self._dataset_cache[path] = ds
+            dsets.append(ds)
+        ds = xr.concat(dsets, dim="time") if len(dsets) > 1 else dsets[0]
 
         # Subset time and variables; select exact requested timestamps and order
         ds = ds.sel(time=time_list)
@@ -190,6 +197,7 @@ class ACE2ERA5Data:
                 )
             elif "time" in da.dims and self._mode == "forcing":
                 # CO2 is time-only
+                da = da.copy()
                 da = da.expand_dims({"lat": self.lat, "lon": self.lon})
                 da = da.transpose("time", "lat", "lon")
                 if self._co2_fn is not None:

--- a/earth2studio/data/ace2.py
+++ b/earth2studio/data/ace2.py
@@ -183,11 +183,7 @@ class ACE2ERA5Data:
             if "time" in da.dims and "lat" in da.dims and "lon" in da.dims:
                 da = da.transpose("time", "lat", "lon")
             elif "lat" in da.dims and "lon" in da.dims:
-                da = (
-                    da.expand_dims("time")
-                    .assign_coords(time=time_list)
-                    .transpose("time", "lat", "lon")
-                )
+                da = da.expand_dims(time=time_list).transpose("time", "lat", "lon")
             elif "time" in da.dims and self._mode == "forcing":
                 # CO2 is time-only
                 da = da.expand_dims({"lat": self.lat, "lon": self.lon})
@@ -257,7 +253,7 @@ class ACE2ERA5Data:
     @property
     def cache(self) -> str:
         """Get the appropriate cache location."""
-        cache_location = os.path.join(datasource_cache_root(), "ACE2ERA5")
+        cache_location = os.path.join(datasource_cache_root(), "ace2era5_data")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_ACE2ERA5")
+            cache_location = os.path.join(cache_location, "tmp_ace2era5_data")
         return cache_location

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 import torch
 import xarray as xr
+from loguru import logger
 
 from earth2studio.data import ACE2ERA5Data
 from earth2studio.data.ace2 import ACE_GRID_LAT, ACE_GRID_LON
@@ -131,6 +132,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
     - ACE2-ERA5 paper: https://arxiv.org/abs/2411.11268v1
     - ACE2 code: https://github.com/ai2cm/ace
+    - Huggingface: https://huggingface.co/allenai/ACE2-ERA5
 
     Notes
     -----
@@ -209,7 +211,8 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # External forcing data source
         self.forcing_data_source = forcing_data_source
         self._forcing_cache: dict[
-            tuple[int, tuple[str, ...], str, int], tuple[torch.Tensor, CoordSystem]
+            tuple[int, tuple[str, ...], str, str, int],
+            tuple[torch.Tensor, CoordSystem],
         ] = {}
 
         # Grid handling
@@ -459,15 +462,82 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         y = y.unsqueeze(2)
         return y
 
-    def _fetch_forcing_at_time(
-        self, valid_time: np.datetime64, device: torch.device
+    def _fetch_forcing_year(
+        self, year: int, device: torch.device
     ) -> tuple[torch.Tensor, CoordSystem]:
-        valid_time = valid_time.astype("datetime64[ns]")
         device = torch.device(device)
         cache_key = (
             id(self.forcing_data_source),
             tuple(self._forcing_vars_e2s),
             str(device),
+            "year",
+            year,
+        )
+        if cache_key in self._forcing_cache:
+            return self._forcing_cache[cache_key]
+
+        logger.warning(
+            "Loading ACE2 forcing data for year {} onto {}. This replaces any "
+            "previous cached forcing year.",
+            year,
+            device,
+        )
+        start = np.datetime64(f"{year:04d}-01-01T00:00:00", "ns")
+        end = np.datetime64(f"{year + 1:04d}-01-01T00:00:00", "ns")
+        year_times = np.arange(start, end, self._dt, dtype="datetime64[ns]")
+        lead_time = np.array([np.timedelta64(0, "h")], dtype="timedelta64[ns]")
+
+        forcing_x, year_coords = fetch_data(
+            self.forcing_data_source,
+            time=year_times,
+            lead_time=lead_time,
+            variable=self._forcing_vars_e2s,
+            device=device,
+        )
+        self._forcing_cache.clear()
+        self._forcing_cache[cache_key] = (forcing_x, year_coords)
+        return self._forcing_cache[cache_key]
+
+    def _fetch_forcing_at_time(
+        self, valid_time: np.datetime64, device: torch.device
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        valid_time = valid_time.astype("datetime64[ns]")
+        device = torch.device(device)
+        if isinstance(self.forcing_data_source, ACE2ERA5Data):
+            year = pd.Timestamp(valid_time).year
+            forcing_x, forcing_coords = self._fetch_forcing_year(year, device)
+
+            year_start = np.datetime64(f"{year:04d}-01-01T00:00:00", "ns")
+            delta_ns = (
+                (valid_time - year_start).astype("timedelta64[ns]").astype(np.int64)
+            )
+            step_ns = np.asarray(self._dt).astype("timedelta64[ns]").astype(np.int64)
+            if delta_ns % step_ns != 0:
+                raise ValueError(
+                    f"ACE2 forcing time {valid_time} is not on model step {self._dt}."
+                )
+            time_index = int(delta_ns // step_ns)
+            if time_index < 0 or time_index >= len(forcing_coords["time"]):
+                raise ValueError(
+                    f"ACE2 forcing time {valid_time} is outside cached year {year}."
+                )
+            if (
+                forcing_coords["time"][time_index].astype("datetime64[ns]")
+                != valid_time
+            ):
+                raise ValueError(
+                    f"ACE2 forcing time {valid_time} was not found in cached year {year}."
+                )
+
+            out_coords = forcing_coords.copy()
+            out_coords["time"] = np.array([valid_time], dtype="datetime64[ns]")
+            return forcing_x[time_index : time_index + 1], out_coords
+
+        cache_key = (
+            id(self.forcing_data_source),
+            tuple(self._forcing_vars_e2s),
+            str(device),
+            "time",
             int(valid_time.astype("datetime64[ns]").astype(np.int64)),
         )
         if cache_key not in self._forcing_cache:

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -111,10 +111,10 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     ACE2 (Ai2 Climate Emulator v2) is a 450M-parameter autoregressive emulator
     with 6-hour time steps, 1-degree horizontal resolution, and eight vertical
     layers that exactly conserves global dry air mass and moisture and can be
-    stepped stably for arbitrarily many steps at about 1500 simulated years
-    per wall-clock day. ACE2-ERA5 was trained on the ERA5 dataset and requires
-    forcing data during rollout (see `forcing_data_source` parameter). This
-    wrapper makes use of the ``fme`` package to run model forward passes.
+    stepped stably for arbitrarily many steps. ACE2-ERA5 was trained on the ERA5
+    dataset and requires forcing data during rollout (see `forcing_data_source`
+    parameter). This wrapper makes use of the ``fme`` package to run model forward
+    passes.
 
     Parameters
     ----------
@@ -128,8 +128,18 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
     References
     ----------
+
     - ACE2-ERA5 paper: https://arxiv.org/abs/2411.11268v1
     - ACE2 code: https://github.com/ai2cm/ace
+
+    Notes
+    -----
+    For throughput-sensitive GPU inference, enabling TensorFloat-32 matmul kernels
+    before running ACE2 can improve performance on supported NVIDIA GPUs:
+
+        torch.set_float32_matmul_precision("high")
+
+    This setting trades some float32 matmul precision for faster matrix operations.
 
     Warning
     -------

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -198,6 +198,9 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
         # External forcing data source
         self.forcing_data_source = forcing_data_source
+        self._forcing_cache: dict[
+            tuple[int, tuple[str, ...], int], tuple[torch.Tensor, CoordSystem]
+        ] = {}
 
         # Grid handling
         self.lat = ACE_GRID_LAT
@@ -446,6 +449,54 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         y = y.unsqueeze(2)
         return y
 
+    def _fetch_forcing_at_time(
+        self, valid_time: np.datetime64
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        valid_time = valid_time.astype("datetime64[ns]")
+        cache_key = (
+            id(self.forcing_data_source),
+            tuple(self._forcing_vars_e2s),
+            int(valid_time.astype("datetime64[ns]").astype(np.int64)),
+        )
+        if cache_key not in self._forcing_cache:
+            self._forcing_cache[cache_key] = fetch_data(
+                self.forcing_data_source,
+                time=np.array([valid_time], dtype="datetime64[ns]"),
+                lead_time=np.array([np.timedelta64(0, "h")], dtype="timedelta64[ns]"),
+                variable=self._forcing_vars_e2s,
+                device="cpu",
+            )
+        forcing_x, forcing_coords = self._forcing_cache[cache_key]
+        return forcing_x, forcing_coords.copy()
+
+    def _fetch_forcing(
+        self, x: torch.Tensor, coords: CoordSystem, lead_times: np.ndarray
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        forcing_by_lead = []
+        forcing_coords = None
+        for lead_time in lead_times:
+            forcing_by_time = []
+            for time in coords["time"]:
+                forcing_x, forcing_coords = self._fetch_forcing_at_time(
+                    time + lead_time
+                )
+                forcing_by_time.append(forcing_x)
+            forcing_by_lead.append(torch.cat(forcing_by_time, dim=0))
+
+        forcing_x = torch.cat(forcing_by_lead, dim=1)
+        if forcing_coords is None:
+            raise ValueError("ACE2ERA5 forcing data requires at least one time value.")
+
+        forcing_coords["time"] = coords["time"]
+        forcing_coords["lead_time"] = lead_times.astype("timedelta64[ns]")
+
+        if self.needs_regrid:
+            forcing_x = self.regridder(forcing_x.to(x.device))
+            forcing_coords["lat"] = coords["lat"]
+            forcing_coords["lon"] = coords["lon"]
+
+        return forcing_x, forcing_coords
+
     @torch.inference_mode()
     def _forward(
         self,
@@ -475,18 +526,11 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         lead_times = np.array(
             [coords["lead_time"][0], coords["lead_time"][0] + self._dt]
         )
-        forcing_x, forcing_coords = fetch_data(
-            self.forcing_data_source,
-            time=coords["time"],
-            lead_time=lead_times,
-            variable=self._forcing_vars_e2s,
+        forcing_x, forcing_coords = self._fetch_forcing(
+            x=x, coords=coords, lead_times=lead_times
         )
 
-        # Interp to proper coords and stack along batch dimension as required
-        if self.needs_regrid:
-            forcing_x = self.regridder(forcing_x.to(x.device))
-            forcing_coords["lat"] = coords["lat"]
-            forcing_coords["lon"] = coords["lon"]
+        # Stack along batch dimension as required
         forcing_x = torch.stack([forcing_x] * len(coords["batch"]), dim=0).to(
             device=x.device, dtype=x.dtype
         )

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -137,11 +137,16 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     Notes
     -----
     For throughput-sensitive GPU inference, enabling TensorFloat-32 matmul kernels
-    before running ACE2 can improve performance on supported NVIDIA GPUs:
+    before importing PyTorch can improve performance on supported NVIDIA GPUs:
+
+        export TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1
+
+    For in-process control, this can also be enabled with:
 
         torch.set_float32_matmul_precision("high")
 
-    This setting trades some float32 matmul precision for faster matrix operations.
+    Both settings trade some float32 matmul precision for faster matrix operations;
+    the environment variable is a process-wide cuBLAS override.
 
     Warning
     -------

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -209,7 +209,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # External forcing data source
         self.forcing_data_source = forcing_data_source
         self._forcing_cache: dict[
-            tuple[int, tuple[str, ...], int], tuple[torch.Tensor, CoordSystem]
+            tuple[int, tuple[str, ...], str, int], tuple[torch.Tensor, CoordSystem]
         ] = {}
 
         # Grid handling
@@ -460,12 +460,14 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         return y
 
     def _fetch_forcing_at_time(
-        self, valid_time: np.datetime64
+        self, valid_time: np.datetime64, device: torch.device
     ) -> tuple[torch.Tensor, CoordSystem]:
         valid_time = valid_time.astype("datetime64[ns]")
+        device = torch.device(device)
         cache_key = (
             id(self.forcing_data_source),
             tuple(self._forcing_vars_e2s),
+            str(device),
             int(valid_time.astype("datetime64[ns]").astype(np.int64)),
         )
         if cache_key not in self._forcing_cache:
@@ -474,7 +476,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                 time=np.array([valid_time], dtype="datetime64[ns]"),
                 lead_time=np.array([np.timedelta64(0, "h")], dtype="timedelta64[ns]"),
                 variable=self._forcing_vars_e2s,
-                device="cpu",
+                device=device,
             )
         forcing_x, forcing_coords = self._forcing_cache[cache_key]
         return forcing_x, forcing_coords.copy()
@@ -488,7 +490,7 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             forcing_by_time = []
             for time in coords["time"]:
                 forcing_x, forcing_coords = self._fetch_forcing_at_time(
-                    time + lead_time
+                    time + lead_time, x.device
                 )
                 forcing_by_time.append(forcing_x)
             forcing_by_lead.append(torch.cat(forcing_by_time, dim=0))

--- a/earth2studio/models/px/ace2.py
+++ b/earth2studio/models/px/ace2.py
@@ -517,17 +517,6 @@ class ACE2ERA5(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                     f"ACE2 forcing time {valid_time} is not on model step {self._dt}."
                 )
             time_index = int(delta_ns // step_ns)
-            if time_index < 0 or time_index >= len(forcing_coords["time"]):
-                raise ValueError(
-                    f"ACE2 forcing time {valid_time} is outside cached year {year}."
-                )
-            if (
-                forcing_coords["time"][time_index].astype("datetime64[ns]")
-                != valid_time
-            ):
-                raise ValueError(
-                    f"ACE2 forcing time {valid_time} was not found in cached year {year}."
-                )
 
             out_coords = forcing_coords.copy()
             out_coords["time"] = np.array([valid_time], dtype="datetime64[ns]")

--- a/test/data/test_ace2_era5.py
+++ b/test/data/test_ace2_era5.py
@@ -21,7 +21,9 @@ import shutil
 
 import numpy as np
 import pytest
+import xarray as xr
 
+import earth2studio.data.ace2 as ace2_module
 from earth2studio.data import ACE2ERA5Data
 
 
@@ -137,6 +139,48 @@ def test_ace2era5_initial_conditions_year_validation():
     # 1981 is not an allowed IC year
     with pytest.raises(ValueError):
         ds(datetime.datetime(year=1981, month=1, day=1, hour=0), ["skt"])
+
+
+def test_ace2era5_forcing_static_fields_expand_multiple_times(monkeypatch, tmp_path):
+    times = np.array(
+        ["1950-01-01T00:00:00", "1950-01-01T06:00:00"], dtype="datetime64[ns]"
+    )
+    lat = np.array([-0.5, 0.5], dtype=np.float32)
+    lon = np.array([0.5, 1.5, 2.5], dtype=np.float32)
+    dataset = xr.Dataset(
+        data_vars={
+            "surface_temperature": (
+                ("time", "lat", "lon"),
+                np.arange(12, dtype=np.float32).reshape(2, 2, 3),
+            ),
+            "HGTsfc": (("lat", "lon"), np.full((2, 3), 10.0, dtype=np.float32)),
+            "global_mean_co2": (("time",), np.array([400.0, 401.0], dtype=np.float32)),
+        },
+        coords={"time": times, "lat": lat, "lon": lon},
+    )
+
+    cache_file = tmp_path / "ACE2ERA5" / "forcing_data" / "forcing_1950.nc"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.touch()
+    monkeypatch.setattr(ace2_module, "datasource_cache_root", lambda: str(tmp_path))
+    monkeypatch.setattr(ace2_module.xr, "open_dataset", lambda *_, **__: dataset)
+
+    ds = ACE2ERA5Data(mode="forcing", cache=True, verbose=False)
+    ds.lat = lat
+    ds.lon = lon
+
+    da = ds(times, ["skt", "z", "global_mean_co2"])
+
+    assert da.dims == ("time", "variable", "lat", "lon")
+    assert da.shape == (2, 3, 2, 3)
+    assert np.array_equal(da.coords["time"].values, times)
+    assert np.array_equal(
+        da.coords["variable"].values,
+        np.array(["skt", "z", "global_mean_co2"], dtype=object),
+    )
+    assert np.all(da.sel(variable="z").values == 10.0)
+    assert np.all(da.sel(variable="global_mean_co2").values[0] == 400.0)
+    assert np.all(da.sel(variable="global_mean_co2").values[1] == 401.0)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Improves ACE2ERA5 forecast performance by caching forcing data in the model wrapper and fixes ACE2ERA5 forcing data retrieval for static variables requested across multiple times.

Key changes:
- Cache ACE2ERA5 forcing data by year on the requested device, replacing the previous per-step forcing fetch path for the default ACE2 datasource.
- Keep custom forcing data sources on the smaller per-time cache path.
- Fix ACE2ERA5 static forcing fields so mixed static, time-only, and dynamic variables can be fetched for multiple timestamps in one call.
- Update ACE2 API docs to remove the paper-derived throughput claim and note `torch.set_float32_matmul_precision("high")` as a useful performance setting.
- Add regression coverage for multi-time static forcing retrieval.

<details>
<summary>Performance notes and benchmark script</summary>

Measured on the Colossus VM with CUDA using the local `test.py` script below. The loop timing excludes model/package loading and reports the ACE2 iterator loop for `loop[28]`.

| Configuration | Iterator loop time | Relative to baseline |
| --- | ---: | ---: |
| Baseline before forcing cache | ~2.52 s | 1.00x |
| Per-timestep forcing cache + TF32 + `torch.compile` | ~1.45 s | ~1.74x faster |
| Yearly forcing cache + TF32 + `torch.compile` | ~1.38 s | ~1.83x faster |

The current branch measured `Elapsed time(loop[28]): 1.380558 seconds`. The one-time `torch.compile` warmup was about `10.6 seconds` and is reported separately by the script.

```python
import time

import numpy as np
import torch
from tqdm import tqdm

from earth2studio.data import fetch_data
from earth2studio.data.ace2 import ACE2ERA5Data
from earth2studio.models.px import ACE2ERA5
from earth2studio.utils.time import to_time_array

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
torch.set_float32_matmul_precision("high")
torch.backends.cudnn.benchmark = True
use_torch_compile = True

start_date = "1950-01-01"


data = ACE2ERA5Data()


package = ACE2ERA5.load_default_package()

prognostic = ACE2ERA5.load_model(package).to(device)

if use_torch_compile:
    prognostic.stepper.modules[0].module = torch.compile(
        prognostic.stepper.modules[0].module, mode="reduce-overhead"
    )


x, coords = fetch_data(
    source=data,
    time=to_time_array([start_date]),
    variable=prognostic.input_coords()["variable"],
    lead_time=prognostic.input_coords()["lead_time"],
    device=device,
)

_ = fetch_data(
    source=prognostic.forcing_data_source,
    time=coords["time"],
    variable=prognostic._forcing_vars_e2s,
    lead_time=np.array([np.timedelta64(0, "h")]),
    device=device,
)

if use_torch_compile:
    if device.type == "cuda":
        torch.cuda.synchronize()
    start_compile = time.perf_counter()
    _ = prognostic(x, coords)
    if device.type == "cuda":
        torch.cuda.synchronize()
    print(f"Torch compile warmup: {time.perf_counter() - start_compile:.6f} seconds")

model = prognostic.create_iterator(x, coords)


nsteps = 28

start_loop = time.perf_counter()

with tqdm(total=nsteps + 1, desc="Running inference", leave=False) as pbar:
    for step, (x_mod, coords_mod) in enumerate(model):
        pbar.update(1)
        if step == nsteps:
            break
end_loop = time.perf_counter()
print(f"Elapsed time(loop[{step}]): {end_loop - start_loop:.6f} seconds")
```

</details>

Validation:
- `uv run pytest test/data/test_ace2_era5.py test/models/px/test_ace2.py`
- `uv run ruff check earth2studio/data/ace2.py earth2studio/models/px/ace2.py test/data/test_ace2_era5.py`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

No new dependencies.
