### PR TITLE
Fix NNJA decode blocking shared fsspec IO loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed NNJA observation sources blocking the shared fsspec IO loop with
+  CPU-bound PrepBUFR decode work, which stalled concurrent fetches from other
+  data sources.
 - Fixed ACE2 distributed inference failures caused by nondeterministic variable ordering
   across MPI ranks.
 - Improved ACE2ERA5 inference performance by caching yearly forcing values

--- a/earth2studio/data/nnja.py
+++ b/earth2studio/data/nnja.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
 import pathlib
@@ -212,7 +213,12 @@ class _NNJAObsBase:
                 verbose=(not self._verbose),
             )
 
-        df = self._compile_dataframe(async_tasks, variable_list, schema)
+        # Decoding is CPU-bound and internally blocks on pool futures; run it in
+        # a worker thread so it does not stall the shared fsspec IO loop that
+        # _sync_async dispatches every data source's fetch onto.
+        df = await asyncio.to_thread(
+            self._compile_dataframe, async_tasks, variable_list, schema
+        )
         df.attrs["source"] = self.SOURCE_ID
         return df
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Fixes NNJA observation sources blocking fsspec's shared background IO loop with CPU-bound decode work.

Fixes #970

### Problem

`_NNJAObsBase.fetch()` runs on fsspec's shared background IO loop (everything dispatched through `_sync_async` lands on that single `fsspecIO` thread). The PrepBUFR compile step, `self._compile_dataframe(...)`, executed synchronously inside that coroutine — descending into `utils_ncep.py::decode_file`, which blocks on `ProcessPoolExecutor` futures with `future.result()`. While the decode runs, the event loop cannot process anything else, so every other data source's fetch stalls behind it.

This is what broke CI in the `test-data` job (see #970): `test_nnja_obs_conv_fetch` hit its timeout and was absorbed as XFAIL, but pytest-timeout cannot kill work on a background thread — the decode kept holding the loop for 3+ minutes afterward. The next tests needing the loop, `test_ifs_time_available[msl-time1-IFS]` / `[msl-time1-IFS_ENS]`, burned their full 30 s timeouts and hard-failed. Those tests are offline (the 1993 date should raise `ValueError` instantly from `_validate_time`), which is how this was traced to loop starvation rather than ECMWF endpoint flakiness: all the timeout stack dumps show the same leftover NNJA frame at `utils_ncep.py:858`.

The failure is load-dependent — it reproduces when the decode is slowed by CPU contention on shared CI runners, which is why it presents as an intermittent "ECMWF flake."

### What changed

- `earth2studio/data/nnja.py`: run the compile/decode step in a worker thread via `await asyncio.to_thread(self._compile_dataframe, ...)` so it no longer holds the shared IO loop. `decode_file` manages its own `ProcessPoolExecutor` internally, so moving the caller to a thread is safe.

### Testing

- All offline NNJA unit tests pass (18 passed, 2 skipped as `--slow`).
- `black` and `ruff` are clean.
- Note: unit tests exercise the code path but not the contention scenario itself; the real signal is CI's `test-data` job no longer failing unrelated tests when NNJA runs slow.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback. Greptile is an AI code review bot for guidance; addressing every suggestion is not required.

## Dependencies

No new dependencies.
