### PR TITLE
Migrate remaining GRIB byte-range sources (HRRR, GEFS, CFS, NCAR ERA5) to obstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `async_workers` and `retries` parameters to GFS / GFS_FX, HRRR / HRRR_FX,
   GEFS_FX / GEFS_FX_721x1440, CFS_FX / CFS_FX_Flux and NCAR_ERA5 data sources;
   `async_workers` defaults to None which autoscales download concurrency to the
-  number of pending tasks (capped at 32)
+  number of pending tasks (capped at 64)
 - Added shared obstore byte-range helpers (`obstore_store_from_url`,
   `obstore_read_range`, `obstore_fetch_to_cache`) in `earth2studio.data.utils`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GRIB fetches; downloads now use bounded concurrency with retry on transient errors
 - Migrated the remaining GRIB byte-range data sources (HRRR / HRRR_FX, GEFS_FX /
   GEFS_FX_721x1440, CFS_FX / CFS_FX_Flux, NCAR_ERA5) from s3fs/gcsfs to obstore with
-  bounded concurrency and retry on transient errors; no fsspec fallbacks remain —
-  HTTP-backed sources (GFS `ncep`, HRRR `nomads`, CFS `nomads`) now use obstore
-  `HTTPStore` against the NOMADS HTTPS endpoint (GFS `ncep` previously used FTP)
+  bounded concurrency and retry on transient errors
+- Migrated HTTP-backed GRIB sources (GFS `ncep`, HRRR `nomads`, CFS `nomads`) to
+  obstore `HTTPStore` against the NOMADS HTTPS endpoint (GFS `ncep` previously used
+  FTP); no fsspec fallbacks remain in the GRIB byte-range sources
 - Refactored UFS observation sources (`UFSObsConv`, `UFSObsSat`) onto the shared
   obstore byte-range helpers
 - Zarr-reading data sources (`ARCO`, `WB2ERA5` and other WeatherBench 2 sources, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GHCN hourly data source (`GHCNHourly`), superseding the deprecated ISD source
 - Added EarthMover ERA5 0.25 degree reanalysis data source
 - Added EarthMover IFS 0.1 degree data source and forecast source hosted by BrightBand
-- Added `async_workers` and `retries` parameters to GFS / GFS_FX data sources
+- Added `async_workers` and `retries` parameters to GFS / GFS_FX, HRRR / HRRR_FX,
+  GEFS_FX / GEFS_FX_721x1440, CFS_FX / CFS_FX_Flux and NCAR_ERA5 data sources;
+  `async_workers` defaults to None which autoscales download concurrency to the
+  number of pending tasks (capped at 32)
 - Added shared obstore byte-range helpers (`obstore_store_from_url`,
   `obstore_read_range`, `obstore_fetch_to_cache`) in `earth2studio.data.utils`
 
@@ -27,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   predictions for GOES GLM Lightning density.
 - Migrated GFS / GFS_FX data sources from s3fs to obstore for index and byte-range
   GRIB fetches; downloads now use bounded concurrency with retry on transient errors
+- Migrated the remaining GRIB byte-range data sources (HRRR / HRRR_FX, GEFS_FX /
+  GEFS_FX_721x1440, CFS_FX / CFS_FX_Flux, NCAR_ERA5) from s3fs/gcsfs to obstore with
+  bounded concurrency and retry on transient errors; no fsspec fallbacks remain —
+  HTTP-backed sources (GFS `ncep`, HRRR `nomads`, CFS `nomads`) now use obstore
+  `HTTPStore` against the NOMADS HTTPS endpoint (GFS `ncep` previously used FTP)
 - Refactored UFS observation sources (`UFSObsConv`, `UFSObsSat`) onto the shared
   obstore byte-range helpers
 - Zarr-reading data sources (`ARCO`, `WB2ERA5` and other WeatherBench 2 sources, and

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -396,7 +396,7 @@ class CFS_FX:
                     _, param_name, level = cfs_name_str.split("::", 2)
                     idx_key = f"{param_name}::{level}"
 
-                    record: tuple[int, int, int] | None = None
+                    record: tuple[int, int | None, int] | None = None
                     for key, value in index_table.items():
                         # key is "<recno>::<param>::<level>"; substring match
                         # tolerates the recno prefix and matches both scalar
@@ -526,7 +526,9 @@ class CFS_FX:
                     f"{_MAX_LEAD_HOURS // 24} days."
                 )
 
-    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int, int]]:
+    async def _fetch_index(
+        self, index_uri: str
+    ) -> dict[str, tuple[int, int | None, int]]:
         """Fetch a CFS grib `.idx` file and parse it into a byte-range lookup.
 
         The CFS pgbf product packs `UGRD`/`VGRD` into a single vector grib
@@ -544,11 +546,11 @@ class CFS_FX:
 
         Returns
         -------
-        dict[str, tuple[int, int, int]]
+        dict[str, tuple[int, int | None, int]]
             Mapping from `<recno>::<param>::<level>` to
-            `(byte_offset, byte_length, submsg_index)`. A negative
-            `byte_length` (last record) means "read from offset to the end of
-            the file".
+            `(byte_offset, byte_length, submsg_index)`. A `byte_length` of
+            `None` (last record) means "read from offset to the end of the
+            file".
             `submsg_index` is the 1-based pygrib message index within the
             cached byte-range file; for scalar records this is always 1, for
             vector siblings it is parsed from the decimal suffix of `recno`.

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -105,7 +105,7 @@ class CFS_FX:
         Total timeout in seconds for the entire fetch operation, by default 600.
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which
-        autoscales to the number of download tasks (capped at 32).
+        autoscales to the number of download tasks (capped at 64).
     retries : int, optional
         Number of retry attempts per failed fetch task with exponential
         backoff, by default 3.
@@ -233,7 +233,7 @@ class CFS_FX:
         """
         self.store = obstore_store_from_url(
             self._store_url,
-            max_pool_connections=self._async_workers or 32,
+            max_pool_connections=self._async_workers or 64,
         )
 
     def __call__(
@@ -768,7 +768,7 @@ class CFS_FX_Flux(CFS_FX):
         Total timeout in seconds for the entire fetch operation, by default 600.
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which
-        autoscales to the number of download tasks (capped at 32).
+        autoscales to the number of download tasks (capped at 64).
     retries : int, optional
         Number of retry attempts per failed fetch task with exponential
         backoff, by default 3.

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -74,7 +74,7 @@ class CFSAsyncTask:
     data_array_indices: tuple[int, int, int]
     cfs_file_uri: str
     cfs_byte_offset: int
-    cfs_byte_length: int
+    cfs_byte_length: int | None
     cfs_submsg_index: int
     cfs_modifier: Callable
 
@@ -577,7 +577,7 @@ class CFS_FX:
         # Compute byte length using the next strictly-greater offset so that
         # vector-sibling records (same offset, decimal-suffixed recno) cover
         # the same byte range.
-        index_table: dict[str, tuple[int, int, int]] = {}
+        index_table: dict[str, tuple[int, int | None, int]] = {}
         for idx, (recno, offset, key) in enumerate(parsed):
             next_offset: int | None = None
             for _next_recno, next_off, _next_key in parsed[idx + 1 :]:
@@ -585,14 +585,13 @@ class CFS_FX:
                     next_offset = next_off
                     break
             if next_offset is None:
-                # Last record: negative sentinel meaning "read from offset to
-                # the end of the object", which downstream maps to
-                # ``byte_length=None`` (matches the GEFS index handling).
-                byte_length = -1
+                # Last record: None means "read from offset to the end of the
+                # object" (matches the GEFS index handling).
+                byte_length = None
             else:
                 byte_length = next_offset - offset
 
-            if byte_length > self.MAX_BYTE_SIZE:
+            if byte_length is not None and byte_length > self.MAX_BYTE_SIZE:
                 raise ValueError(
                     f"Byte length {byte_length} of variable {key} larger than "
                     f"safe threshold {self.MAX_BYTE_SIZE}"
@@ -623,17 +622,13 @@ class CFS_FX:
         byte_offset : int, optional
             Starting byte offset, by default 0.
         byte_length : int | None, optional
-            Number of bytes to fetch, by default None (full file). A negative
-            value means "read from offset to the end of the file".
+            Number of bytes to fetch, by default None (read to end of file).
 
         Returns
         -------
         str
             Path to the cached file on local disk.
         """
-        if byte_length is not None and byte_length < 0:
-            byte_length = None
-
         # Hash the original path string (bucket-prefixed for AWS, full HTTPS
         # URL for NOMADS) so warm caches populated before the obstore
         # migration remain valid

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -25,11 +25,11 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import numpy as np
+import obstore as obs
 import pygrib
-import s3fs
 import xarray as xr
-from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
@@ -38,7 +38,10 @@ from earth2studio.data.utils import (
     cancellable_to_thread,
     datasource_cache_root,
     gather_with_concurrency,
+    obstore_fetch_to_cache,
+    obstore_store_from_url,
     prep_forecast_inputs,
+    resolve_async_workers,
 )
 from earth2studio.lexicon import CFSFluxLexicon, CFSLexicon
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
@@ -101,7 +104,8 @@ class CFS_FX:
     async_timeout : int, optional
         Total timeout in seconds for the entire fetch operation, by default 600.
     async_workers : int, optional
-        Maximum number of concurrent async fetch tasks, by default 16.
+        Maximum number of concurrent downloads. By default None, which
+        autoscales to the number of download tasks (capped at 32).
     retries : int, optional
         Number of retry attempts per failed fetch task with exponential
         backoff, by default 3.
@@ -141,7 +145,11 @@ class CFS_FX:
     CFS_LON = np.linspace(0, 359, 360)
 
     CFS_AWS_BUCKET = "noaa-cfs-pds"
-    CFS_NOMADS_BASE = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/cfs/prod"
+    # NOMADS HTTPS mirror of the NCEP production feed, supports the ranged
+    # GETs obstore's HTTPStore issues for byte-range fetches. The store is
+    # rooted at the host; object keys carry the full "pub/..." path.
+    CFS_NOMADS_HOST = "https://nomads.ncep.noaa.gov"
+    CFS_NOMADS_BASE = f"{CFS_NOMADS_HOST}/pub/data/nccf/com/cfs/prod"
 
     CFS_MEMBERS = (1, 2, 3, 4)
     CFS_SOURCES = ("nomads", "aws")
@@ -159,7 +167,7 @@ class CFS_FX:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
-        async_workers: int = 16,
+        async_workers: int | None = None,
         retries: int = 3,
     ):
         if member not in self.CFS_MEMBERS:
@@ -182,6 +190,7 @@ class CFS_FX:
 
         if source == "nomads":
             self.uri_prefix = self.CFS_NOMADS_BASE
+            self._store_url = self.CFS_NOMADS_HOST
 
             def _history_range(time: datetime) -> None:
                 # NOMADS keeps roughly the last seven cycles online; allow a
@@ -198,6 +207,7 @@ class CFS_FX:
 
         else:  # aws
             self.uri_prefix = self.CFS_AWS_BUCKET
+            self._store_url = f"s3://{self.CFS_AWS_BUCKET}"
 
             def _history_range(time: datetime) -> None:
                 if time < _AWS_HISTORY_START:
@@ -208,25 +218,23 @@ class CFS_FX:
 
         self._history_range = _history_range
 
-        # Filesystem is lazily initialised inside the event loop.
-        self.fs: s3fs.S3FileSystem | HTTPFileSystem | None = None
+        # Object store is lazily initialised on first fetch (AWS uses an
+        # anonymous S3 store, NOMADS an HTTP store rooted at the host).
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialisation of the fsspec backend.
+        """Async initialization of the object store
 
         Note
         ----
-        Async fsspec expects initialisation inside the execution loop.
+        Unlike async fsspec filesystems, obstore stores are event-loop
+        independent and could be built in ``__init__``; kept as a lazy async
+        method to preserve the initialization seam.
         """
-        if self._source == "aws":
-            self.fs = s3fs.S3FileSystem(
-                anon=True,
-                client_kwargs={},
-                asynchronous=True,
-                skip_instance_cache=True,
-            )
-        else:
-            self.fs = HTTPFileSystem(asynchronous=True)
+        self.store = obstore_store_from_url(
+            self._store_url,
+            max_pool_connections=self._async_workers or 32,
+        )
 
     def __call__(
         self,
@@ -282,7 +290,8 @@ class CFS_FX:
         xr.DataArray
             CFS forecast data array.
         """
-        if self.fs is None:
+        # Lazily initialize the object store on first use
+        if self.store is None:
             await self._async_init()
 
         time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
@@ -290,50 +299,39 @@ class CFS_FX:
         self._validate_time(time)
         self._validate_leadtime(lead_time)
 
-        # s3fs needs an explicit aiohttp session for parallel fetches; the
-        # HTTPFileSystem manages its own session lazily and does not accept
-        # the s3fs ``refresh`` kwarg, so we only set up a session for s3.
-        session = None
-        if isinstance(self.fs, s3fs.S3FileSystem):
-            session = await self.fs.set_session(refresh=True)
-
-        try:
-            # NaN-initialise so variables that are not resolved against the
-            # grib index surface as detectable missing values instead of
-            # arbitrary memory.
-            xr_array = xr.DataArray(
-                data=np.full(
-                    (
-                        len(time),
-                        len(lead_time),
-                        len(variable),
-                        len(self.CFS_LAT),
-                        len(self.CFS_LON),
-                    ),
-                    np.nan,
+        # NaN-initialise so variables that are not resolved against the
+        # grib index surface as detectable missing values instead of
+        # arbitrary memory.
+        xr_array = xr.DataArray(
+            data=np.full(
+                (
+                    len(time),
+                    len(lead_time),
+                    len(variable),
+                    len(self.CFS_LAT),
+                    len(self.CFS_LON),
                 ),
-                dims=["time", "lead_time", "variable", "lat", "lon"],
-                coords={
-                    "time": time,
-                    "lead_time": lead_time,
-                    "variable": variable,
-                    "lat": self.CFS_LAT,
-                    "lon": self.CFS_LON,
-                },
-            )
+                np.nan,
+            ),
+            dims=["time", "lead_time", "variable", "lat", "lon"],
+            coords={
+                "time": time,
+                "lead_time": lead_time,
+                "variable": variable,
+                "lat": self.CFS_LAT,
+                "lon": self.CFS_LON,
+            },
+        )
 
-            tasks = await self._create_tasks(time, lead_time, variable)
-            coros = [self.fetch_wrapper(task, xr_array=xr_array) for task in tasks]
-            await gather_with_concurrency(
-                coros,
-                max_workers=self._async_workers,
-                task_timeout=120.0,
-                desc="Fetching CFS data",
-                verbose=(not self._verbose),
-            )
-        finally:
-            if session is not None:
-                await session.close()
+        tasks = await self._create_tasks(time, lead_time, variable)
+        coros = [self.fetch_wrapper(task, xr_array=xr_array) for task in tasks]
+        await gather_with_concurrency(
+            coros,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
+            task_timeout=120.0,
+            desc="Fetching CFS data",
+            verbose=(not self._verbose),
+        )
 
         return xr_array
 
@@ -365,12 +363,14 @@ class CFS_FX:
         # Fetch every required .idx in parallel up front.  Most CFS variable
         # records live in the same grib file (one file per IC x lead_time), so
         # we cache them in a dict keyed by URI.  Bound the index fetches by
-        # the configured ``async_workers`` budget rather than launching all
-        # of them simultaneously through a bare ``tqdm.gather``.
+        # the ``async_workers`` budget (autoscaled to the task count when
+        # unset) rather than launching all of them simultaneously through a
+        # bare ``tqdm.gather``.
         idx_uris = [self._grib_index_uri(t, lt) for t in time for lt in lead_time]
+        idx_coros = [self._fetch_index(uri) for uri in idx_uris]
         idx_results = await gather_with_concurrency(
-            [self._fetch_index(uri) for uri in idx_uris],
-            max_workers=self._async_workers,
+            idx_coros,
+            max_workers=resolve_async_workers(self._async_workers, len(idx_coros)),
             task_timeout=60.0,
             desc="Fetching CFS index files",
             verbose=True,
@@ -546,7 +546,9 @@ class CFS_FX:
         -------
         dict[str, tuple[int, int, int]]
             Mapping from `<recno>::<param>::<level>` to
-            `(byte_offset, byte_length, submsg_index)`.
+            `(byte_offset, byte_length, submsg_index)`. A negative
+            `byte_length` (last record) means "read from offset to the end of
+            the file".
             `submsg_index` is the 1-based pygrib message index within the
             cached byte-range file; for scalar records this is always 1, for
             vector siblings it is parsed from the decimal suffix of `recno`.
@@ -583,9 +585,10 @@ class CFS_FX:
                     next_offset = next_off
                     break
             if next_offset is None:
-                # Last record: use a generous upper bound; fsspec/`_cat_file`
-                # treats `end > size` as "rest of file".
-                byte_length = self.MAX_BYTE_SIZE
+                # Last record: negative sentinel meaning "read from offset to
+                # the end of the object", which downstream maps to
+                # ``byte_length=None`` (matches the GEFS index handling).
+                byte_length = -1
             else:
                 byte_length = next_offset - offset
 
@@ -616,39 +619,43 @@ class CFS_FX:
         Parameters
         ----------
         path : str
-            Remote URI (``s3://...`` style for AWS or HTTPS URL for NOMADS).
+            Remote URI (``bucket/key`` style for AWS or HTTPS URL for NOMADS).
         byte_offset : int, optional
             Starting byte offset, by default 0.
         byte_length : int | None, optional
-            Number of bytes to fetch, by default None (full file).
+            Number of bytes to fetch, by default None (full file). A negative
+            value means "read from offset to the end of the file".
 
         Returns
         -------
         str
             Path to the cached file on local disk.
         """
-        if self.fs is None:
-            raise ValueError("File system is not initialised")
+        if byte_length is not None and byte_length < 0:
+            byte_length = None
 
+        # Hash the original path string (bucket-prefixed for AWS, full HTTPS
+        # URL for NOMADS) so warm caches populated before the obstore
+        # migration remain valid
         sha = hashlib.sha256((path + str(byte_offset)).encode())
-        cache_path = os.path.join(self.cache, sha.hexdigest())
+        filename = sha.hexdigest()
 
-        if pathlib.Path(cache_path).is_file():
-            return cache_path
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
-        end: int | None = None
-        if byte_length:
-            end = int(byte_offset + byte_length)
-
-        try:
-            data = await self.fs._cat_file(path, start=byte_offset, end=end)
-        except FileNotFoundError as e:
-            logger.error(f"Failed to download {path}: not found")
-            raise e
-
-        with open(cache_path, "wb") as fh:
-            fh.write(data)
-        return cache_path
+        # AWS paths are bucket-prefixed; NOMADS paths are full HTTPS URLs on
+        # the store host — strip either prefix to get the store-relative key
+        key = path.removeprefix(self.CFS_AWS_BUCKET + "/").removeprefix(
+            self.CFS_NOMADS_HOST + "/"
+        )
+        return await obstore_fetch_to_cache(
+            self.store,
+            key,
+            self.cache,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+            cache_key=filename,
+        )
 
     def _grib_uri(self, time: datetime, lead_time: timedelta) -> str:
         """Build the grib file URI for a given IC and lead time."""
@@ -668,7 +675,9 @@ class CFS_FX:
         """Join the source-specific URI prefix to a relative path."""
         if self._source == "nomads":
             return f"{self.uri_prefix.rstrip('/')}/{suffix}"
-        # AWS: s3fs accepts ``bucket/key`` for ``_cat_file``.
+        # AWS: bucket-prefixed path; the bucket prefix is stripped to a
+        # store-relative key before the obstore read, but the full path is
+        # kept in the cache-key hash for warm-cache compatibility.
         return f"{self.uri_prefix}/{suffix}"
 
     @property
@@ -721,15 +730,19 @@ class CFS_FX:
             return False
 
         member_dir = f"{member:02d}"
-        cycle_uri = (
-            f"s3://{cls.CFS_AWS_BUCKET}/cfs.{time:%Y%m%d}/"
-            f"{time:%H}/6hrly_grib_{member_dir}/"
-        )
-        fs = s3fs.S3FileSystem(anon=True)
+        # Object store directory for the requested cycle / member
+        prefix = f"cfs.{time:%Y%m%d}/{time:%H}/6hrly_grib_{member_dir}/"
+        store = obstore_store_from_url(f"s3://{cls.CFS_AWS_BUCKET}")
         try:
-            return fs.exists(cycle_uri)
-        except OSError:
+            # obs.list yields chunks (lists) of entries; one entry proves
+            # existence
+            chunk: list = next(iter(obs.list(store, prefix=prefix, chunk_size=1)), [])
+        except Exception:
+            # Availability probe: treat transport / permission errors the same
+            # as "not available" rather than raising (matches the previous
+            # fsspec `exists` behavior).
             return False
+        return len(chunk) > 0
 
 
 class CFS_FX_Flux(CFS_FX):
@@ -754,7 +767,8 @@ class CFS_FX_Flux(CFS_FX):
     async_timeout : int, optional
         Total timeout in seconds for the entire fetch operation, by default 600.
     async_workers : int, optional
-        Maximum number of concurrent async fetch tasks, by default 16.
+        Maximum number of concurrent downloads. By default None, which
+        autoscales to the number of download tasks (capped at 32).
     retries : int, optional
         Number of retry attempts per failed fetch task with exponential
         backoff, by default 3.

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -631,6 +631,9 @@ class CFS_FX:
         str
             Path to the cached file on local disk.
         """
+        if byte_length is not None and byte_length < 0:
+            byte_length = None
+
         # Hash the original path string (bucket-prefixed for AWS, full HTTPS
         # URL for NOMADS) so warm caches populated before the obstore
         # migration remain valid

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-import functools
 import hashlib
 import os
 import pathlib
@@ -26,16 +24,23 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
+import obstore as obs
 import pygrib
-import s3fs
 import xarray as xr
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     _sync_async,
+    async_retry,
+    cancellable_to_thread,
     datasource_cache_root,
+    gather_with_concurrency,
+    obstore_fetch_to_cache,
+    obstore_store_from_url,
     prep_forecast_inputs,
+    resolve_async_workers,
 )
 from earth2studio.lexicon import GEFSLexicon, GEFSLexiconSel
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
@@ -69,8 +74,8 @@ class GEFS_FX:
         GEFS member. Options are: control gec00 (control), gepNN (forecast member NN,
         e.g. gep01, gep02,...), by default "gec00"
     max_workers : int, optional
-        Max works in async io thread pool. Only applied when using sync call function
-        and will modify the default async loop if one exists, by default 24
+        Deprecated, use async_workers instead. Kept for API compatibility, by
+        default 24
     cache : bool, optional
         Cache data source on local memory, by default True
     verbose : bool, optional
@@ -78,6 +83,11 @@ class GEFS_FX:
     async_timeout : int, optional
         Time in sec after which download will be cancelled if not finished successfully,
         by default 600
+    async_workers : int, optional
+        Maximum number of concurrent downloads. By default None, which autoscales
+        to the number of download tasks (capped at 32)
+    retries : int, optional
+        Number of retries for each download task on transient errors, by default 3
 
     Warning
     -------
@@ -118,10 +128,14 @@ class GEFS_FX:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
+        async_workers: int | None = None,
+        retries: int = 3,
     ):
         self._cache = cache
         self._verbose = verbose
         self._max_workers = max_workers
+        self._async_workers = async_workers
+        self._retries = retries
         self._tmp_cache_hash: str | None = None
 
         if member not in self.GEFS_MEMBERS:
@@ -133,17 +147,20 @@ class GEFS_FX:
         self.async_timeout = async_timeout
         self.lexicon = GEFSLexicon
 
-        self.fs: s3fs.S3FileSystem | None = None
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialization of zarr group
+        """Async initialization of the object store
 
         Note
         ----
-        Async fsspec expects initialization inside of the execution loop
+        Unlike async fsspec filesystems, obstore stores are event-loop
+        independent and could be built in ``__init__``; kept as a lazy async
+        method to preserve the initialization seam.
         """
-        self.fs = s3fs.S3FileSystem(
-            anon=True, client_kwargs={}, asynchronous=True, skip_instance_cache=True
+        self.store = obstore_store_from_url(
+            f"s3://{self.GEFS_BUCKET_NAME}",
+            max_pool_connections=self._async_workers or 32,
         )
 
     def __call__(
@@ -203,7 +220,8 @@ class GEFS_FX:
         xr.DataArray
             GEFS forecast data array
         """
-        if self.fs is None:
+        # Lazily initialize the object store on first use
+        if self.store is None:
             await self._async_init()
 
         time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
@@ -213,12 +231,6 @@ class GEFS_FX:
         # Make sure input time is valid
         self._validate_time(time)
         self._validate_leadtime(lead_time)
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        if isinstance(self.fs, s3fs.S3FileSystem):
-            session = await self.fs.set_session(refresh=True)
-        else:
-            session = None
 
         # Note, this could be more memory efficient and avoid pre-allocation of the array
         # but this is much much cleaner to deal with, compared to something seen in the
@@ -243,19 +255,16 @@ class GEFS_FX:
             },
         )
 
-        async_tasks = []
         async_tasks = await self._create_tasks(time, lead_time, variable)
-        func_map = map(
-            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
-        )
+        coros = [self.fetch_wrapper(task, xr_array=xr_array) for task in async_tasks]
 
-        await tqdm.gather(
-            *func_map, desc="Fetching GEFS data", disable=(not self._verbose)
+        await gather_with_concurrency(
+            coros,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
+            task_timeout=120.0,
+            desc="Fetching GEFS data",
+            verbose=(not self._verbose),
         )
-
-        # Close aiohttp client if s3fs
-        if session:
-            await session.close()
 
         return xr_array
 
@@ -289,9 +298,12 @@ class GEFS_FX:
             for lt in lead_time
             for p in products
         ]
-        func_map = map(self._fetch_index, args)
-        results = await tqdm.gather(
-            *func_map, desc="Fetching GEFS index files", disable=True
+        results = await gather_with_concurrency(
+            [self._fetch_index(uri) for uri in args],
+            max_workers=resolve_async_workers(self._async_workers, len(args)),
+            task_timeout=60.0,
+            desc="Fetching GEFS index files",
+            verbose=True,
         )
         for i, t in enumerate(time):
             for j, lt in enumerate(lead_time):
@@ -348,11 +360,16 @@ class GEFS_FX:
         xr_array: xr.DataArray,
     ) -> xr.DataArray:
         """Small wrapper to pack arrays into the DataArray"""
-        out = await self.fetch_array(
+        out = await async_retry(
+            self.fetch_array,
             task.gefs_file_uri,
             task.gefs_byte_offset,
             task.gefs_byte_length,
             task.gefs_modifier,
+            retries=self._retries,
+            backoff=1.0,
+            task_timeout=60.0,
+            exceptions=(OSError, IOError, TimeoutError, ConnectionError),
         )
         i, j, k = task.data_array_indices
         xr_array[i, j, k] = out
@@ -389,21 +406,9 @@ class GEFS_FX:
             byte_offset=byte_offset,
             byte_length=byte_length,
         )
-        # Open into xarray data-array
-        # Load with pygrib (faster and lower memory than xarray for slices)
-        try:
-            grbs = pygrib.open(grib_file)
-        except Exception as e:
-            logger.error(f"Failed to open grib file {grib_file}")
-            raise e
-        try:
-            values = modifier(grbs[1].values)
-        except Exception as e:
-            logger.error(f"Failed to read grib file {grib_file}")
-            raise e
-        finally:
-            grbs.close()
-        return values
+        # pygrib decode is blocking and GIL-bound; run in a thread with timeout
+        values = await cancellable_to_thread(_decode_gefs_grib, grib_file, timeout=30.0)
+        return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
         """Verify if date time is valid for GEFS based on offline knowledge
@@ -467,6 +472,8 @@ class GEFS_FX:
         with open(index_file) as file:
             index_lines = [line.rstrip() for line in file]
         # Add dummy variable at end of file with max offset so algo below works
+        # This gives the last record a negative byte length, which downstream
+        # maps to byte_length=None (read from offset to end of object)
         index_lines.append("xx:-1:d=xx:NULL:NULL:NULL:NULL")
         index_table: dict[str, tuple[int, int]] = {}
 
@@ -493,26 +500,23 @@ class GEFS_FX:
         self, path: str, byte_offset: int = 0, byte_length: int | None = None
     ) -> str:
         """Fetches remote file into cache"""
-        if self.fs is None:
-            raise ValueError("File system is not initialized")
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
+        # Hash the bucket-prefixed path (not the store-relative key) so warm
+        # caches populated before the obstore migration remain valid
         sha = hashlib.sha256((path + str(byte_offset)).encode())
         filename = sha.hexdigest()
-        cache_path = os.path.join(self.cache, filename)
 
-        if not pathlib.Path(cache_path).is_file():
-            if self.fs.async_impl:
-                if byte_length:
-                    byte_length = int(byte_offset + byte_length)
-                data = await self.fs._cat_file(path, start=byte_offset, end=byte_length)
-            else:
-                data = await asyncio.to_thread(
-                    self.fs.read_block, path, offset=byte_offset, length=byte_length
-                )
-            with open(cache_path, "wb") as file:
-                await asyncio.to_thread(file.write, data)
-
-        return cache_path
+        key = path.removeprefix(self.GEFS_BUCKET_NAME + "/")
+        return await obstore_fetch_to_cache(
+            self.store,
+            key,
+            self.cache,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+            cache_key=filename,
+        )
 
     def _grib_uri(
         self, time: datetime, lead_time: timedelta, product: str = "pgrb2a"
@@ -579,14 +583,14 @@ class GEFS_FX:
             _ds = np.timedelta64(1, "s")
             time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
 
-        fs = s3fs.S3FileSystem(anon=True)
+        store = obstore_store_from_url(f"s3://{cls.GEFS_BUCKET_NAME}")
         # Object store directory for given time
-        # Just picking the first variable to look for
-        file_name = f"gefs.{time.year}{time.month:0>2}{time.day:0>2}/{time.hour:0>2}/atmos/{cls.GEFS_CHECK_PRODUCT}/"
-        s3_uri = f"s3://{cls.GEFS_BUCKET_NAME}/{file_name}"
-        exists = fs.exists(s3_uri)
+        # Just picking the first product to look for
+        prefix = f"gefs.{time.year}{time.month:0>2}{time.day:0>2}/{time.hour:0>2}/atmos/{cls.GEFS_CHECK_PRODUCT}/"
+        # obs.list yields chunks (lists) of entries; one entry proves existence
+        chunk: list = next(iter(obs.list(store, prefix=prefix, chunk_size=1)), [])
 
-        return exists
+        return len(chunk) > 0
 
 
 class GEFS_FX_721x1440(GEFS_FX):
@@ -604,8 +608,8 @@ class GEFS_FX_721x1440(GEFS_FX):
         GEFS member. Options are: control gec00 (control), gepNN (forecast member NN,
         e.g. gep01, gep02,...), by default "gec00"
     max_workers : int, optional
-        Max works in async io thread pool. Only applied when using sync call function
-        and will modify the default async loop if one exists, by default 24
+        Deprecated, use async_workers instead. Kept for API compatibility, by
+        default 24
     cache : bool, optional
         Cache data source on local memory, by default True
     verbose : bool, optional
@@ -613,6 +617,11 @@ class GEFS_FX_721x1440(GEFS_FX):
     async_timeout : int, optional
         Time in sec after which download will be cancelled if not finished successfully,
         by default 600
+    async_workers : int, optional
+        Maximum number of concurrent downloads. By default None, which autoscales
+        to the number of download tasks (capped at 32)
+    retries : int, optional
+        Number of retries for each download task on transient errors, by default 3
 
     Warning
     -------
@@ -654,6 +663,8 @@ class GEFS_FX_721x1440(GEFS_FX):
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
+        async_workers: int | None = None,
+        retries: int = 3,
     ):
         super().__init__(
             member=member,
@@ -661,6 +672,8 @@ class GEFS_FX_721x1440(GEFS_FX):
             cache=cache,
             verbose=verbose,
             async_timeout=async_timeout,
+            async_workers=async_workers,
+            retries=retries,
         )
         self._product_resolution = "0p25"
         self.lexicon = GEFSLexiconSel  # type: ignore
@@ -707,3 +720,34 @@ class GEFS_FX_721x1440(GEFS_FX):
                     raise ValueError(
                         f"Requested lead time {delta} needs to be 3 hour interval for first 10 days in GEFS 0.25 degree data"
                     )
+
+
+def _decode_gefs_grib(grib_file: str) -> np.ndarray:
+    """Decode a single-message GEFS grib file into a numpy array.
+
+    Module-level so it can be dispatched to a worker thread and patched in
+    offline tests. Uses pygrib, which is faster and lower memory than
+    xarray/cfgrib for single-message slices.
+
+    Parameters
+    ----------
+    grib_file : str
+        Path to local grib file holding one message
+
+    Returns
+    -------
+    np.ndarray
+        Decoded field values
+    """
+    try:
+        grbs = pygrib.open(grib_file)
+    except Exception:
+        logger.error(f"Failed to open grib file {grib_file}")
+        raise
+    try:
+        return grbs[1].values
+    except Exception:
+        logger.error(f"Failed to read grib file {grib_file}")
+        raise
+    finally:
+        grbs.close()

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -85,7 +85,7 @@ class GEFS_FX:
         by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales
-        to the number of download tasks (capped at 32)
+        to the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 
@@ -160,7 +160,7 @@ class GEFS_FX:
         """
         self.store = obstore_store_from_url(
             f"s3://{self.GEFS_BUCKET_NAME}",
-            max_pool_connections=self._async_workers or 32,
+            max_pool_connections=self._async_workers or 64,
         )
 
     def __call__(
@@ -617,7 +617,7 @@ class GEFS_FX_721x1440(GEFS_FX):
         by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales
-        to the number of download tasks (capped at 32)
+        to the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -326,15 +326,14 @@ class GEFS_FX:
                         )
                         raise e
 
-                    # Get byte range from index
+                    # Get byte range from index. A byte length of None means
+                    # the record runs to the end of the file (read to EOF).
                     byte_offset = None
                     byte_length = None
                     for key, value in index_files[product].items():
                         if gefs_key in key:
                             byte_offset = value[0]
-                            byte_length = (
-                                None if value[1] < 0 else value[1]
-                            )  # Negative means to eof
+                            byte_length = value[1]
                             break
 
                     if byte_offset is None:
@@ -454,7 +453,7 @@ class GEFS_FX:
                         f"Requested lead time {delta} needs to be 6 hour interval for last 6 days in GEFS"
                     )
 
-    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int]]:
+    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int | None]]:
         """Fetch GEFS atmospheric index file
 
         Parameters
@@ -464,30 +463,29 @@ class GEFS_FX:
 
         Returns
         -------
-        dict[str, tuple[int, int]]
-            Dictionary of GEFS vairables (byte offset, byte length)
+        dict[str, tuple[int, int | None]]
+            Dictionary of GEFS variables (byte offset, byte length). The last
+            record has a byte length of ``None``, meaning read to end of file.
         """
         # Grab index file
         index_file = await self._fetch_remote_file(index_uri)
         with open(index_file) as file:
-            index_lines = [line.rstrip() for line in file]
-        # Add dummy variable at end of file with max offset so algo below works
-        # This gives the last record a negative byte length, which downstream
-        # maps to byte_length=None (read from offset to end of object)
-        index_lines.append("xx:-1:d=xx:NULL:NULL:NULL:NULL")
-        index_table: dict[str, tuple[int, int]] = {}
+            records = [
+                lsplit for line in file if len(lsplit := line.rstrip().split(":")) >= 7
+            ]
 
-        index_table = {}
-        for i, line in enumerate(index_lines[:-1]):
-            lsplit = line.split(":")
-            if len(lsplit) < 7:
-                continue
-
-            nlsplit = index_lines[i + 1].split(":")
-            byte_length = int(nlsplit[1]) - int(lsplit[1])
+        index_table: dict[str, tuple[int, int | None]] = {}
+        for i, lsplit in enumerate(records):
             byte_offset = int(lsplit[1])
+            # The final record runs to the end of the file (no next offset to
+            # bound it), signalled with a byte length of None (read to EOF).
+            byte_length: int | None
+            if i + 1 < len(records):
+                byte_length = int(records[i + 1][1]) - byte_offset
+            else:
+                byte_length = None
             key = f"{lsplit[0]}::{lsplit[3]}::{lsplit[4]}::{lsplit[5]}"
-            if byte_length > self.MAX_BYTE_SIZE:
+            if byte_length is not None and byte_length > self.MAX_BYTE_SIZE:
                 raise ValueError(
                     f"Byte length, {byte_length}, of variable {key} larger than safe threshold of {self.MAX_BYTE_SIZE}"
                 )

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -80,7 +80,7 @@ class GFS:
         by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales
-        to the number of download tasks (capped at 32)
+        to the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 
@@ -172,7 +172,7 @@ class GFS:
         """
         self.store = obstore_store_from_url(
             self._store_url,
-            max_pool_connections=self._async_workers or 32,
+            max_pool_connections=self._async_workers or 64,
         )
 
     def __call__(

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import hashlib
 import os
 import pathlib
@@ -28,7 +27,6 @@ import numpy as np
 import obstore as obs
 import pygrib
 import xarray as xr
-from fsspec.implementations.ftp import FTPFileSystem
 from loguru import logger
 from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
@@ -43,6 +41,7 @@ from earth2studio.data.utils import (
     obstore_store_from_url,
     prep_data_inputs,
     prep_forecast_inputs,
+    resolve_async_workers,
 )
 from earth2studio.lexicon import GFSLexicon
 from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
@@ -80,7 +79,8 @@ class GFS:
         Time in sec after which download will be cancelled if not finished successfully,
         by default 600
     async_workers : int, optional
-        Maximum number of concurrent downloads, by default 16
+        Maximum number of concurrent downloads. By default None, which autoscales
+        to the number of download tasks (capped at 32)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 
@@ -119,7 +119,7 @@ class GFS:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
-        async_workers: int = 16,
+        async_workers: int | None = None,
         retries: int = 3,
     ):
         self._cache = cache
@@ -131,7 +131,7 @@ class GFS:
         self.store: ObjectStore | None = None
         if source == "aws":
             self.uri_prefix = "noaa-gfs-bdp-pds"
-            self.fs: FTPFileSystem | None = None
+            self._store_url = f"s3://{self.GFS_BUCKET_NAME}"
 
             # To update search "gfs." at https://noaa-gfs-bdp-pds.s3.amazonaws.com/index.html
             # They are slowly adding more data
@@ -143,10 +143,11 @@ class GFS:
 
             self._history_range = _range
         elif source == "ncep":
-            # Could use http location, but using ftp since better for larger data
+            # NOMADS HTTPS mirror of the NCEP production feed, supports the
+            # ranged GETs obstore's HTTPStore issues for byte-range fetches
             # https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/
             self.uri_prefix = "pub/data/nccf/com/gfs/prod/"
-            self.fs = FTPFileSystem(host="ftpprd.ncep.noaa.gov")  # Not async
+            self._store_url = "https://nomads.ncep.noaa.gov"
 
             def _range(time: datetime) -> None:
                 if time + timedelta(days=10) < datetime.today():
@@ -170,8 +171,8 @@ class GFS:
         method to preserve the initialization seam.
         """
         self.store = obstore_store_from_url(
-            f"s3://{self.GFS_BUCKET_NAME}",
-            max_pool_connections=self._async_workers,
+            self._store_url,
+            max_pool_connections=self._async_workers or 32,
         )
 
     def __call__(
@@ -226,7 +227,7 @@ class GFS:
             GFS weather data array
         """
         # Lazily initialize the object store on first use
-        if self.store is None and self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time, variable = prep_data_inputs(time, variable)
@@ -258,7 +259,7 @@ class GFS:
 
         await gather_with_concurrency(
             coros,
-            max_workers=self._async_workers,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
             task_timeout=120.0,
             desc="Fetching GFS data",
             verbose=(not self._verbose),
@@ -289,7 +290,7 @@ class GFS:
         args = [self._grib_index_uri(t, lt) for t in time for lt in lead_time]
         results = await gather_with_concurrency(
             [self._fetch_index(uri) for uri in args],
-            max_workers=self._async_workers,
+            max_workers=resolve_async_workers(self._async_workers, len(args)),
             task_timeout=60.0,
             desc="Fetching GFS index files",
             verbose=True,
@@ -462,30 +463,19 @@ class GFS:
         sha = hashlib.sha256((path + str(byte_offset)).encode())
         filename = sha.hexdigest()
 
-        if self.store is not None:
-            key = path.removeprefix(self.GFS_BUCKET_NAME + "/")
-            return await obstore_fetch_to_cache(
-                self.store,
-                key,
-                self.cache,
-                byte_offset=byte_offset,
-                byte_length=byte_length,
-                cache_key=filename,
-            )
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
-        if self.fs is None:
-            raise ValueError("File system is not initialized")
-
-        # ncep FTP source (sync filesystem)
-        cache_path = os.path.join(self.cache, filename)
-        if not pathlib.Path(cache_path).is_file():
-            data = await asyncio.to_thread(
-                self.fs.read_block, path, offset=byte_offset, length=byte_length
-            )
-            with open(cache_path, "wb") as file:
-                await asyncio.to_thread(file.write, data)
-
-        return cache_path
+        # aws paths are bucket-prefixed; ncep paths are already store-relative
+        key = path.removeprefix(self.GFS_BUCKET_NAME + "/")
+        return await obstore_fetch_to_cache(
+            self.store,
+            key,
+            self.cache,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+            cache_key=filename,
+        )
 
     def _grib_uri(self, time: datetime, lead_time: timedelta) -> str:
         """Generates the URI for GFS grib files"""
@@ -653,7 +643,7 @@ class GFS_FX(GFS):
             GFS weather data array
         """
         # Lazily initialize the object store on first use
-        if self.store is None and self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
@@ -692,7 +682,7 @@ class GFS_FX(GFS):
 
         await gather_with_concurrency(
             coros,
-            max_workers=self._async_workers,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
             task_timeout=120.0,
             desc="Fetching GFS data",
             verbose=(not self._verbose),

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-import functools
 import hashlib
 import os
 import pathlib
@@ -24,20 +22,25 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-import gcsfs
 import numpy as np
+import obstore as obs
 import pygrib
-import s3fs
 import xarray as xr
-from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     _sync_async,
+    async_retry,
+    cancellable_to_thread,
     datasource_cache_root,
+    gather_with_concurrency,
+    obstore_fetch_to_cache,
+    obstore_store_from_url,
     prep_data_inputs,
     prep_forecast_inputs,
+    resolve_async_workers,
 )
 from earth2studio.lexicon import HRRRFXLexicon, HRRRLexicon
 from earth2studio.utils.imports import (
@@ -93,8 +96,7 @@ class HRRR:
     source : str, optional
         Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
     max_workers : int, optional
-        Max works in async io thread pool. Only applied when using sync call function
-        and will modify the default async loop if one exists, by default 24
+        Deprecated, has no effect. Kept for API compatibility, by default 24
     cache : bool, optional
         Cache data source on local memory, by default True
     verbose : bool, optional
@@ -102,6 +104,11 @@ class HRRR:
     async_timeout : int, optional
         Time in sec after which download will be cancelled if not finished successfully,
         by default 600
+    async_workers : int, optional
+        Maximum number of concurrent downloads. By default None, which autoscales to
+        the number of download tasks (capped at 32)
+    retries : int, optional
+        Number of retries for each download task on transient errors, by default 3
 
     Warning
     -------
@@ -140,11 +147,15 @@ class HRRR:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
+        async_workers: int | None = None,
+        retries: int = 3,
     ):
         self._source = source
         self._cache = cache
         self._verbose = verbose
         self._max_workers = max_workers
+        self._async_workers = async_workers
+        self._retries = retries
 
         self.lexicon = HRRRLexicon
         self.async_timeout = async_timeout
@@ -196,41 +207,29 @@ class HRRR:
         else:
             raise ValueError(f"Invalid HRRR source { self._source}")
 
-        # Filesystem is lazily initialized on first call
-        self.fs: s3fs.S3FileSystem | gcsfs.GCSFileSystem | HTTPFileSystem | None = None
+        # Object store is lazily initialized on first call
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialization of fsspec file stores
+        """Async initialization of the object store
 
         Note
         ----
-        Async fsspec expects initialization inside of the execution loop
+        Unlike async fsspec filesystems, obstore stores are event-loop
+        independent and could be built in ``__init__``; kept as a lazy async
+        method to preserve the initialization seam.
         """
         if self._source == "aws":
-            self.fs = s3fs.S3FileSystem(
-                anon=self.HRRR_BUCKET_ANON,
-                client_kwargs={},
-                asynchronous=True,
-                skip_instance_cache=True,
-            )
+            store_url = f"s3://{self.HRRR_BUCKET_NAME}"
         elif self._source == "google":
-            fs = gcsfs.GCSFileSystem(
-                cache_timeout=-1,
-                token=(
-                    "anon" if self.HRRR_BUCKET_ANON else None
-                ),  # noqa: S106 # nosec B106
-                access="read_only",
-                block_size=8**20,
-            )
-            fs._loop = asyncio.get_event_loop()
-            self.fs = fs
-        elif self._source == "azure":
-            raise NotImplementedError(
-                "Azure data source not implemented yet, open an issue if needed"
-            )
-        elif self._source == "nomads":
-            # HTTP file system, tried FTP but didnt work
-            self.fs = HTTPFileSystem(asynchronous=True)
+            store_url = f"gs://{self.uri_prefix}"
+        else:  # nomads
+            store_url = self.uri_prefix.rstrip("/")
+        self.store = obstore_store_from_url(
+            store_url,
+            anonymous=self.HRRR_BUCKET_ANON,
+            max_pool_connections=self._async_workers or 32,
+        )
 
     def __call__(
         self,
@@ -283,7 +282,8 @@ class HRRR:
         xr.DataArray
             HRRR weather data array
         """
-        if self.fs is None:
+        # Lazily initialize the object store on first use
+        if self.store is None:
             await self._async_init()
 
         time, variable = prep_data_inputs(time, variable)
@@ -292,12 +292,6 @@ class HRRR:
 
         # Make sure input time is valid
         self._validate_time(time)
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        if isinstance(self.fs, s3fs.S3FileSystem):
-            session = await self.fs.set_session(refresh=True)
-        else:
-            session = None
 
         # Generate HRRR lat-lon grid to append onto data array
         lat, lon = self.grid()
@@ -327,18 +321,16 @@ class HRRR:
         xr_array["hrrr_y"].attrs = {"standard_name": "latitude", "axis": "Y"}
         xr_array["hrrr_x"].attrs = {"standard_name": "longitude", "axis": "X"}
 
-        async_tasks = []
         async_tasks = await self._create_tasks(time, [timedelta(hours=0)], variable)
-        func_map = map(
-            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
-        )
+        coros = [self.fetch_wrapper(task, xr_array=xr_array) for task in async_tasks]
 
-        await tqdm.gather(
-            *func_map, desc="Fetching HRRR data", disable=(not self._verbose)
+        await gather_with_concurrency(
+            coros,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
+            task_timeout=120.0,
+            desc="Fetching HRRR data",
+            verbose=(not self._verbose),
         )
-
-        if session:
-            await session.close()
 
         xr_array = xr_array.isel(lead_time=0)
         del xr_array.coords["lead_time"]
@@ -373,9 +365,13 @@ class HRRR:
             for lt in lead_time
             for p in products
         ]
-        func_map = map(self._fetch_index, args)
-        results = await tqdm.gather(
-            *func_map, desc="Fetching HRRR index files", disable=True
+        index_coros = [self._fetch_index(uri) for uri in args]
+        results = await gather_with_concurrency(
+            index_coros,
+            max_workers=resolve_async_workers(self._async_workers, len(index_coros)),
+            task_timeout=60.0,
+            desc="Fetching HRRR index files",
+            verbose=True,
         )
         for i, t in enumerate(time):
             for j, lt in enumerate(lead_time):
@@ -447,11 +443,16 @@ class HRRR:
         xr_array: xr.DataArray,
     ) -> xr.DataArray:
         """Small wrapper to pack arrays into the DataArray"""
-        out = await self.fetch_array(
+        out = await async_retry(
+            self.fetch_array,
             task.hrrr_file_uri,
             task.hrrr_byte_offset,
             task.hrrr_byte_length,
             task.hrrr_modifier,
+            retries=self._retries,
+            backoff=1.0,
+            task_timeout=60.0,
+            exceptions=(OSError, IOError, TimeoutError, ConnectionError),
         )
         i, j, k = task.data_array_indices
         xr_array[i, j, k] = out
@@ -478,8 +479,8 @@ class HRRR:
 
         Returns
         -------
-        xr.DataArray
-            FS data array for given time and lead time
+        np.ndarray
+            HRRR array for given time and lead time
         """
         logger.debug(f"Fetching HRRR grib file: {grib_uri} {byte_offset}-{byte_length}")
         # Download the grib file to cache
@@ -488,21 +489,9 @@ class HRRR:
             byte_offset=byte_offset,
             byte_length=byte_length,
         )
-        # Load with pygrib, xarray with cfgrib is 10x slower and leaks memory
-        try:
-            grbs = pygrib.open(grib_file)
-        except Exception as e:
-            logger.error(f"Failed to open grib file {grib_file}")
-            raise e
-        try:
-            values = modifier(grbs[1].values)
-        except Exception as e:
-            logger.error(f"Failed to read grib file {grib_file}")
-            raise e
-        finally:
-            grbs.close()
-
-        return values
+        # pygrib decode is blocking and GIL-bound; run in a thread with timeout
+        values = await cancellable_to_thread(_decode_hrrr_grib, grib_file, timeout=30.0)
+        return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
         """Verify if date time is valid for HRRR based on offline knowledge
@@ -569,32 +558,28 @@ class HRRR:
         self, path: str, byte_offset: int = 0, byte_length: int | None = None
     ) -> str:
         """Fetches remote file into cache"""
-        if self.fs is None:
-            raise ValueError("File system is not initialized")
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
+        # Hash the original prefixed uri (not the store-relative key) so warm
+        # caches populated before the obstore migration remain valid
         sha = hashlib.sha256((path + str(byte_offset)).encode())
         filename = sha.hexdigest()
-        cache_path = os.path.join(self.cache, filename)
 
+        # Strip the bucket / url prefix to get the store-relative key
+        key = path.removeprefix(self.uri_prefix).lstrip("/")
         try:
-            if not pathlib.Path(cache_path).is_file():
-                if self.fs.async_impl:
-                    if byte_length:
-                        byte_length = int(byte_offset + byte_length)
-                    data = await self.fs._cat_file(
-                        path, start=byte_offset, end=byte_length
-                    )
-                else:
-                    data = await asyncio.to_thread(
-                        self.fs.read_block, path, offset=byte_offset, length=byte_length
-                    )
-                with open(cache_path, "wb") as file:
-                    await asyncio.to_thread(file.write, data)
+            return await obstore_fetch_to_cache(
+                self.store,
+                key,
+                self.cache,
+                byte_offset=byte_offset,
+                byte_length=byte_length,
+                cache_key=filename,
+            )
         except FileNotFoundError as e:
             logger.error(f"Failed to download file {path}, not found")
             raise e
-
-        return cache_path
 
     def _grib_uri(
         self, time: datetime, lead_time: timedelta, product: str = "wrfsfc"
@@ -693,15 +678,18 @@ class HRRR:
             _ds = np.timedelta64(1, "s")
             time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
 
-        fs = s3fs.S3FileSystem(anon=cls.HRRR_BUCKET_ANON)
-        # Object store directory for given time
+        store = obstore_store_from_url(
+            f"s3://{cls.HRRR_BUCKET_NAME}", anonymous=cls.HRRR_BUCKET_ANON
+        )
+        # Object store key for given time
         # Just picking the first variable to look for
         file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus"
         file_name = f"{file_name}/hrrr.t{time.hour:0>2}z.wrfnatf00.grib2.idx"
-        s3_uri = f"s3://{cls.HRRR_BUCKET_NAME}/{file_name}"
-        exists = fs.exists(s3_uri)
-
-        return exists
+        try:
+            obs.head(store, file_name)
+        except (FileNotFoundError, obs.exceptions.NotFoundError):
+            return False
+        return True
 
 
 class HRRR_FX(HRRR):
@@ -716,8 +704,7 @@ class HRRR_FX(HRRR):
     source : str, optional
         Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
     max_workers : int, optional
-        Max works in async io thread pool. Only applied when using sync call function
-        and will modify the default async loop if one exists, by default 24
+        Deprecated, has no effect. Kept for API compatibility, by default 24
     cache : bool, optional
         Cache data source on local memory, by default True
     verbose : bool, optional
@@ -725,6 +712,11 @@ class HRRR_FX(HRRR):
     async_timeout : int, optional
         Time in sec after which download will be cancelled if not finished successfully,
         by default 600
+    async_workers : int, optional
+        Maximum number of concurrent downloads. By default None, which autoscales to
+        the number of download tasks (capped at 32)
+    retries : int, optional
+        Number of retries for each download task on transient errors, by default 3
 
     Warning
     -------
@@ -756,6 +748,8 @@ class HRRR_FX(HRRR):
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
+        async_workers: int | None = None,
+        retries: int = 3,
     ):
         super().__init__(
             source=source,
@@ -763,6 +757,8 @@ class HRRR_FX(HRRR):
             cache=cache,
             verbose=verbose,
             async_timeout=async_timeout,
+            async_workers=async_workers,
+            retries=retries,
         )
         self.lexicon = HRRRFXLexicon  # type: ignore
 
@@ -823,7 +819,8 @@ class HRRR_FX(HRRR):
         xr.DataArray
             HRRR forecast data array
         """
-        if self.fs is None:
+        # Lazily initialize the object store on first use
+        if self.store is None:
             await self._async_init()
 
         time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
@@ -833,12 +830,6 @@ class HRRR_FX(HRRR):
         # Make sure input time is valid
         self._validate_time(time)
         self._validate_leadtime(time, lead_time)
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        if isinstance(self.fs, s3fs.S3FileSystem):
-            session = await self.fs.set_session(refresh=True)
-        else:
-            session = None
 
         # Generate HRRR lat-lon grid to append onto data array
         lat, lon = self.grid()
@@ -869,18 +860,16 @@ class HRRR_FX(HRRR):
         xr_array["hrrr_y"].attrs = {"standard_name": "latitude", "axis": "Y"}
         xr_array["hrrr_x"].attrs = {"standard_name": "longitude", "axis": "X"}
 
-        async_tasks = []
         async_tasks = await self._create_tasks(time, lead_time, variable)
-        func_map = map(
-            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
-        )
+        coros = [self.fetch_wrapper(task, xr_array=xr_array) for task in async_tasks]
 
-        await tqdm.gather(
-            *func_map, desc="Fetching HRRR data", disable=(not self._verbose)
+        await gather_with_concurrency(
+            coros,
+            max_workers=resolve_async_workers(self._async_workers, len(coros)),
+            task_timeout=120.0,
+            desc="Fetching HRRR data",
+            verbose=(not self._verbose),
         )
-
-        if session:
-            await session.close()
 
         return xr_array
 
@@ -914,3 +903,34 @@ class HRRR_FX(HRRR):
                     raise ValueError(
                         f"Requested lead time {delta} can only be between [0,18] hours for HRRR forecast not on 6 hour interval {time}"
                     )
+
+
+def _decode_hrrr_grib(grib_file: str) -> np.ndarray:
+    """Decode a single-message HRRR grib file into a numpy array.
+
+    Module-level so it can be dispatched to a worker thread and patched in
+    offline tests. Uses pygrib, which is faster and lower memory than
+    xarray/cfgrib for single-message slices.
+
+    Parameters
+    ----------
+    grib_file : str
+        Path to local grib file holding one message
+
+    Returns
+    -------
+    np.ndarray
+        Decoded field values
+    """
+    try:
+        grbs = pygrib.open(grib_file)
+    except Exception:
+        logger.error(f"Failed to open grib file {grib_file}")
+        raise
+    try:
+        return grbs[1].values
+    except Exception:
+        logger.error(f"Failed to read grib file {grib_file}")
+        raise
+    finally:
+        grbs.close()

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -106,7 +106,7 @@ class HRRR:
         by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales to
-        the number of download tasks (capped at 32)
+        the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 
@@ -228,7 +228,7 @@ class HRRR:
         self.store = obstore_store_from_url(
             store_url,
             anonymous=self.HRRR_BUCKET_ANON,
-            max_pool_connections=self._async_workers or 32,
+            max_pool_connections=self._async_workers or 64,
         )
 
     def __call__(
@@ -714,7 +714,7 @@ class HRRR_FX(HRRR):
         by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales to
-        the number of download tasks (capped at 32)
+        the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 

--- a/earth2studio/data/ncar.py
+++ b/earth2studio/data/ncar.py
@@ -20,22 +20,29 @@ import hashlib
 import os
 import shutil
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+import obstore as obs
 import pandas as pd
-import s3fs
 import xarray as xr
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     _sync_async,
+    async_retry,
+    cancellable_to_thread,
     datasource_cache_root,
+    gather_with_concurrency,
+    obstore_store_from_url,
     prep_data_inputs,
+    resolve_async_workers,
 )
 from earth2studio.lexicon import NCAR_ERA5Lexicon
 from earth2studio.utils.type import TimeArray, VariableArray
@@ -66,14 +73,19 @@ class NCAR_ERA5:
     Parameters
     ----------
     max_workers : int, optional
-        Max works in async io thread pool. Only applied when using sync call function
-        and will modify the default async loop if one exists, by default 24
+        Deprecated, retained for backwards compatibility. Use async_workers to
+        control download concurrency, by default 24
     cache : bool, optional
             Cache data source on local memory, by default True
     verbose : bool, optional
         Print download progress, by default True
     async_timeout : int, optional
         Timeout in seconds for async operations, by default 600
+    async_workers : int, optional
+        Maximum number of concurrent downloads. By default None, which autoscales
+        to the number of download tasks (capped at 32)
+    retries : int, optional
+        Number of retries for each download task on transient errors, by default 3
 
 
     Warning
@@ -91,6 +103,8 @@ class NCAR_ERA5:
     region:global dataclass:reanalysis product:wind product:precip product:temp product:atmos
     """
 
+    NCAR_ERA5_BUCKET_NAME = "nsf-ncar-era5"
+
     NCAR_EAR5_LAT = np.linspace(90, -90, 721)
     NCAR_EAR5_LON = np.linspace(0, 360, 1440, endpoint=False)
 
@@ -100,12 +114,35 @@ class NCAR_ERA5:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
+        async_workers: int | None = None,
+        retries: int = 3,
     ):
         self._max_workers = max_workers
         self._cache = cache
         self._verbose = verbose
+        self._async_workers = async_workers
+        self._retries = retries
         self.async_timeout = async_timeout
         self._tmp_cache_hash: str | None = None
+
+        self.store: ObjectStore | None = None
+
+    async def _async_init(self) -> None:
+        """Async initialization of the object store
+
+        Note
+        ----
+        Unlike async fsspec filesystems, obstore stores are event-loop
+        independent and could be built in ``__init__``; kept as a lazy async
+        method to preserve the initialization seam.
+        """
+        # nsf-ncar-era5 lives in us-west-2; obstore does not follow S3 region
+        # redirects, so the helper's us-east-1 default must be overridden
+        self.store = obstore_store_from_url(
+            f"s3://{self.NCAR_ERA5_BUCKET_NAME}",
+            max_pool_connections=self._async_workers or 32,
+            region="us-west-2",
+        )
 
     def __call__(
         self,
@@ -159,6 +196,10 @@ class NCAR_ERA5:
         xr.DataArray
             ERA5 weather data array from ARCO
         """
+        # Lazily initialize the object store on first use
+        if self.store is None:
+            await self._async_init()
+
         time, variable = prep_data_inputs(time, variable)
         # Create cache dir if doesnt exist
         Path(self.cache).mkdir(parents=True, exist_ok=True)
@@ -174,8 +215,11 @@ class NCAR_ERA5:
             async_tasks.append(future)
 
         # Now wait
-        results = await tqdm.gather(
-            *async_tasks, desc="Fetching NCAR ERA5 data", disable=(not self._verbose)
+        results = await gather_with_concurrency(
+            async_tasks,
+            max_workers=resolve_async_workers(self._async_workers, len(async_tasks)),
+            desc="Fetching NCAR ERA5 data",
+            verbose=(not self._verbose),
         )
         # Group based on variable
         for result in results:
@@ -346,12 +390,16 @@ class NCAR_ERA5:
         task: NCARAsyncTask,
     ) -> xr.DataArray:
         """Small wrapper to pack arrays into the DataArray"""
-        out = await self.fetch_array(
+        out = await async_retry(
+            self.fetch_array,
             task.ncar_file_uri,
             task.ncar_data_variable,
             list(task.ncar_time_indices.keys()),
             list(task.ncar_level_indices.keys()),
             task.ncar_meta,
+            retries=self._retries,
+            backoff=1.0,
+            exceptions=(OSError, IOError, TimeoutError, ConnectionError),
         )
         # Rename levels coord to variable
         out = out.rename({"level": "variable", "longitude": "lon", "latitude": "lat"})
@@ -411,79 +459,28 @@ class NCAR_ERA5:
                 xr.open_dataarray, cache_path, engine="h5netcdf", cache=False
             )
         else:
-            ds = await asyncio.to_thread(
-                self._read_s3_dataset,
-                nc_file_uri,
+            if self.store is None:
+                raise ValueError("Object store is not initialized")
+            # Bucket-relative object key for the obstore store
+            nc_key = nc_file_uri.removeprefix(f"s3://{self.NCAR_ERA5_BUCKET_NAME}/")
+            # h5netcdf / h5py decode is blocking and GIL-bound; run in a thread
+            # with a timeout. The read also performs the network byte-range
+            # requests, hence the generous timeout compared to grib decodes
+            ds = await cancellable_to_thread(
+                _read_object_store_dataset,
+                self.store,
+                nc_key,
                 data_variable,
                 time_idx,
                 level_idx,
                 ncar_meta,
+                timeout=300.0,
             )
             # Cache nc file if present
             if self._cache:
                 await asyncio.to_thread(ds.to_netcdf, cache_path, engine="h5netcdf")
 
         return ds
-
-    @staticmethod
-    def _read_s3_dataset(
-        nc_file_uri: str,
-        data_variable: str,
-        time_idx: list[int],
-        level_idx: list[int],
-        ncar_meta: dict[int, dict[str, Any]],
-    ) -> xr.DataArray:
-        """Read and subset an S3-hosted NetCDF file synchronously.
-
-        This must run in a worker thread (via ``asyncio.to_thread``) because it
-        uses a synchronous S3FileSystem which internally calls
-        ``fsspec.asyn.sync()`` — that would cause a re-entrance error if called
-        from fsspec's IO loop directly.
-        """
-        fs = s3fs.S3FileSystem(anon=True, asynchronous=False, skip_instance_cache=True)
-        with fs.open(nc_file_uri, "rb", block_size=4 * 1400 * 720) as f:
-            ds = xr.open_dataset(f, engine="h5netcdf", cache=False)
-            # Sometimes data field have VAR_ prepended
-            if f"VAR_{data_variable}" in ds:
-                data_variable = f"VAR_{data_variable}"
-
-            if data_variable not in ds:
-                raise ValueError(
-                    f"Variable '{data_variable}' or 'VAR_{data_variable}' from task not found in dataset. "
-                    + f"Available variables: {list(ds.keys())}."
-                )
-
-            # Pressure level variable
-            if "level" in ds.dims:
-                da = ds.isel(time=list(time_idx), level=list(level_idx))[data_variable]
-            # Other product indexing
-            else:
-                if "e5.oper.an.sfc" in nc_file_uri:
-                    da = ds.isel(time=list(time_idx))[data_variable]
-                elif "e5.oper.fc.sfc.accumu" in nc_file_uri:
-                    # This is annoying here because we are dealing with mapping
-                    # two dimensions to a single time coord
-                    outputs = []
-                    ds_var = ds[data_variable]
-                    for i in time_idx:
-                        out = ds_var.sel(forecast_hour=ncar_meta[i]["forecast_hour"])
-                        out = out.sel(
-                            forecast_initial_time=ncar_meta[i]["forecast_initial_time"]
-                        )
-                        out = out.expand_dims({"time": [ncar_meta[i]["time"]]}, axis=0)
-                        out = out.drop_vars(
-                            ["forecast_hour", "forecast_initial_time"],
-                            errors="ignore",
-                        )
-                        outputs.append(out)
-                    da = xr.concat(outputs, dim="time", coords="minimal")
-                else:
-                    raise ValueError("Unknown product")
-
-                da = da.expand_dims({"level": [0]}, axis=1)
-            # Load the data — this is the actual download
-            da = da.load()
-        return da
 
     @classmethod
     def _validate_time(cls, times: list[datetime]) -> None:
@@ -516,3 +513,167 @@ class NCAR_ERA5:
                 cache_location, f"tmp_ncar_{self._tmp_cache_hash}"
             )
         return cache_location
+
+
+class _ObstoreBlockCachedIO:
+    """Block-cached file-like adapter over an obstore object for h5py.
+
+    h5py issues many small scattered reads (metadata b-tree walks plus data
+    chunks) against the multi-GB NetCDF objects; issuing one ranged GET per
+    read makes the decode latency-bound. This shim serves reads from
+    fixed-size blocks fetched via ``obs.get_range`` and kept in a small LRU —
+    the same access pattern fsspec's block cache provided before the obstore
+    migration. Returns plain ``bytes`` as h5py's file-object driver requires.
+    """
+
+    def __init__(
+        self,
+        store: ObjectStore,
+        key: str,
+        size: int,
+        block_size: int = 8 * 1024 * 1024,
+        max_blocks: int = 16,
+    ):
+        self._store = store
+        self._key = key
+        self._size = size
+        self._block_size = block_size
+        self._max_blocks = max_blocks
+        self._blocks: OrderedDict[int, bytes] = OrderedDict()
+        self._pos = 0
+
+    def _block(self, index: int) -> bytes:
+        block = self._blocks.get(index)
+        if block is None:
+            start = index * self._block_size
+            end = min(start + self._block_size, self._size)
+            block = bytes(obs.get_range(self._store, self._key, start=start, end=end))
+            self._blocks[index] = block
+            if len(self._blocks) > self._max_blocks:
+                self._blocks.popitem(last=False)
+        else:
+            self._blocks.move_to_end(index)
+        return block
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = self._size - self._pos
+        size = max(0, min(size, self._size - self._pos))
+        out = bytearray()
+        while size > 0:
+            index, offset = divmod(self._pos, self._block_size)
+            chunk = self._block(index)[offset : offset + size]
+            out += chunk
+            self._pos += len(chunk)
+            size -= len(chunk)
+        return bytes(out)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        if whence == 0:
+            self._pos = offset
+        elif whence == 1:
+            self._pos += offset
+        elif whence == 2:
+            self._pos = self._size + offset
+        else:
+            raise ValueError(f"Invalid whence {whence}")
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def close(self) -> None:
+        self._blocks.clear()
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+
+def _read_object_store_dataset(
+    store: ObjectStore,
+    nc_key: str,
+    data_variable: str,
+    time_idx: list[int],
+    level_idx: list[int],
+    ncar_meta: dict[int, dict[str, Any]],
+) -> xr.DataArray:
+    """Read and subset an S3-hosted NetCDF file synchronously via obstore.
+
+    Only the byte ranges h5py requests are downloaded (block-cached ranged
+    reads via :class:`_ObstoreBlockCachedIO`), never the whole multi-GB
+    NetCDF object.
+    Module-level so it can be dispatched to a worker thread (via
+    ``cancellable_to_thread``) and patched in offline tests; the h5py decode
+    is blocking and GIL-bound.
+
+    Parameters
+    ----------
+    store : ObjectStore
+        Object store rooted at the NCAR ERA5 bucket
+    nc_key : str
+        Bucket-relative key of the NetCDF file
+    data_variable : str
+        Data variable name of the array to use in the NetCDF file
+    time_idx : list[int]
+        Time indexes (hours since start time of file)
+    level_idx : list[int]
+        Pressure level indices if applicable
+    ncar_meta : dict[int, dict[str, Any]]
+        Per time index metadata, only used for accumulated products
+
+    Returns
+    -------
+    xr.DataArray
+        Data array loaded from requested file
+    """
+    try:
+        size = int(obs.head(store, nc_key)["size"])
+    except (FileNotFoundError, obs.exceptions.NotFoundError):
+        raise FileNotFoundError(f"Object {nc_key} not found in store")
+    with xr.open_dataset(
+        _ObstoreBlockCachedIO(store, nc_key, size), engine="h5netcdf", cache=False
+    ) as ds:
+        # Sometimes data field have VAR_ prepended
+        if f"VAR_{data_variable}" in ds:
+            data_variable = f"VAR_{data_variable}"
+
+        if data_variable not in ds:
+            raise ValueError(
+                f"Variable '{data_variable}' or 'VAR_{data_variable}' from task not found in dataset. "
+                + f"Available variables: {list(ds.keys())}."
+            )
+
+        # Pressure level variable
+        if "level" in ds.dims:
+            da = ds.isel(time=list(time_idx), level=list(level_idx))[data_variable]
+        # Other product indexing
+        else:
+            if "e5.oper.an.sfc" in nc_key:
+                da = ds.isel(time=list(time_idx))[data_variable]
+            elif "e5.oper.fc.sfc.accumu" in nc_key:
+                # This is annoying here because we are dealing with mapping
+                # two dimensions to a single time coord
+                outputs = []
+                ds_var = ds[data_variable]
+                for i in time_idx:
+                    out = ds_var.sel(forecast_hour=ncar_meta[i]["forecast_hour"])
+                    out = out.sel(
+                        forecast_initial_time=ncar_meta[i]["forecast_initial_time"]
+                    )
+                    out = out.expand_dims({"time": [ncar_meta[i]["time"]]}, axis=0)
+                    out = out.drop_vars(
+                        ["forecast_hour", "forecast_initial_time"],
+                        errors="ignore",
+                    )
+                    outputs.append(out)
+                da = xr.concat(outputs, dim="time", coords="minimal")
+            else:
+                raise ValueError("Unknown product")
+
+            da = da.expand_dims({"level": [0]}, axis=1)
+        # Load the data — this is the actual download
+        da = da.load()
+    return da

--- a/earth2studio/data/ncar.py
+++ b/earth2studio/data/ncar.py
@@ -83,7 +83,7 @@ class NCAR_ERA5:
         Timeout in seconds for async operations, by default 600
     async_workers : int, optional
         Maximum number of concurrent downloads. By default None, which autoscales
-        to the number of download tasks (capped at 32)
+        to the number of download tasks (capped at 64)
     retries : int, optional
         Number of retries for each download task on transient errors, by default 3
 
@@ -140,7 +140,7 @@ class NCAR_ERA5:
         # redirects, so the helper's us-east-1 default must be overridden
         self.store = obstore_store_from_url(
             f"s3://{self.NCAR_ERA5_BUCKET_NAME}",
-            max_pool_connections=self._async_workers or 32,
+            max_pool_connections=self._async_workers or 64,
             region="us-west-2",
         )
 

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -771,6 +771,35 @@ async def cancellable_to_thread(
         raise
 
 
+def resolve_async_workers(
+    async_workers: int | None, n_tasks: int, cap: int = 32
+) -> int:
+    """Resolves the concurrent download worker count for a data source.
+
+    When ``async_workers`` is None (the default for obstore-backed sources),
+    concurrency autoscales to the number of pending download tasks, bounded by
+    ``cap`` to keep request bursts against public endpoints reasonable. An
+    explicit ``async_workers`` value is always honored as-is.
+
+    Parameters
+    ----------
+    async_workers : int | None
+        User-provided worker count, or None to autoscale
+    n_tasks : int
+        Number of pending download tasks
+    cap : int, optional
+        Upper bound applied when autoscaling, by default 32
+
+    Returns
+    -------
+    int
+        Number of concurrent workers to use (at least 1)
+    """
+    if async_workers is not None:
+        return async_workers
+    return max(1, min(n_tasks, cap))
+
+
 def obstore_store_from_url(
     url: str,
     anonymous: bool = True,

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -772,7 +772,7 @@ async def cancellable_to_thread(
 
 
 def resolve_async_workers(
-    async_workers: int | None, n_tasks: int, cap: int = 32
+    async_workers: int | None, n_tasks: int, cap: int = 64
 ) -> int:
     """Resolves the concurrent download worker count for a data source.
 
@@ -788,7 +788,7 @@ def resolve_async_workers(
     n_tasks : int
         Number of pending download tasks
     cap : int, optional
-        Upper bound applied when autoscaling, by default 32
+        Upper bound applied when autoscaling, by default 64
 
     Returns
     -------

--- a/test/data/test_cfs.py
+++ b/test/data/test_cfs.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import hashlib
 import pathlib
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
@@ -253,6 +255,13 @@ def test_cfs_index_parser_vector_records(tmp_path):
     assert u_len == v_len == (147274 - 96515)
     assert (u_submsg, v_submsg) == (1, 2)
 
+    # Last record gets the negative "read to end of file" sentinel.
+    tmp_key = next(k for k in table if "TMP::500 mb" in k)
+    tmp_offset, tmp_length, tmp_submsg = table[tmp_key]
+    assert tmp_offset == 147274
+    assert tmp_length < 0
+    assert tmp_submsg == 1
+
 
 # ----------------------------------------------------------------------
 # Mock end-to-end (no network, exercises __call__ path)
@@ -287,8 +296,8 @@ def test_cfs_call_mock(tmp_path, monkeypatch):
             return_value=fake_grid,
         ),
     ):
-        # Bypass real fs by stubbing it to a truthy sentinel.
-        ds.fs = object()  # type: ignore[assignment]
+        # Bypass real store by stubbing it to a truthy sentinel.
+        ds.store = object()  # type: ignore[assignment]
         data = ds(_TEST_CYCLE, timedelta(hours=6), ["msl", "z500"])
 
     assert data.shape == (1, 1, 2, 181, 360)
@@ -296,6 +305,85 @@ def test_cfs_call_mock(tmp_path, monkeypatch):
     # same mock grid, so msl matches the grid and z500 = grid * 9.81.
     np.testing.assert_allclose(data.sel(variable="msl").values[0, 0], fake_grid)
     np.testing.assert_allclose(data.sel(variable="z500").values[0, 0], fake_grid * 9.81)
+
+
+@pytest.mark.timeout(15)
+def test_cfs_nomads_call_mock(tmp_path, monkeypatch):
+    """Exercise the NOMADS-source __call__ path (obstore HTTP store) with
+    mocked index + grib decode."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {"1::PRMSL::mean sea level": (0, 65300, 1)}
+    fake_grid = np.full((181, 360), 101325.0, dtype=np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.grb2")
+
+    # Recent 6-hour cycle inside the NOMADS rolling window.
+    now = datetime.now()
+    recent_cycle = datetime(now.year, now.month, now.day) - timedelta(days=1)
+
+    ds = CFS_FX(member=1, source="nomads", cache=True)
+
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.cfs._decode_cfs_grib", return_value=fake_grid),
+    ):
+        # Bypass real store by stubbing it to a truthy sentinel.
+        ds.store = object()  # type: ignore[assignment]
+        data = ds(recent_cycle, timedelta(hours=6), ["msl"])
+
+    assert data.shape == (1, 1, 1, 181, 360)
+    np.testing.assert_allclose(data.sel(variable="msl").values[0, 0], fake_grid)
+
+
+@pytest.mark.timeout(15)
+def test_cfs_flux_call_mock(tmp_path, monkeypatch):
+    """Exercise the CFS_FX_Flux __call__ path using mocked index + decode."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {
+        "1::TMP::2 m above ground": (0, 65300, 1),
+        "2.1::UGRD::10 m above ground": (65300, 50759, 1),
+        "2.2::VGRD::10 m above ground": (65300, 50759, 2),
+    }
+    # flxf product lives on the T126 Gaussian grid (190 x 384).
+    fake_grid = np.full((190, 384), 288.0, dtype=np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.grb2")
+
+    ds = CFS_FX_Flux(member=1, source="aws", cache=True)
+
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch(
+            "earth2studio.data.cfs._decode_cfs_grib",
+            return_value=fake_grid,
+        ),
+    ):
+        # Bypass real store by stubbing it to a truthy sentinel.
+        ds.store = object()  # type: ignore[assignment]
+        data = ds(
+            _TEST_CYCLE,
+            [timedelta(hours=0), timedelta(hours=6)],
+            ["t2m", "u10m"],
+        )
+
+    assert data.shape == (1, 2, 2, 190, 384)
+    for j in range(2):
+        np.testing.assert_allclose(data.sel(variable="t2m").values[0, j], fake_grid)
+        np.testing.assert_allclose(data.sel(variable="u10m").values[0, j], fake_grid)
 
 
 @pytest.mark.timeout(15)
@@ -322,12 +410,65 @@ def test_cfs_missing_variable_returns_nan(tmp_path, monkeypatch):
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
         patch("earth2studio.data.cfs._decode_cfs_grib", return_value=fake_grid),
     ):
-        ds.fs = object()  # type: ignore[assignment]
+        ds.store = object()  # type: ignore[assignment]
         data = ds(_TEST_CYCLE, timedelta(hours=6), ["msl", "z500"])
 
     np.testing.assert_allclose(data.sel(variable="msl").values[0, 0], fake_grid)
     # Skipped variable surfaces as all-NaN.
     assert np.isnan(data.sel(variable="z500").values).all()
+
+
+@pytest.mark.timeout(10)
+def test_cfs_fetch_remote_file_obstore_routing(tmp_path, monkeypatch):
+    # The obstore path must strip the bucket prefix to a store-relative key
+    # while hashing the ORIGINAL bucket-prefixed path (+ byte offset) for the
+    # cache file name, so pre-migration warm caches remain valid. Negative
+    # byte lengths (last idx record) map to None (read to end of object).
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+    ds = CFS_FX(source="aws", cache=True)
+    ds.store = object()  # type: ignore[assignment]
+
+    path = (
+        "noaa-cfs-pds/cfs.20240601/00/6hrly_grib_01/pgbf2024060106.01.2024060100.grb2"
+    )
+    expected_key = "cfs.20240601/00/6hrly_grib_01/pgbf2024060106.01.2024060100.grb2"
+    expected_cache_key = hashlib.sha256((path + "123").encode()).hexdigest()
+
+    mock_fetch = AsyncMock(return_value="local-file")
+    with patch("earth2studio.data.cfs.obstore_fetch_to_cache", mock_fetch):
+        out = asyncio.run(ds._fetch_remote_file(path, byte_offset=123, byte_length=456))
+        assert out == "local-file"
+        args, kwargs = mock_fetch.call_args
+        assert args[1] == expected_key
+        assert kwargs["byte_offset"] == 123
+        assert kwargs["byte_length"] == 456
+        assert kwargs["cache_key"] == expected_cache_key
+
+        # Negative sentinel -> read to end of file.
+        asyncio.run(ds._fetch_remote_file(path, byte_offset=123, byte_length=-1))
+        assert mock_fetch.call_args.kwargs["byte_length"] is None
+
+    # NOMADS: full HTTPS URL is hashed for the cache key while the key is the
+    # host-relative path (store is rooted at the NOMADS host).
+    ds_nomads = CFS_FX(source="nomads", cache=True)
+    ds_nomads.store = object()  # type: ignore[assignment]
+    url = (
+        "https://nomads.ncep.noaa.gov/pub/data/nccf/com/cfs/prod/"
+        "cfs.20240601/00/6hrly_grib_01/pgbf2024060106.01.2024060100.grb2"
+    )
+    expected_key = (
+        "pub/data/nccf/com/cfs/prod/"
+        "cfs.20240601/00/6hrly_grib_01/pgbf2024060106.01.2024060100.grb2"
+    )
+    expected_cache_key = hashlib.sha256((url + "0").encode()).hexdigest()
+
+    mock_fetch = AsyncMock(return_value="local-file")
+    with patch("earth2studio.data.cfs.obstore_fetch_to_cache", mock_fetch):
+        out = asyncio.run(ds_nomads._fetch_remote_file(url))
+    assert out == "local-file"
+    args, kwargs = mock_fetch.call_args
+    assert args[1] == expected_key
+    assert kwargs["cache_key"] == expected_cache_key
 
 
 # ----------------------------------------------------------------------

--- a/test/data/test_cfs.py
+++ b/test/data/test_cfs.py
@@ -255,11 +255,11 @@ def test_cfs_index_parser_vector_records(tmp_path):
     assert u_len == v_len == (147274 - 96515)
     assert (u_submsg, v_submsg) == (1, 2)
 
-    # Last record gets the negative "read to end of file" sentinel.
+    # Last record gets the None "read to end of file" sentinel.
     tmp_key = next(k for k in table if "TMP::500 mb" in k)
     tmp_offset, tmp_length, tmp_submsg = table[tmp_key]
     assert tmp_offset == 147274
-    assert tmp_length < 0
+    assert tmp_length is None
     assert tmp_submsg == 1
 
 

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -794,6 +794,7 @@ async def test_obstore_fetch_to_cache(tmp_path):
         store, "some/key", str(tmp_path), byte_offset=0, cache_key="warmcache"
     )
     assert Path(path).read_bytes() == payload
+<<<<<<< HEAD
 
 
 @pytest.fixture

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -794,7 +794,6 @@ async def test_obstore_fetch_to_cache(tmp_path):
         store, "some/key", str(tmp_path), byte_offset=0, cache_key="warmcache"
     )
     assert Path(path).read_bytes() == payload
-<<<<<<< HEAD
 
 
 @pytest.fixture

--- a/test/data/test_gefs.py
+++ b/test/data/test_gefs.py
@@ -285,14 +285,14 @@ def test_gefs_index_parser(tmp_path):
     with patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch):
         table = asyncio.run(ds._fetch_index("dummy-uri"))
 
-    # Unlike GFS, a dummy end line is appended so the LAST record is kept,
-    # with a negative byte length signalling a read to end-of-file
+    # Unlike GFS, the LAST record is kept, with a byte length of None
+    # signalling a read from its offset to the end of the file
     assert len(table) == 3
     assert table["1::PRMSL::mean sea level::3 hour fcst"] == (0, 65300)
     assert table["2::HGT::500 mb::3 hour fcst"] == (65300, 96515 - 65300)
     trailing = table["3::TMP::2 m above ground::3 hour fcst"]
     assert trailing[0] == 96515
-    assert trailing[1] < 0
+    assert trailing[1] is None
 
 
 @pytest.mark.timeout(10)
@@ -359,13 +359,12 @@ def test_gefs_call_mock(tmp_path, monkeypatch):
 
 @pytest.mark.timeout(15)
 def test_gefs_call_mock_trailing_record(tmp_path, monkeypatch):
-    """A negative byte length in the index (last grib message in the file) must
+    """A byte length of None in the index (last grib message in the file) must
     reach the remote fetch as byte_length=None (read offset -> EOF)."""
     monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
 
-    # Negative byte length signals the trailing record, per the dummy index
-    # line appended in _fetch_index
-    fake_index = {"1::TMP::2 m above ground::3 hour fcst": (96515, -96516)}
+    # A byte length of None signals the trailing record, per _fetch_index
+    fake_index = {"1::TMP::2 m above ground::3 hour fcst": (96515, None)}
     fake_grid = np.random.rand(361, 720).astype(np.float32)
     fetch_calls = []
 

--- a/test/data/test_gefs.py
+++ b/test/data/test_gefs.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import pathlib
 import shutil
 from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
@@ -255,3 +257,219 @@ def test_gefs_invalid_variable(variable):
 def test_gefs_invalid_product(product):
     with pytest.raises(ValueError):
         GEFS_FX(product, cache=False)
+
+
+# ----------------------------------------------------------------------
+# Index parser (offline, no network)
+# ----------------------------------------------------------------------
+
+
+_MOCK_PGRB2A_IDX = (
+    "1:0:d=2024010100:PRMSL:mean sea level:3 hour fcst:ENS=low-res ctl\n"
+    "2:65300:d=2024010100:HGT:500 mb:3 hour fcst:ENS=low-res ctl\n"
+    "3:96515:d=2024010100:TMP:2 m above ground:3 hour fcst:ENS=low-res ctl\n"
+)
+
+
+@pytest.mark.timeout(10)
+def test_gefs_index_parser(tmp_path):
+    # Write a fake .idx file and patch _fetch_remote_file to return it.
+    idx_path = tmp_path / "fake.pgrb2a.idx"
+    idx_path.write_text(_MOCK_PGRB2A_IDX)
+
+    ds = GEFS_FX(cache=False)
+
+    async def _fake_fetch(uri):
+        return str(idx_path)
+
+    with patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch):
+        table = asyncio.run(ds._fetch_index("dummy-uri"))
+
+    # Unlike GFS, a dummy end line is appended so the LAST record is kept,
+    # with a negative byte length signalling a read to end-of-file
+    assert len(table) == 3
+    assert table["1::PRMSL::mean sea level::3 hour fcst"] == (0, 65300)
+    assert table["2::HGT::500 mb::3 hour fcst"] == (65300, 96515 - 65300)
+    trailing = table["3::TMP::2 m above ground::3 hour fcst"]
+    assert trailing[0] == 96515
+    assert trailing[1] < 0
+
+
+@pytest.mark.timeout(10)
+def test_gefs_index_parser_max_byte_size(tmp_path):
+    # A record spanning more than MAX_BYTE_SIZE must raise.
+    idx_path = tmp_path / "fake.pgrb2a.idx"
+    idx_path.write_text(
+        "1:0:d=2024010100:PRMSL:mean sea level:3 hour fcst:ENS=low-res ctl\n"
+        "2:6000000:d=2024010100:HGT:500 mb:3 hour fcst:ENS=low-res ctl\n"
+    )
+
+    ds = GEFS_FX(cache=False)
+
+    async def _fake_fetch(uri):
+        return str(idx_path)
+
+    with patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch):
+        with pytest.raises(ValueError):
+            asyncio.run(ds._fetch_index("dummy-uri"))
+
+
+# ----------------------------------------------------------------------
+# Mock end-to-end (no network, exercises __call__ path)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.timeout(15)
+def test_gefs_call_mock(tmp_path, monkeypatch):
+    """Exercise the full __call__ path using mocked index + grib decode."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {
+        "1::TMP::2 m above ground::3 hour fcst": (0, 65300),
+        "2::HGT::500 mb::3 hour fcst": (65300, 31215),
+    }
+    fake_grid = np.random.rand(361, 720).astype(np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.pgrb2")
+
+    ds = GEFS_FX(cache=True, verbose=False)
+
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+    ):
+        # Bypass real store by stubbing it to a truthy sentinel.
+        ds.store = object()  # type: ignore[assignment]
+        data = ds(datetime(2024, 1, 1), timedelta(hours=3), ["t2m", "z500"])
+
+    assert data.shape == (1, 1, 2, 361, 720)
+    # t2m is identity, z500 multiplies HGT by 9.81 — both records used the
+    # same mock grid, so t2m matches the grid and z500 = grid * 9.81.
+    np.testing.assert_allclose(data.sel(variable="t2m").values[0, 0], fake_grid)
+    np.testing.assert_allclose(
+        data.sel(variable="z500").values[0, 0], fake_grid * 9.81, rtol=1e-6
+    )
+
+
+@pytest.mark.timeout(15)
+def test_gefs_call_mock_trailing_record(tmp_path, monkeypatch):
+    """A negative byte length in the index (last grib message in the file) must
+    reach the remote fetch as byte_length=None (read offset -> EOF)."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    # Negative byte length signals the trailing record, per the dummy index
+    # line appended in _fetch_index
+    fake_index = {"1::TMP::2 m above ground::3 hour fcst": (96515, -96516)}
+    fake_grid = np.random.rand(361, 720).astype(np.float32)
+    fetch_calls = []
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(path, byte_offset=0, byte_length=None):
+        fetch_calls.append((path, byte_offset, byte_length))
+        return str(tmp_path / "ignored.pgrb2")
+
+    ds = GEFS_FX(cache=True, verbose=False)
+
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+    ):
+        ds.store = object()  # type: ignore[assignment]
+        data = ds(datetime(2024, 1, 1), timedelta(hours=3), ["t2m"])
+
+    assert data.shape == (1, 1, 1, 361, 720)
+    np.testing.assert_allclose(data.values[0, 0, 0], fake_grid)
+    assert len(fetch_calls) == 1
+    _, byte_offset, byte_length = fetch_calls[0]
+    assert byte_offset == 96515
+    assert byte_length is None
+
+
+@pytest.mark.timeout(15)
+def test_gefs_0p25_call_mock(tmp_path, monkeypatch):
+    """Exercise the GEFS_FX_721x1440 __call__ path on the 0.25 degree grid."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {"1::TMP::2 m above ground::3 hour fcst": (0, 65300)}
+    fake_grid = np.random.rand(721, 1440).astype(np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.pgrb2")
+
+    ds = GEFS_FX_721x1440(cache=True, verbose=False)
+
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+    ):
+        ds.store = object()  # type: ignore[assignment]
+        data = ds(
+            datetime(2024, 1, 1),
+            [timedelta(hours=0), timedelta(hours=3)],
+            ["t2m"],
+        )
+
+    assert data.shape == (1, 2, 1, 721, 1440)
+    for j in range(2):
+        np.testing.assert_allclose(data.values[0, j, 0], fake_grid)
+
+
+@pytest.mark.timeout(15)
+def test_gefs_fetch_remote_file_key_and_cache(tmp_path, monkeypatch):
+    """The obstore fetch must receive the store-relative key while the cache
+    file name stays hashed from the original bucket-prefixed path."""
+    import hashlib
+
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    ds = GEFS_FX(cache=True, verbose=False)
+    ds.store = object()  # type: ignore[assignment]
+
+    captured = {}
+
+    async def _fake_fetch_to_cache(
+        store, key, cache_dir, byte_offset=0, byte_length=None, cache_key=None
+    ):
+        captured.update(
+            key=key,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+            cache_key=cache_key,
+        )
+        return str(tmp_path / "cached")
+
+    path = f"{GEFS_FX.GEFS_BUCKET_NAME}/gefs.20240101/00/atmos/pgrb2ap5/gec00.t00z.pgrb2a.0p50.f003"
+    with patch(
+        "earth2studio.data.gefs.obstore_fetch_to_cache",
+        side_effect=_fake_fetch_to_cache,
+    ):
+        result = asyncio.run(
+            ds._fetch_remote_file(path, byte_offset=123, byte_length=None)
+        )
+
+    assert result == str(tmp_path / "cached")
+    # Key is store-relative (bucket prefix stripped)
+    assert (
+        captured["key"] == "gefs.20240101/00/atmos/pgrb2ap5/gec00.t00z.pgrb2a.0p50.f003"
+    )
+    assert captured["byte_offset"] == 123
+    assert captured["byte_length"] is None
+    # Cache file name hashes the ORIGINAL bucket-prefixed path for warm-cache
+    # compatibility with the pre-obstore implementation
+    expected = hashlib.sha256((path + "123").encode()).hexdigest()
+    assert captured["cache_key"] == expected

--- a/test/data/test_hrrr.py
+++ b/test/data/test_hrrr.py
@@ -18,12 +18,11 @@ import asyncio
 import pathlib
 import shutil
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
-import gcsfs
 import numpy as np
 import pytest
-import s3fs
-from fsspec.implementations.http import HTTPFileSystem
+from obstore.store import GCSStore, HTTPStore, S3Store
 
 from earth2studio.data import HRRR, HRRR_FX
 
@@ -115,41 +114,24 @@ def test_hrrr_init():
     """Test HRRR initialization with different sources and parameters"""
     # Test AWS source
     ds = HRRR(source="aws", cache=True, verbose=True, async_timeout=300)
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # If no event loop exists, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    loop.run_until_complete(ds._async_init())
+    assert ds.store is None  # Lazy init
+    asyncio.run(ds._async_init())
 
     assert ds.uri_prefix == "noaa-hrrr-bdp-pds"
-    assert isinstance(ds.fs, s3fs.S3FileSystem)
+    assert isinstance(ds.store, S3Store)
     assert ds.async_timeout == 300
 
     # Test Google source
     ds = HRRR(source="google", cache=False, verbose=False)
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # If no event loop exists, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    loop.run_until_complete(ds._async_init())
+    asyncio.run(ds._async_init())
     assert ds.uri_prefix == "high-resolution-rapid-refresh"
-    assert isinstance(ds.fs, gcsfs.GCSFileSystem)
+    assert isinstance(ds.store, GCSStore)
 
     # Test Nomads source
     ds = HRRR(source="nomads")
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # If no event loop exists, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    loop.run_until_complete(ds._async_init())
+    asyncio.run(ds._async_init())
     assert ds.uri_prefix == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
-    assert isinstance(ds.fs, HTTPFileSystem)
+    assert isinstance(ds.store, HTTPStore)
 
     # Test invalid source
     with pytest.raises(ValueError):
@@ -266,3 +248,167 @@ def test_hrrr_fx_available(lead_time):
     with pytest.raises(ValueError):
         ds = HRRR_FX()
         ds(time, lead_time, variable)
+
+
+# ----------------------------------------------------------------------
+# Index parser (offline, no network)
+# ----------------------------------------------------------------------
+
+
+_MOCK_HRRR_IDX = (
+    "1:0:d=2024010100:REFC:entire atmosphere:anl:\n"
+    "2:375155:d=2024010100:TMP:2 m above ground:anl:\n"
+    "3:475155:d=2024010100:HGT:500 mb:anl:\n"
+    "4:575155:d=2024010100:UGRD:10 m above ground:anl:\n"
+)
+
+
+@pytest.mark.timeout(10)
+def test_hrrr_index_parser(tmp_path):
+    # Write a fake .idx file and patch _fetch_remote_file to return it.
+    idx_path = tmp_path / "fake.grib2.idx"
+    idx_path.write_text(_MOCK_HRRR_IDX)
+
+    ds = HRRR(cache=False)
+
+    async def _fake_fetch(uri):
+        return str(idx_path)
+
+    with patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch):
+        table = asyncio.run(ds._fetch_index("dummy-uri"))
+
+    # Last record is dropped (no next line to compute its length from)
+    assert len(table) == 3
+    assert table["1::REFC::entire atmosphere::anl"] == (0, 375155)
+    assert table["2::TMP::2 m above ground::anl"] == (375155, 100000)
+    assert table["3::HGT::500 mb::anl"] == (475155, 100000)
+
+
+@pytest.mark.timeout(10)
+def test_hrrr_index_parser_max_byte_size(tmp_path):
+    # A record spanning more than MAX_BYTE_SIZE must raise.
+    idx_path = tmp_path / "fake.grib2.idx"
+    idx_path.write_text(
+        "1:0:d=2024010100:REFC:entire atmosphere:anl:\n"
+        "2:6000000:d=2024010100:TMP:2 m above ground:anl:\n"
+    )
+
+    ds = HRRR(cache=False)
+
+    async def _fake_fetch(uri):
+        return str(idx_path)
+
+    with patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch):
+        with pytest.raises(ValueError):
+            asyncio.run(ds._fetch_index("dummy-uri"))
+
+
+# ----------------------------------------------------------------------
+# Mock end-to-end (no network, exercises __call__ path)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.timeout(15)
+@pytest.mark.parametrize("source", ["aws", "google"])
+def test_hrrr_call_mock(source, tmp_path, monkeypatch):
+    """Exercise the full __call__ path using mocked index + grib decode.
+
+    The real (offline) store construction runs for both the aws (S3) and
+    google (GCS) sources; only the remote reads are mocked out.
+    """
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {
+        "1::TMP::2 m above ground::anl": (0, 65300),
+        "2::HGT::500 mb::anl": (65300, 31215),
+    }
+    fake_grid = np.random.rand(1059, 1799).astype(np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.grib2")
+
+    ds = HRRR(source=source, cache=True, verbose=False)
+
+    with (
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+    ):
+        data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
+
+    # Store was built lazily for the requested source
+    assert isinstance(ds.store, S3Store if source == "aws" else GCSStore)
+    assert data.shape == (1, 2, 1059, 1799)
+    # t2m is identity, z500 multiplies HGT by 9.81 — both records used the
+    # same mock grid, so t2m matches the grid and z500 = grid * 9.81.
+    np.testing.assert_allclose(data.sel(variable="t2m").values[0], fake_grid)
+    np.testing.assert_allclose(
+        data.sel(variable="z500").values[0], fake_grid * 9.81, rtol=1e-6
+    )
+
+
+@pytest.mark.timeout(15)
+def test_hrrr_fx_call_mock(tmp_path, monkeypatch):
+    """Exercise the HRRR_FX __call__ path with multiple lead times."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    fake_index = {
+        "1::TMP::2 m above ground::anl": (0, 65300),
+        "2::TMP::2 m above ground::6 hour fcst": (65300, 65300),
+    }
+    fake_grid = np.random.rand(1059, 1799).astype(np.float32)
+
+    async def _fake_fetch_index(uri):
+        return fake_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.grib2")
+
+    ds = HRRR_FX(source="aws", cache=True, verbose=False)
+
+    with (
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+    ):
+        data = ds(
+            datetime(2024, 1, 1),
+            [timedelta(hours=0), timedelta(hours=6)],
+            ["t2m"],
+        )
+
+    assert data.shape == (1, 2, 1, 1059, 1799)
+    for j in range(2):
+        np.testing.assert_allclose(data.values[0, j, 0], fake_grid)
+
+
+@pytest.mark.timeout(15)
+def test_hrrr_missing_variable_mock(tmp_path, monkeypatch):
+    # If the requested variable is absent from the .idx, _create_tasks warns
+    # and skips it — the output slot keeps its zero initialization.
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    # Index only has t2m; z500 is missing on purpose.
+    partial_index = {"1::TMP::2 m above ground::anl": (0, 65300)}
+    fake_grid = np.random.rand(1059, 1799).astype(np.float32) + 1.0
+
+    async def _fake_fetch_index(uri):
+        return partial_index
+
+    async def _fake_fetch_remote_file(*args, **kwargs):
+        return str(tmp_path / "ignored.grib2")
+
+    ds = HRRR(source="aws", cache=True, verbose=False)
+    with (
+        patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
+        patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
+        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+    ):
+        data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
+
+    np.testing.assert_allclose(data.sel(variable="t2m").values[0], fake_grid)
+    # Skipped variable keeps the zero fill.
+    assert (data.sel(variable="z500").values == 0.0).all()

--- a/test/data/test_ncar.py
+++ b/test/data/test_ncar.py
@@ -14,14 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import pathlib
 import shutil
 from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
+import obstore as obs
 import pytest
+import xarray as xr
+from obstore.store import MemoryStore
 
 from earth2studio.data import NCAR_ERA5
+from earth2studio.data.ncar import _read_object_store_dataset
 
 
 @pytest.mark.slow
@@ -212,3 +218,172 @@ def test_ncar_create_tasks_accumulated_mult():
     for task in tasks.values():
         all_vars.update(task.ncar_level_indices.values())
     assert all_vars == set(variables)
+
+
+# ----------------------------------------------------------------------
+# Mock end-to-end (no network, exercises __call__ path)
+# ----------------------------------------------------------------------
+
+
+def _fake_read_dataset(captured: list):
+    """Build a fake `_read_object_store_dataset` that returns random fields
+    shaped like the real reader output."""
+
+    def _fake_read(store, nc_key, data_variable, time_idx, level_idx, ncar_meta):
+        captured.append((nc_key, data_variable, tuple(time_idx), tuple(level_idx)))
+        data = np.random.rand(len(time_idx), len(level_idx), 721, 1440).astype(
+            np.float32
+        )
+        return xr.DataArray(
+            data,
+            dims=["time", "level", "latitude", "longitude"],
+            coords={
+                "time": np.array(
+                    [np.datetime64("2000-01-01")] * len(time_idx),
+                    dtype="datetime64[ns]",
+                ),
+                "level": list(level_idx),
+                "latitude": NCAR_ERA5.NCAR_EAR5_LAT,
+                "longitude": NCAR_ERA5.NCAR_EAR5_LON,
+            },
+        )
+
+    return _fake_read
+
+
+@pytest.mark.timeout(30)
+def test_ncar_call_mock_pl(tmp_path, monkeypatch):
+    """Exercise the full __call__ path for pressure level variables using a
+    mocked object store read."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    captured: list = []
+    times = [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 12)]
+    ds = NCAR_ERA5(cache=True, verbose=False)
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch(
+            "earth2studio.data.ncar._read_object_store_dataset",
+            side_effect=_fake_read_dataset(captured),
+        ),
+    ):
+        # Bypass real store by stubbing it to a truthy sentinel.
+        ds.store = object()
+        data = ds(times, ["t500", "t850"])
+
+    assert data.shape == (2, 2, 721, 1440)
+    assert not np.isnan(data.values).any()
+    assert list(data.coords["variable"].values) == ["t500", "t850"]
+    assert np.array_equal(data.coords["lat"].values, NCAR_ERA5.NCAR_EAR5_LAT)
+    assert np.array_equal(data.coords["lon"].values, NCAR_ERA5.NCAR_EAR5_LON)
+    # Both times and levels share a single daily file -> single read with the
+    # bucket-relative (no s3:// prefix) key
+    assert len(captured) == 1
+    nc_key, data_variable, time_idx, level_idx = captured[0]
+    assert nc_key.startswith("e5.oper.an.pl/202401/")
+    assert data_variable == "T"
+    assert time_idx == (0, 12)
+    assert len(level_idx) == 2
+
+
+@pytest.mark.timeout(30)
+def test_ncar_call_mock_sfc_accum(tmp_path, monkeypatch):
+    """Exercise the full __call__ path mixing surface and accumulated
+    variables using a mocked object store read."""
+    monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
+
+    captured: list = []
+    ds = NCAR_ERA5(cache=True, verbose=False)
+    with (
+        patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
+        patch(
+            "earth2studio.data.ncar._read_object_store_dataset",
+            side_effect=_fake_read_dataset(captured),
+        ),
+    ):
+        ds.store = object()
+        data = ds(datetime(2024, 1, 1, 6), ["t2m", "lsp"])
+
+    assert data.shape == (1, 2, 721, 1440)
+    assert not np.isnan(data.values).any()
+    assert list(data.coords["variable"].values) == ["t2m", "lsp"]
+    # One monthly surface file + one bi-monthly accumulation file
+    assert len(captured) == 2
+    keys = sorted(k for k, *_ in captured)
+    assert keys[0].startswith("e5.oper.an.sfc/202401/")
+    assert keys[1].startswith("e5.oper.fc.sfc.accumu/202312/")
+
+
+# ----------------------------------------------------------------------
+# Object store NetCDF reader (offline, in-memory store)
+# ----------------------------------------------------------------------
+
+
+def _put_netcdf(store, key: str, ds: xr.Dataset) -> None:
+    buffer = io.BytesIO()
+    ds.to_netcdf(buffer, engine="h5netcdf")
+    obs.put(store, key, buffer.getvalue())
+
+
+def _make_dataset(variable: str, with_level: bool) -> xr.Dataset:
+    dims = ["time", "latitude", "longitude"]
+    shape = [4, 5, 6]
+    coords = {
+        "time": np.array(
+            [np.datetime64("2024-01-01T00") + np.timedelta64(i, "h") for i in range(4)]
+        ),
+        "latitude": np.linspace(90, -90, 5),
+        "longitude": np.linspace(0, 359, 6),
+    }
+    if with_level:
+        dims.insert(1, "level")
+        shape.insert(1, 3)
+        coords["level"] = np.array([1000.0, 850.0, 500.0])
+    data = np.random.rand(*shape).astype(np.float32)
+    return xr.Dataset({variable: (dims, data)}, coords=coords)
+
+
+@pytest.mark.timeout(30)
+def test_ncar_read_object_store_dataset_pl():
+    store = MemoryStore()
+    key = (
+        "e5.oper.an.pl/202401/e5.oper.an.pl.128_130_t.ll025sc.2024010100_2024010123.nc"
+    )
+    _put_netcdf(store, key, _make_dataset("T", with_level=True))
+
+    da = _read_object_store_dataset(store, key, "T", [1, 3], [0, 2], {})
+    assert da.shape == (2, 2, 5, 6)
+    assert list(da.dims) == ["time", "level", "latitude", "longitude"]
+
+
+@pytest.mark.timeout(30)
+def test_ncar_read_object_store_dataset_sfc_var_prefix():
+    # Surface files sometimes have VAR_ prepended to the data variable
+    store = MemoryStore()
+    key = "e5.oper.an.sfc/202401/e5.oper.an.sfc.128_167_2t.ll025sc.2024010100_2024013123.nc"
+    _put_netcdf(store, key, _make_dataset("VAR_2T", with_level=False))
+
+    da = _read_object_store_dataset(store, key, "2T", [0, 2], [0], {})
+    # Level dim of size 1 is inserted for surface products
+    assert da.shape == (2, 1, 5, 6)
+
+
+@pytest.mark.timeout(30)
+def test_ncar_read_object_store_dataset_errors():
+    store = MemoryStore()
+    key = "e5.oper.an.sfc/202401/e5.oper.an.sfc.128_167_2t.ll025sc.2024010100_2024013123.nc"
+    _put_netcdf(store, key, _make_dataset("VAR_2T", with_level=False))
+
+    # Missing data variable in the file
+    with pytest.raises(ValueError):
+        _read_object_store_dataset(store, key, "SD", [0], [0], {})
+
+    # Unknown product type
+    bad_key = "e5.unknown/202401/file.nc"
+    _put_netcdf(store, bad_key, _make_dataset("VAR_2T", with_level=False))
+    with pytest.raises(ValueError):
+        _read_object_store_dataset(store, bad_key, "2T", [0], [0], {})
+
+    # Missing object
+    with pytest.raises(FileNotFoundError):
+        _read_object_store_dataset(store, "e5.oper.an.sfc/nope.nc", "2T", [0], [0], {})


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Completes the GRIB byte-range obstore migration ([physicsnemo-roadmap#2747](https://github.com/NVIDIA/physicsnemo-roadmap/issues/2747)) started in #964.

> **Stacked on #964** — this branch is based on `obstore-gfs`; the first commits shown here belong to that PR. Review only the three commits from `Migrate remaining GRIB byte-range sources...` onward; will rebase onto `main` once #964 merges.

### What changed

* Migrated the four remaining GRIB byte-range sources from s3fs/gcsfs to obstore via the shared `data/utils.py` helpers, following the GFS reference implementation:
  * `HRRR` / `HRRR_FX` — all three backends: S3 (`noaa-hrrr-bdp-pds`), the GCS mirror (`high-resolution-rapid-refresh`), and NOMADS over obstore `HTTPStore`.
  * `GEFS_FX` / `GEFS_FX_721x1440` — including a sentinel-free index parser where the trailing GRIB record is expressed directly as `byte_length=None` (read-to-EOF).
  * `CFS_FX` / `CFS_FX_Flux` — both `aws` and `nomads` sources.
  * `NCAR_ERA5` — with a new `_ObstoreBlockCachedIO` adapter serving h5py's scattered reads from LRU-cached 8 MB ranged GETs, and an explicit `us-west-2` region (obstore does not follow S3 region redirects; the naive port failed outright).
* **No fsspec fallbacks remain**: the GFS `ncep` source (fsspec FTP in #964) and the HRRR/CFS `nomads` sources now use obstore `HTTPStore` against the NOMADS HTTPS endpoint. None of the five modules import fsspec/s3fs/gcsfs.
* Download concurrency now autoscales: `async_workers=None` (new default) scales workers to the number of pending download tasks, capped at 64, via a shared `resolve_async_workers` helper; an explicit value still pins it. `retries` added to all migrated sources.
* `available()` probes use obstore listings/head requests instead of `s3fs.exists()`.

### Behavior notes

* Outputs are unchanged — every migrated source was verified **bit-identical** to its fsspec implementation against live stores.
* Existing warm caches remain valid (cache keys still hash the historical bucket-prefixed URIs).
* GFS `ncep` moves from FTP to HTTPS; environments that block outbound FTP (where the old source could not connect at all) now work.

### Performance (cold cache, full variable set, sequential runs)

| Data Source | Variables | Before (s3fs) | After (obstore) | Speedup |
|-------------|----------:|--------------:|:---------------:|--------:|
| GEFS_FX | 214 | 8.2s / 26 v/s | 2.1s / 104 v/s | **4.0x** |
| CFS_FX | 81 | 4.2s / 19 v/s | 1.6s / 51 v/s | **2.6x** |
| NCAR_ERA5 | 278 | 289s / 1.0 v/s | 152s / 1.8 v/s | **1.9x** |
| HRRR | 648 | 22.3s / 29 v/s | 13.3s / 49 v/s | **1.7x** |

### Testing

* Offline mock tests for every migrated source following the GFS/CFS pattern (index parsers, end-to-end `__call__` mocks, cache-key/bucket-prefix routing, GEFS trailing-record read-to-EOF, NCAR reads against `MemoryStore` with in-memory h5netcdf files) — 130+ tests, no network required.
* Live smoke tests against all real endpoints: HRRR via S3/GCS/NOMADS, GEFS trailing record, CFS aws + nomads (including UGRD/VGRD vector submessages and the Gaussian-grid flux product), NCAR ERA5, and positive/negative `available()` probes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).