### PR TITLE
Eval recipe upgrades and fixes

### DIFF
--- a/recipes/eval/README.md
+++ b/recipes/eval/README.md
@@ -226,12 +226,29 @@ python main.py \
 
 ### Multi-source pipelines (StormScope)
 
-StormScope needs two IC sources (GOES satellite + MRMS radar) plus a
-conditioning source (GFS).  A single top-level `ic_source` doesn't fit,
-so the pipeline declares `needs_data_source = False` and resolves its
-own sources from per-component config blocks — `main.py` skips
-top-level source resolution and the predownload sentinel check for
-these pipelines.
+The default StormScope checkpoint is the **`3km_10min`** CONUS nowcasting
+variant (3 km grid, 10-minute step).  The pipeline runs two coupled models:
+
+- **`StormScopeGOES`** — forecasts the eight ABI satellite channels.  The
+  `3km_10min` variant is *pure obs*: it takes **no external conditioning**.
+- **`StormScopeMRMS`** — forecasts radar reflectivity (`refc`, `refc_base`)
+  **plus a gridded GLM lightning channel** (`glm_density`), conditioned on
+  GOES (observations at the IC time, then the GOES model's own predictions
+  during rollout via `call_with_conditioning`).
+
+So the pipeline needs three IC-side sources — GOES satellite, MRMS radar, and
+GLM lightning — living on three different native grids.  A single top-level
+`ic_source` doesn't fit, so the pipeline declares `needs_data_source = False`
+and resolves its own sources from per-component config blocks; `main.py` skips
+top-level source resolution and the predownload sentinel check for these
+pipelines.
+
+The **GLM channel** (`glm_density`) is a *state* channel — both an input
+(observation history) and a predicted output that evolves autoregressively.
+It comes from `earth2studio.data.GOESGLMGrid` on a 0.1° lat/lon grid and is
+regridded **bilinearly** onto the model grid (`src.regrid.BilinearRegridder`),
+matching the model's own `build_glm_interpolator` — unlike the
+nearest-neighbor path used for radar/satellite.
 
 BYO is done by overriding the per-component entries in `cfg.model`:
 
@@ -242,44 +259,57 @@ python main.py campaign=stormscope_2023_convection \
     model.goes.ic_grid._target_=my_pkg.my_goes_grid \
     model.mrms.ic_source._target_=my_pkg.MyMrmsZarrSource \
     model.mrms.ic_source.path=/data/my_mrms.zarr \
-    model.mrms.ic_grid._target_=my_pkg.my_mrms_grid
+    model.mrms.ic_grid._target_=my_pkg.my_mrms_grid \
+    model.mrms.glm_data_source._target_=my_pkg.MyGlmSource \
+    model.mrms.glm_grid._target_=my_pkg.my_glm_grid
 ```
 
-`ic_grid` is a Hydra-instantiable callable that returns `(lats, lons)`
-for the source's native grid — the pipeline uses it to build
-StormScope's internal nearest-neighbor interpolator.  If your BYO store
-is already on the HRRR grid, point `ic_grid` at a resolver that returns
-the model's own `y`/`x` — StormScope's `prep_input` detects the match
-and skips interpolation.
+`ic_grid` (and `glm_grid`) is a Hydra-instantiable callable that returns
+`(lats, lons)` for the source's native grid — the pipeline uses it to build
+StormScope's internal interpolator.  If your BYO store is already on the HRRR
+grid, point `ic_grid` at a resolver that returns the model's own `y`/`x` —
+StormScope's `prep_input` detects the match and skips interpolation.
 
 #### Predownload with HRRR-aligned storage
 
-Running `predownload.py` for a StormScope campaign writes two zarr
-stores, one per model, already resampled onto the model's HRRR
-sub-region via a nearest-neighbor regridder
-(`src.regrid.NearestNeighborRegridder`):
+Running `predownload.py` for a StormScope campaign writes **three** zarr
+stores, each already resampled onto the model's HRRR sub-region — radar and
+satellite via a nearest-neighbor regridder
+(`src.regrid.NearestNeighborRegridder`), GLM via the bilinear regridder
+(`src.regrid.BilinearRegridder`):
 
 ```bash
 python predownload.py campaign=stormscope_2023_convection
-# → <output.path>/data_goes.zarr   (time, y, x) on HRRR sub-region
-# → <output.path>/data_mrms.zarr   (time, y, x) on HRRR sub-region
+# → <output.path>/data_goes.zarr   (time, y, x)  GOES ABI channels (nearest)
+# → <output.path>/data_mrms.zarr   (time, y, x)  radar refc/refc_base (nearest)
+# → <output.path>/data_glm.zarr    (time, y, x)  glm_density (bilinear)
 ```
 
-At inference time, `main.py` auto-detects these stores under
-`<output.path>` and wires them in with `PredownloadedSource`;
-StormScope's `prep_input` sees the matching `y`/`x` and skips its
-live interpolator, so the predownload is both a disk-size win (raw
-GOES is ~10x the regridded footprint) and an inference-speed win.
+Each store covers both the IC input window and every forecast valid time, so
+`data_mrms.zarr` / `data_glm.zarr` double as verification for scoring the
+radar and lightning channels.
 
-Per-model BYO overrides of `ic_source` bypass predownload for that
-model.  To fully skip predownload for both models, either set
+At inference time, `main.py` auto-detects these stores under `<output.path>`.
+The MRMS state spans two grids (radar + GLM), so its IC is reassembled from
+`data_mrms.zarr` + `data_glm.zarr` via a `CompositeSource` that dispatches
+each variable to the store providing it; `data_goes.zarr` is wired in with
+`PredownloadedSource` directly.  Because every store is already on the model
+`y`/`x`, StormScope's `prep_input` skips its live interpolators — so the
+predownload is both a disk-size win (raw GOES is ~10× the regridded footprint;
+raw GLM is far larger still) and an inference-speed win.  After the first
+step, `glm_density` flows autoregressively from the model's own predictions.
+
+Per-model BYO overrides of `ic_source` (or `glm_data_source`) bypass
+predownload for that source.  To fully skip predownload, either set
 `model.goes.ic_byo=true model.mrms.ic_byo=true` or simply don't run
-`predownload.py` — the pipeline will fall back to the live sources.
+`predownload.py` — the pipeline falls back to the live sources, wrapping each
+in the appropriate regridder (nearest for radar/satellite, bilinear for GLM)
+so the assembled state still lands on the model grid.
 
-Conditioning data (GFS for the GOES model; GOES observations for
-MRMS) is still fetched live by each model's internal conditioning
-source — that path isn't predownloaded because the conditioning
-request shape changes every forecast step.
+Because the `3km_10min` GOES model is pure-obs, there is **no** conditioning
+source to predownload (no `cond_goes.zarr`).  MRMS conditioning is supplied
+externally in the coupling loop (the GOES state via `call_with_conditioning`),
+so its internal conditioning source is bypassed too.
 
 ## Multi-GPU Execution
 
@@ -612,7 +642,7 @@ recipes/eval/
 │   ├── distributed.py   # Rank-ordered execution, logging setup
 │   ├── models.py        # Model loading (prognostic + diagnostic)
 │   ├── output.py        # OutputManager (zarr lifecycle)
-│   ├── grids.py         # Grid-resolver helpers (goes, mrms, gfs, arco)
+│   ├── grids.py         # Grid-resolver helpers (goes, mrms, glm, gfs, arco)
 │   └── data.py          # PredownloadedSource (zarr → DataSource)
 └── pyproject.toml
 ```
@@ -629,7 +659,7 @@ Each source module has a specific scoped responsibilities:
 | `distributed.py` | Rank-ordered execution primitive; logging setup |
 | `models.py` | Load prognostic/diagnostic models from config |
 | `output.py` | Zarr store creation, validation, threaded writes, consolidation |
-| `grids.py` | Hydra-instantiable grid resolvers (`goes_grid`, `mrms_grid`, `gfs_grid`, `arco_grid`) |
+| `grids.py` | Hydra-instantiable grid resolvers (`goes_grid`, `mrms_grid`, `glm_grid`, `gfs_grid`, `arco_grid`) |
 | `data.py` | `PredownloadedSource` — DataSource wrapper for predownloaded zarr stores |
 <!-- markdownlint-enable MD013 -->
 

--- a/recipes/eval/cfg/campaign/stormscope_2023_convection.yaml
+++ b/recipes/eval/cfg/campaign/stormscope_2023_convection.yaml
@@ -11,7 +11,7 @@ run_id: stormscope_2023_convection
 start_times:
     - "2023-12-05 12:00:00"
 
-nsteps: 2                   # 2 × 10min = 20min forecast
+nsteps: 6                   # 6 × 10min = 60min forecast
 
 # The StormScope pipeline sets needs_data_source=False, so main.py neither
 # resolves a top-level ic_source/data_source nor enforces the predownload

--- a/recipes/eval/cfg/campaign/stormscope_2023_convection.yaml
+++ b/recipes/eval/cfg/campaign/stormscope_2023_convection.yaml
@@ -1,5 +1,5 @@
 # @package _global_
-# StormScope GOES + MRMS coupled nowcast — 60-minute timestep, 2h rollout.
+# StormScope GOES + MRMS + GLM coupled nowcast — 3km / 10-minute timestep.
 # Single IC at a known convective event to keep the smoke test tight.
 
 defaults:
@@ -11,11 +11,12 @@ run_id: stormscope_2023_convection
 start_times:
     - "2023-12-05 12:00:00"
 
-nsteps: 2                   # 2 × 60min = 2h forecast
+nsteps: 2                   # 2 × 10min = 20min forecast
 
 # The StormScope pipeline sets needs_data_source=False, so main.py neither
 # resolves a top-level ic_source/data_source nor enforces the predownload
-# sentinel.  Data sources are resolved inside cfg.model.{goes,mrms}.ic_source.
+# sentinel.  Data sources are resolved inside cfg.model.{goes,mrms}.ic_source
+# (radar) and cfg.model.mrms.glm_data_source (lightning).
 #
 # Bring-your-own data: override the per-model ic_source entries below.
 # If your BYO store is already on the HRRR grid, point ic_grid at a resolver
@@ -36,50 +37,28 @@ nsteps: 2                   # 2 × 60min = 2h forecast
 #         ic_grid:
 #             _target_: my_pkg.my_mrms_grid
 #
-# ---------------------------------------------------------------------------
-# Conditioning source extensions
-# ---------------------------------------------------------------------------
-# The GOES model fetches conditioning (default: GFS_FX) once per forecast
-# step.  For longer rollouts or multi-IC campaigns, predownloading the
-# conditioning is a large speedup.  Two knobs are available:
-#
-# 1) Cadence rounding — useful when the source's native resolution is
-#    coarser than the model's step (e.g., hourly GFS with a 10-min
-#    StormScope variant).  Rounds each requested valid time to the
-#    nearest cadence boundary at predownload AND at inference, so the
-#    6x redundant fetches per hour collapse to 1.  Safe default for
-#    synoptic-scale conditioning.
-#
-model:
-    goes:
-        conditioning_cadence: "1h"
-#
-# 2) ERA5 reanalysis instead of GFS forecast — useful for ablations that
-#    compare skill against a "ground truth" conditioning signal.
-#    ARCO is a DataSource (not a ForecastSource), so no
-#    ValidTimeForecastAdapter is needed in the predownload path.
-#
-# model:
-#     goes:
-#         load_args:
-#             conditioning_data_source:
-#                 _target_: earth2studio.data.ARCO
-#         conditioning_grid:
-#             _target_: src.grids.arco_grid
-#         conditioning_cadence: "1h"   # ARCO is hourly too
-#
-#    Note: the GOES model's conditioning_variables are fixed by the
-#    loaded checkpoint (e.g. ``["z500"]``).  Whichever source you wire
-#    in must supply those variables under the same names in the
-#    earth2studio lexicon.
+# GLM (glm_density) is a state channel sourced from GOESGLMGrid on a
+# 0.1-degree grid and bilinearly regridded to the model grid.  Predownload
+# writes it to data_glm.zarr (alongside data_goes.zarr / data_mrms.zarr);
+# at inference the MRMS state is reassembled from the radar + GLM stores via
+# a CompositeSource.  To bring your own GLM store, override
+# model.mrms.glm_data_source / model.mrms.glm_grid the same way.
 
 output:
     variables:
+        # GOES ABI channels (8)
         - abi01c
         - abi02c
+        - abi03c
         - abi07c
+        - abi08c
+        - abi09c
+        - abi10c
         - abi13c
+        # MRMS radar + GLM lightning
         - refc
+        - refc_base
+        - glm_density
     overwrite: true
     thread_writers: 0       # conservative while we validate multi-model writes
     chunks:
@@ -109,26 +88,35 @@ scoring:
     # -9999, which otherwise dominate the sum-of-squares; with a valid
     # range of [0, 75] dBZ those pixels become 0 (matching the model's
     # zero-fill at invalid grid points) and contribute 0 to the RMSE.
+    # GLM counts are non-negative; clamp the lower bound at 0.
     # Leave a bound null for a one-sided clamp.
     valid_ranges:
         refc: {min: 0}
+        refc_base: {min: 0}
+        glm_density: {min: 0}
         abi01c: {min: 0, max: 1.0}
         abi02c: {min: 0, max: 1.0}
+        abi03c: {min: 0, max: 1.0}
         abi07c: {min: 200, max: 320}
+        abi08c: {min: 200, max: 320}
+        abi09c: {min: 200, max: 320}
+        abi10c: {min: 200, max: 320}
         abi13c: {min: 200, max: 320}
 
 # ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 # HRRR-native projection; prediction/verification zarrs carry y/x in meters.
-# variable_groups keeps GOES channels and MRMS radar in separate plots so
-# the color scales don't collide.
+# variable_groups keeps GOES channels, MRMS radar, and GLM in separate plots
+# so the color scales don't collide.
 report:
-    title: "StormScope GOES+MRMS — 2023-12-05 Convection"
+    title: "StormScope GOES+MRMS+GLM — 2023-12-05 Convection"
 
     variable_groups:
-        goes_abi: [abi01c, abi02c, abi07c, abi13c]
-        mrms: [refc]
+        goes_visible: [abi01c, abi02c, abi03c]
+        goes_ir: [abi07c, abi08c, abi09c, abi10c, abi13c]
+        mrms: [refc, refc_base]
+        glm: [glm_density]
 
     projection: hrrr_lambert
 
@@ -137,19 +125,27 @@ report:
     # offset, not skill.  Hide it for this campaign.
     show_diff: false
 
-    # 60-min stride, 2h rollout — days on the x-axis would compress
-    # every tick near zero.  Hours are readable.
-    lead_time_axis_unit: hours
+    # 10-min stride, 1h rollout — days on the x-axis would compress every
+    # tick near zero.  Minutes are readable.
+    lead_time_axis_unit: minutes
 
     # Per-variable visualization color ranges.  Omit a key to auto-scale
-    # (nanmin/nanmax).  MRMS refc in particular has large-negative
-    # no-data fill values that otherwise crush the usable range, so we
-    # clamp to the physical 0–75 dBZ window.
+    # (nanmin/nanmax).  MRMS refc in particular has large-negative no-data
+    # fill values that otherwise crush the usable range, so we clamp to the
+    # physical 0–75 dBZ window.  GLM is a sparse non-negative count field.
     color_ranges:
         refc:
             vmin: 0
             vmax: 75
             diff_abs: 40
+        refc_base:
+            vmin: 0
+            vmax: 75
+            diff_abs: 40
+        glm_density:            # lightning event counts per cell
+            vmin: 0
+            vmax: 5
+            diff_abs: 5
         abi01c:                 # visible reflectance — unitless 0..1
             vmin: 0
             vmax: 1.0
@@ -158,7 +154,23 @@ report:
             vmin: 0
             vmax: 1.0
             diff_abs: 0.5
+        abi03c:
+            vmin: 0
+            vmax: 1.0
+            diff_abs: 0.5
         abi07c:                 # IR brightness temperature (K)
+            vmin: 200
+            vmax: 320
+            diff_abs: 30
+        abi08c:
+            vmin: 200
+            vmax: 320
+            diff_abs: 30
+        abi09c:
+            vmin: 200
+            vmax: 320
+            diff_abs: 30
+        abi10c:
             vmin: 200
             vmax: 320
             diff_abs: 30
@@ -170,18 +182,18 @@ report:
     sections:
         - type: header_visualization
           variable: refc
-          lead_time: "120 min"
+          lead_time: "60 min"
 
         - type: summary_table
-          lead_times: ["60 min", "120 min"]
+          lead_times: ["30 min", "60 min"]
           collapsed: false
 
         - type: lead_time_curves
           collapsed: false
 
         - type: visualization
-          variables: [abi13c, refc]
-          lead_times: ["60 min", "120 min"]
+          variables: [abi13c, refc, glm_density]
+          lead_times: ["30 min", "60 min"]
           collapsed: true
 
         - type: ic_heatmap

--- a/recipes/eval/cfg/model/stormscope_goes_mrms.yaml
+++ b/recipes/eval/cfg/model/stormscope_goes_mrms.yaml
@@ -1,23 +1,38 @@
-# StormScope coupled GOES + MRMS nowcasting (60-min variants)
+# StormScope coupled GOES + MRMS + GLM nowcasting (3km / 10-min default).
 # The pipeline runs both models together:
-#   * StormScopeGOES forecasts GOES channels, conditioned on GFS z500.
-#   * StormScopeMRMS forecasts radar reflectivity (refc), conditioned on
-#     GOES (observations at IC, then the GOES model's own predictions).
+#   * StormScopeGOES forecasts the eight ABI channels.  The 3km_10min variant
+#     is "pure obs" — no external conditioning source.
+#   * StormScopeMRMS forecasts radar reflectivity ([refc, refc_base]) plus a
+#     gridded GLM lightning channel (glm_density), conditioned on GOES
+#     (observations at IC, then the GOES model's own predictions).
 # Both operate on the HRRR Lambert-conformal grid (y, x).
 #
-# `cache: false` on every data source disables the per-source on-disk
-# cache (~/.cache/earth2studio).  Predownload writes its own dedicated
-# zarr under <output.path>/ (data_goes.zarr / data_mrms.zarr, already
-# regridded to the HRRR sub-region), so leaving the cache on would
-# store the much larger raw GOES/MRMS footprint a second time on disk.
+# GLM (glm_density) is a state channel: it is both an input (observation
+# history) and a predicted output that evolves autoregressively.  It is
+# sourced from earth2studio.data.GOESGLMGrid on a 0.1-degree lat/lon grid and
+# regridded *bilinearly* onto the model grid (unlike the nearest-neighbor
+# radar/satellite path).  Predownload writes it to data_glm.zarr; see the
+# recipe README "Multi-source pipelines (StormScope)" section.
+#
+# `cache: false` on every data source disables the per-source on-disk cache
+# (~/.cache/earth2studio).  Predownload writes its own dedicated, already
+# HRRR-regridded zarrs under <output.path>/ (data_goes.zarr / data_mrms.zarr /
+# data_glm.zarr), so leaving the cache on would store the much larger raw
+# GOES/MRMS/GLM footprint a second time on disk.
 
 goes:
     architecture: earth2studio.models.px.StormScopeGOES
     load_args:
-        model_name: 6km_60min_natten_cos_zenith_input_eoe_v2
-        conditioning_data_source:
-            _target_: earth2studio.data.GFS_FX
-            cache: false
+        model_name: 3km_10min
+        # 3km_10min GOES is pure-obs: no external conditioning source.
+        conditioning_data_source: null
+        # Mixed precision + torch.compile of the diffusion experts.  compile
+        # is REQUIRED at this domain size: it makes NATTEN's flex attention
+        # build a sparse block mask, whereas the eager path materializes a
+        # dense [B, H, Q, KV] mask and OOMs (tens of GiB) on the full HRRR
+        # 3km grid.  Matches the notebook example's load_model settings.
+        amp: true
+        compile: true
     ic_source:
         _target_: earth2studio.data.GOES
         satellite: goes16
@@ -27,28 +42,47 @@ goes:
         _target_: src.grids.goes_grid
         satellite: goes16
         scan_mode: C
-    conditioning_grid:
-        _target_: src.grids.gfs_grid
+    # No conditioning_grid — the pure-obs GOES variant has no conditioning
+    # source, so no conditioning interpolator (or cond_goes.zarr) is built.
 
 mrms:
     architecture: earth2studio.models.px.StormScopeMRMS
     load_args:
-        model_name: 6km_60min_natten_cos_zenith_input_mrms_eoe
+        model_name: 3km_10min
+        # In the coupled rollout MRMS conditioning is supplied externally
+        # (the GOES state via call_with_conditioning); this source is used
+        # only to satisfy the model API and as a live fallback.
         conditioning_data_source:
             _target_: earth2studio.data.GOES
             satellite: goes16
             scan_mode: C
             cache: false
+        # Gridded GLM lightning source for the glm_density state channel.
+        glm_data_source:
+            _target_: earth2studio.data.GOESGLMGrid
+            satellite: east
+            cache: false
+        # See the GOES block: compile is required to avoid the dense NATTEN
+        # flex-attention mask OOM at this domain size.
+        amp: true
+        compile: true
     ic_source:
         _target_: earth2studio.data.MRMS
         cache: false
     ic_grid:
         _target_: src.grids.mrms_grid
+    # Source grid of the gridded GLM product (0.1-degree CONUS box).  Paired
+    # with a bilinear regridder at predownload time to resample GLM onto the
+    # model's HRRR sub-region exactly as the model would internally.
+    glm_grid:
+        _target_: src.grids.glm_grid
+        satellite: east
     conditioning_grid:
         _target_: src.grids.goes_grid
         satellite: goes16
         scan_mode: C
 
 # Nearest-neighbor tolerance for the input / conditioning interpolators.
-# Pixels farther than this from any source point become NaN.
+# Pixels farther than this from any source point become NaN.  (GLM uses
+# bilinear interpolation, which is not distance-thresholded.)
 max_dist_km: 30.0

--- a/recipes/eval/pyproject.toml
+++ b/recipes/eval/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   { name="NVIDIA Earth-2 Team" },
 ]
 dependencies = [
-    "earth2studio[data,dlwp,fcn3,perturbation,statistics,utils]",
+    "earth2studio[data,dlwp,fcn3,perturbation,statistics,stormscope,utils]",
     "hydra-core>=1.3.0",
     "omegaconf",
     "nvidia-physicsnemo>=2.0",

--- a/recipes/eval/src/distributed.py
+++ b/recipes/eval/src/distributed.py
@@ -28,6 +28,16 @@ from physicsnemo.distributed import DistributedManager
 T = TypeVar("T")
 
 
+def get_rank() -> int:
+    """Return the process rank, or 0 when distribution is not initialized.
+
+    Guards on ``DistributedManager.is_initialized()`` so we don't instantiate
+    an uninitialized manager (which warns / errors on CPU / unit-test runs).
+    Callers typically use this only to gate rank-0-only output such as tqdm.
+    """
+    return DistributedManager().rank if DistributedManager.is_initialized() else 0
+
+
 def run_on_rank0_first(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Execute a function on rank 0 first, barrier, then on remaining ranks.
 

--- a/recipes/eval/src/grids.py
+++ b/recipes/eval/src/grids.py
@@ -96,6 +96,32 @@ def arco_grid() -> tuple[torch.Tensor, torch.Tensor]:
     return _as_tensor(ARCO.ARCO_LAT), _as_tensor(ARCO.ARCO_LON)
 
 
+def glm_grid(
+    satellite: str = "east",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return ``(lats, lons)`` for the gridded GOES GLM lightning source.
+
+    Reads the 0.1-degree cell-centre ``lat`` / ``lon`` vectors exposed by
+    :class:`earth2studio.data.GOESGLMGrid`.  These are the source grid for
+    StormScope's ``glm_density`` state channel; the recipe pairs this
+    resolver with :class:`~src.regrid.BilinearRegridder` at predownload time
+    to resample GLM onto the model's HRRR sub-region exactly as the model's
+    internal ``build_glm_interpolator`` would.
+
+    The grid is fixed (regular 0.1-degree CONUS box) and independent of the
+    ``satellite`` selector, but the argument is accepted for symmetry with
+    the ``GOESGLMGrid`` constructor and the ``glm_data_source`` config block::
+
+        glm_grid:
+            _target_: src.grids.glm_grid
+            satellite: east
+    """
+    from earth2studio.data import GOESGLMGrid
+
+    grid = GOESGLMGrid(satellite=satellite)
+    return _as_tensor(grid.lat), _as_tensor(grid.lon)
+
+
 def mrms_grid(
     sample_time: str | datetime | None = None,
     variable: str = "refc",

--- a/recipes/eval/src/pipelines/base.py
+++ b/recipes/eval/src/pipelines/base.py
@@ -569,9 +569,12 @@ class Pipeline(ABC):
         if self._output_regridder is not None:
             self._output_regridder = self._output_regridder.to(device)
 
-        if not DistributedManager.is_initialized():
-            DistributedManager.initialize()
-        rank = DistributedManager().rank
+        # Rank only gates tqdm output below.  Default to 0 when the
+        # DistributedManager isn't initialized (unit tests, or single-process
+        # runs where main.py didn't set it up) rather than forcing
+        # initialization here — DistributedManager.initialize() requires an
+        # indexed accelerator on some backends and fails on CPU.
+        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
 
         # None is only passed when needs_data_source=False, in which case
         # the subclass's run_item ignores the argument.

--- a/recipes/eval/src/pipelines/base.py
+++ b/recipes/eval/src/pipelines/base.py
@@ -48,12 +48,12 @@ import numpy as np
 import torch
 from loguru import logger
 from omegaconf import DictConfig
-from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource
 from earth2studio.utils.coords import CoordSystem, map_coords
 from src.data import CompositeSource, PredownloadedSource
+from src.distributed import get_rank
 from src.output import OutputManager, build_output_coords
 from src.regrid import Regridder
 from src.work import WorkItem, write_marker
@@ -569,12 +569,8 @@ class Pipeline(ABC):
         if self._output_regridder is not None:
             self._output_regridder = self._output_regridder.to(device)
 
-        # Rank only gates tqdm output below.  Default to 0 when the
-        # DistributedManager isn't initialized (unit tests, or single-process
-        # runs where main.py didn't set it up) rather than forcing
-        # initialization here — DistributedManager.initialize() requires an
-        # indexed accelerator on some backends and fails on CPU.
-        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
+        # Rank only gates tqdm output below.
+        rank = get_rank()
 
         # None is only passed when needs_data_source=False, in which case
         # the subclass's run_item ignores the argument.

--- a/recipes/eval/src/pipelines/dlesym.py
+++ b/recipes/eval/src/pipelines/dlesym.py
@@ -23,12 +23,12 @@ from collections.abc import Iterator
 import numpy as np
 import torch
 from omegaconf import DictConfig
-from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource, fetch_data
 from earth2studio.utils.coords import CoordSystem, map_coords
 
+from ..distributed import get_rank
 from ..models import load_prognostic
 from ..work import WorkItem
 from .base import PredownloadStore
@@ -162,11 +162,8 @@ class DLESyMPipeline(ForecastPipeline):
         # ([-48h..0h] for DLESyM), outside the output zarr schema.
         next(model_iter)
 
-        # Rank only gates tqdm output below.  Default to 0 when the
-        # DistributedManager isn't initialized (unit tests, or single-process
-        # runs) rather than forcing initialization here — which requires an
-        # indexed accelerator on some backends and fails on CPU.
-        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
+        # Rank only gates tqdm output below.
+        rank = get_rank()
 
         for step, (x_step, coords_step) in enumerate(
             tqdm(

--- a/recipes/eval/src/pipelines/dlesym.py
+++ b/recipes/eval/src/pipelines/dlesym.py
@@ -27,7 +27,6 @@ from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource, fetch_data
-from earth2studio.models.px.dlesym import DLESyM
 from earth2studio.utils.coords import CoordSystem, map_coords
 
 from ..models import load_prognostic
@@ -163,9 +162,11 @@ class DLESyMPipeline(ForecastPipeline):
         # ([-48h..0h] for DLESyM), outside the output zarr schema.
         next(model_iter)
 
-        if not DistributedManager.is_initialized():
-            DistributedManager.initialize()
-        rank = DistributedManager().rank
+        # Rank only gates tqdm output below.  Default to 0 when the
+        # DistributedManager isn't initialized (unit tests, or single-process
+        # runs) rather than forcing initialization here — which requires an
+        # indexed accelerator on some backends and fails on CPU.
+        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
 
         for step, (x_step, coords_step) in enumerate(
             tqdm(
@@ -207,9 +208,10 @@ class DLESyMPipeline(ForecastPipeline):
         if not self._ocean_variables:
             return x_step
 
-        if not isinstance(self.prognostic, DLESyM):
+        if not hasattr(self.prognostic, "retrieve_valid_ocean_outputs"):
             raise ValueError(
-                "DLESyMPipeline expects the loaded prognostic to be a DLESyM model; "
+                "DLESyMPipeline expects the loaded prognostic to expose "
+                "retrieve_valid_ocean_outputs (as DLESyM / DLESyMLatLon do); "
                 f"Got: {type(self.prognostic).__name__}"
             )
         _, valid_coords = self.prognostic.retrieve_valid_ocean_outputs(

--- a/recipes/eval/src/pipelines/forecast.py
+++ b/recipes/eval/src/pipelines/forecast.py
@@ -205,7 +205,10 @@ class ForecastPipeline(Pipeline):
 
         model_iter = self.prognostic.create_iterator(x, coords)
 
-        rank = DistributedManager().rank
+        # Rank only gates tqdm output below.  Guard on is_initialized() so we
+        # don't instantiate an uninitialized DistributedManager (which warns /
+        # errors); default to 0 for single-process and unit-test runs.
+        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
 
         for step, (x_step, coords_step) in enumerate(
             tqdm(

--- a/recipes/eval/src/pipelines/forecast.py
+++ b/recipes/eval/src/pipelines/forecast.py
@@ -26,7 +26,6 @@ import numpy as np
 import torch
 import xarray as xr
 from omegaconf import DictConfig
-from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource, fetch_data
@@ -35,6 +34,7 @@ from earth2studio.models.px import PrognosticModel
 from earth2studio.perturbation import Perturbation
 from earth2studio.utils.coords import CoordSystem, cat_coords, map_coords
 
+from ..distributed import get_rank
 from ..models import load_diagnostics, load_prognostic
 from ..output import build_diagnostic_coords, build_forecast_coords
 from ..work import WorkItem
@@ -205,10 +205,8 @@ class ForecastPipeline(Pipeline):
 
         model_iter = self.prognostic.create_iterator(x, coords)
 
-        # Rank only gates tqdm output below.  Guard on is_initialized() so we
-        # don't instantiate an uninitialized DistributedManager (which warns /
-        # errors); default to 0 for single-process and unit-test runs.
-        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
+        # Rank only gates tqdm output below.
+        rank = get_rank()
 
         for step, (x_step, coords_step) in enumerate(
             tqdm(

--- a/recipes/eval/src/pipelines/stormscope.py
+++ b/recipes/eval/src/pipelines/stormscope.py
@@ -632,9 +632,9 @@ class StormScopePipeline(Pipeline):
         input window plus every forecast valid time — so it doubles as GLM
         verification for scoring ``glm_density``.
 
-        Returns ``None`` when the campaign config provides neither a
-        ``glm_data_source`` (under ``load_args``) nor a ``glm_grid`` resolver;
-        without those the GLM channel can't be sourced or regridded.
+        Returns ``None`` when the campaign config is missing either
+        ``glm_data_source`` (under ``load_args``) or a ``glm_grid`` resolver;
+        both are required to source and regrid the GLM channel.
         """
         glm_vars = [str(v) for v in getattr(model, "glm_variables", [])]
         if not glm_vars:

--- a/recipes/eval/src/pipelines/stormscope.py
+++ b/recipes/eval/src/pipelines/stormscope.py
@@ -38,11 +38,12 @@ from earth2studio.utils.coords import CoordSystem, cat_coords
 
 from ..data import (
     CadenceRoundedSource,
+    CompositeSource,
     PredownloadedSource,
     ValidTimeForecastAdapter,
     resolve_ic_source,
 )
-from ..regrid import NearestNeighborRegridder, RegriddedSource
+from ..regrid import BilinearRegridder, NearestNeighborRegridder, RegriddedSource
 from ..work import WorkItem
 from .base import Pipeline, PredownloadStore
 
@@ -50,40 +51,43 @@ from .base import Pipeline, PredownloadStore
 class StormScopePipeline(Pipeline):
     """Coupled GOES/MRMS nowcasting pipeline using StormScope models.
 
-    Runs two prognostic models together:
+    Runs two prognostic models together (default variant ``3km_10min``):
 
-    * :class:`earth2studio.models.px.StormScopeGOES` — forecasts GOES
-      satellite channels.  Conditioned on synoptic-scale GFS data (60-min
-      variants) or nothing (10-min variants).
+    * :class:`earth2studio.models.px.StormScopeGOES` — forecasts the GOES
+      ABI satellite channels.  The ``3km_10min`` variant is *pure obs*
+      (no external conditioning); legacy 60-min variants condition on
+      synoptic-scale GFS data.
     * :class:`earth2studio.models.px.StormScopeMRMS` — forecasts MRMS
-      composite reflectivity (``refc``), conditioned on GOES (either
-      observations at IC time or the GOES model's own predictions
-      during rollout).
+      reflectivity (``refc``, ``refc_base``) plus a gridded GLM lightning
+      channel (``glm_density``), conditioned on GOES (either observations
+      at IC time or the GOES model's own predictions during rollout).
 
     Both models share the HRRR Lambert-conformal grid (``y``, ``x``)
     and the pipeline yields a combined ``(variables × y × x)`` tensor
-    per forecast step — GOES channels and MRMS refc stacked along the
-    ``variable`` axis so the output zarr is a single unified store.
+    per forecast step — GOES channels, MRMS radar, and GLM stacked along
+    the ``variable`` axis so the output zarr is a single unified store.
 
     Config shape
     ------------
-    Expected structure under ``cfg.model``::
+    Expected structure under ``cfg.model`` (see
+    ``cfg/model/stormscope_goes_mrms.yaml``)::
 
         goes:
             architecture: earth2studio.models.px.StormScopeGOES
             load_args:
-                model_name: 6km_60min_natten_cos_zenith_input_eoe_v2
-                conditioning_data_source: {_target_: earth2studio.data.GFS_FX}
+                model_name: 3km_10min
+                conditioning_data_source: null      # pure-obs
             ic_source: {_target_: earth2studio.data.GOES, satellite: goes16, scan_mode: C}
             ic_grid: {_target_: src.grids.goes_grid, satellite: goes16, scan_mode: C}
-            conditioning_grid: {_target_: src.grids.gfs_grid}
         mrms:
             architecture: earth2studio.models.px.StormScopeMRMS
             load_args:
-                model_name: 6km_60min_natten_cos_zenith_input_mrms_eoe
+                model_name: 3km_10min
                 conditioning_data_source: {_target_: earth2studio.data.GOES, ...}
+                glm_data_source: {_target_: earth2studio.data.GOESGLMGrid, satellite: east}
             ic_source: {_target_: earth2studio.data.MRMS}
             ic_grid: {_target_: src.grids.mrms_grid}
+            glm_grid: {_target_: src.grids.glm_grid, satellite: east}
             conditioning_grid: {_target_: src.grids.goes_grid, ...}
         max_dist_km: 30.0     # optional; passed to build_*_interpolator
 
@@ -104,20 +108,27 @@ class StormScopePipeline(Pipeline):
     Predownload
     -----------
     :meth:`predownload_stores` declares one zarr per IC source
-    (``data_goes.zarr``, ``data_mrms.zarr``), each wrapped in a
-    :class:`~src.regrid.RegriddedSource` that resamples the raw source
-    onto the model's HRRR sub-region at write time.  The resulting
-    store has ``(time, y, x)`` dims whose ``y``/``x`` values match the
-    model's native grid exactly — so at inference time
+    (``data_goes.zarr``, ``data_mrms.zarr``) plus, for GLM-bearing
+    variants, a ``data_glm.zarr`` for the ``glm_density`` state channel.
+    Each is wrapped in a :class:`~src.regrid.RegriddedSource` that
+    resamples the raw source onto the model's HRRR sub-region at write
+    time — **nearest-neighbor** for radar/satellite, **bilinear** for the
+    sparse GLM count field (matching
+    :meth:`StormScopeMRMS.build_glm_interpolator`).  The resulting stores
+    have ``(time, y, x)`` dims whose ``y``/``x`` values match the model's
+    native grid exactly — so at inference time
     :meth:`StormScopeBase.prep_input` detects the match and skips its
     live interpolation.
 
     :meth:`setup` auto-detects the predownloaded stores under
-    ``<output.path>/data_{goes,mrms}.zarr`` and uses
-    :class:`~src.data.PredownloadedSource` in their place.  Users can
-    skip predownload entirely with per-model BYO overrides (see
-    :class:`StormScopePipeline` docstring) or by pointing to raw live
-    sources and running with the model's live interpolators.
+    ``<output.path>/data_{goes,mrms,glm}.zarr`` and uses
+    :class:`~src.data.PredownloadedSource` in their place.  The MRMS state
+    spans two grids (radar + GLM), so its IC is reassembled from
+    ``data_mrms.zarr`` + ``data_glm.zarr`` via a
+    :class:`~src.data.CompositeSource`.  Users can skip predownload
+    entirely with per-model BYO overrides (see :class:`StormScopePipeline`
+    docstring) or by pointing to raw live sources and running with the
+    model's live interpolators.
     """
 
     needs_data_source = False
@@ -194,11 +205,7 @@ class StormScopePipeline(Pipeline):
             store_name="data_goes.zarr",
             live_source=cfg.model.goes.ic_source,
         )
-        self._mrms_ic_source = resolve_ic_source(
-            cfg,
-            store_name="data_mrms.zarr",
-            live_source=cfg.model.mrms.ic_source,
-        )
+        self._mrms_ic_source = self._resolve_mrms_ic_source(cfg)
 
         # Conditioning source: swap in the predownloaded, regridded zarr
         # (<output.path>/cond_goes.zarr) when present so the GOES model's
@@ -285,9 +292,11 @@ class StormScopePipeline(Pipeline):
         # expose a set_rng hook; torch.manual_seed is the supported path.
         torch.manual_seed(item.seed)
 
-        if not DistributedManager.is_initialized():
-            DistributedManager.initialize()
-        rank = DistributedManager().rank
+        # Rank only gates tqdm output below.  Default to 0 when the
+        # DistributedManager isn't initialized (unit tests, or single-process
+        # runs) rather than forcing initialization here — which requires an
+        # indexed accelerator on some backends and fails on CPU.
+        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
 
         for step_idx in tqdm(
             range(self.nsteps),
@@ -331,12 +340,17 @@ class StormScopePipeline(Pipeline):
     # ------------------------------------------------------------------
 
     def predownload_stores(self, cfg: DictConfig) -> list[PredownloadStore]:
-        """Declare one regridded IC + verification store per StormScope model.
+        """Declare the regridded IC + verification stores for StormScope.
 
-        Each store holds data pre-resampled onto the model's HRRR
-        sub-region via a :class:`~src.regrid.NearestNeighborRegridder`,
-        so the inference-time ``prep_input`` grid-match check passes
-        and the live interpolator never runs.
+        One store per IC source — ``data_goes`` (satellite) and
+        ``data_mrms`` (radar) — plus, for GLM-bearing variants, a
+        ``data_glm`` store for the ``glm_density`` state channel.  Radar
+        and satellite are resampled onto the model's HRRR sub-region via a
+        :class:`~src.regrid.NearestNeighborRegridder`; the sparse GLM count
+        field uses a :class:`~src.regrid.BilinearRegridder` (see
+        :meth:`_build_glm_store`).  In every case the inference-time
+        ``prep_input`` grid-match check passes and the live interpolator
+        never runs.
 
         The stored times are the union of:
 
@@ -387,14 +401,8 @@ class StormScopePipeline(Pipeline):
 
             max_dist_km = cfg.model.get("max_dist_km", None)
             src_lat, src_lon = hydra.utils.instantiate(model_cfg.ic_grid)
-            regridder = NearestNeighborRegridder(
-                source_lats=src_lat,
-                source_lons=src_lon,
-                target_lats=model.latitudes,
-                target_lons=model.longitudes,
-                target_y=_as_np(model.y),
-                target_x=_as_np(model.x),
-                max_dist_km=(float(max_dist_km) if max_dist_km is not None else 12.0),
+            regridder = _nn_regridder(
+                model, src_lat, src_lon, max_dist_km, default_km=12.0
             )
 
             raw_source = hydra.utils.instantiate(model_cfg.ic_source)
@@ -419,16 +427,35 @@ class StormScopePipeline(Pipeline):
                 ]
             )
 
+            # GLM-bearing MRMS variants (``3km_10min``) carry a ``glm_density``
+            # state channel sourced from a different grid than radar.  Split it
+            # into its own bilinear-regridded ``data_glm.zarr`` store; the radar
+            # store (``ic_source``) then holds only the radar channels.  At
+            # inference the two are recombined via a CompositeSource.
+            glm_vars = {str(v) for v in getattr(model, "glm_variables", [])}
+            radar_vars = [
+                str(v) for v in ic_coords["variable"] if str(v) not in glm_vars
+            ]
             stores.append(
                 PredownloadStore(
                     name=f"data_{side}",
                     source=wrapped,
                     times=fetch_times,
-                    variables=[str(v) for v in ic_coords["variable"]],
+                    variables=radar_vars,
                     spatial_ref=spatial_ref,
                     role="ic",
                 )
             )
+
+            if glm_vars:
+                glm_store = self._build_glm_store(
+                    model=model,
+                    model_cfg=model_cfg,
+                    fetch_times=fetch_times,
+                    spatial_ref=spatial_ref,
+                )
+                if glm_store is not None:
+                    stores.append(glm_store)
 
             # Conditioning predownload — only for the GOES model.  In our
             # coupling loop MRMS is always called via call_with_conditioning,
@@ -485,7 +512,13 @@ class StormScopePipeline(Pipeline):
         cutting redundant 10-minute fetches from campaigns that use a
         sub-hour-stride model.
         """
-        cond_vars: list[str] = [str(v) for v in (model.conditioning_variables or [])]
+        # conditioning_variables may be a numpy array (truth-testing an array
+        # is ambiguous) or None — normalize before iterating.  Pure-obs
+        # variants (e.g. GOES 3km_10min) expose an empty array.
+        cond_vars_raw = model.conditioning_variables
+        cond_vars: list[str] = (
+            [] if cond_vars_raw is None else [str(v) for v in cond_vars_raw]
+        )
         if not cond_vars:
             return None
         if model_cfg.get("conditioning_grid") is None:
@@ -577,6 +610,66 @@ class StormScopePipeline(Pipeline):
             role="conditioning",
         )
 
+    def _build_glm_store(
+        self,
+        *,
+        model: Any,
+        model_cfg: DictConfig,
+        fetch_times: list[np.datetime64],
+        spatial_ref: CoordSystem,
+    ) -> PredownloadStore | None:
+        """Build the ``data_glm.zarr`` predownload store for a GLM-bearing model.
+
+        The gridded GLM source (:class:`~earth2studio.data.GOESGLMGrid`) lives
+        on a 0.1-degree lat/lon grid, so it is resampled onto the model's HRRR
+        sub-region with a :class:`~src.regrid.BilinearRegridder` — the same
+        bilinear map the model applies internally
+        (:meth:`StormScopeMRMS.build_glm_interpolator`) — rather than the
+        nearest-neighbor path used for radar/satellite channels.  Stored counts
+        are physical (the model applies ``log1p`` at inference).
+
+        The store covers the same ``fetch_times`` as the radar store — the IC
+        input window plus every forecast valid time — so it doubles as GLM
+        verification for scoring ``glm_density``.
+
+        Returns ``None`` when the campaign config provides neither a
+        ``glm_data_source`` (under ``load_args``) nor a ``glm_grid`` resolver;
+        without those the GLM channel can't be sourced or regridded.
+        """
+        glm_vars = [str(v) for v in getattr(model, "glm_variables", [])]
+        if not glm_vars:
+            return None
+
+        glm_source_cfg = model_cfg.get("load_args", {}).get("glm_data_source")
+        if glm_source_cfg is None:
+            logger.warning(
+                "StormScope mrms: model has GLM state channels but no "
+                "load_args.glm_data_source is configured — skipping GLM "
+                "predownload.  GLM will be fetched live at inference."
+            )
+            return None
+        if model_cfg.get("glm_grid") is None:
+            logger.warning(
+                "StormScope mrms: glm_grid resolver not configured — cannot "
+                "regrid GLM at predownload.  GLM will be fetched live at "
+                "inference."
+            )
+            return None
+
+        glm_src_lat, glm_src_lon = hydra.utils.instantiate(model_cfg.glm_grid)
+        glm_regridder = _bilinear_regridder(model, glm_src_lat, glm_src_lon)
+        raw_glm_source = hydra.utils.instantiate(glm_source_cfg)
+        wrapped_glm = RegriddedSource(raw_glm_source, glm_regridder)
+
+        return PredownloadStore(
+            name="data_glm",
+            source=wrapped_glm,
+            times=fetch_times,
+            variables=glm_vars,
+            spatial_ref=spatial_ref,
+            role="ic",
+        )
+
     # Verification sourcing is handled by the base class: its
     # default `Pipeline.verification_source` picks up
     # ``data_{goes,mrms}.zarr`` via the ``data_*.zarr`` glob and wraps
@@ -637,6 +730,117 @@ class StormScopePipeline(Pipeline):
                 f"{cache_path}"
             )
         model.conditioning_data_source = source
+
+    def _resolve_mrms_ic_source(self, cfg: DictConfig) -> DataSource:
+        """Resolve the MRMS initial-condition source.
+
+        For GLM-bearing variants (``3km_10min``), the MRMS state spans two
+        native grids — radar (``refc`` / ``refc_base`` from
+        :class:`~earth2studio.data.MRMS`) and lightning (``glm_density`` from
+        :class:`~earth2studio.data.GOESGLMGrid`) — so no single source can
+        supply it.  We build a :class:`~src.data.CompositeSource` that
+        dispatches radar variables to one component and GLM to the other,
+        with each component resolved independently:
+
+        * a predownloaded, already-regridded zarr (``data_mrms.zarr`` /
+          ``data_glm.zarr``) when present — the cheap inference path; or
+        * a live source wrapped in the matching regridder (nearest-neighbor
+          for radar, **bilinear** for GLM, matching training) so both land
+          on the model ``y`` / ``x`` grid.
+
+        Either way the assembled state is already on the model grid, so
+        :meth:`StormScopeBase.prep_input` skips re-interpolation and the
+        ``glm_density`` channel then evolves autoregressively through
+        :meth:`next_input` (``call_with_conditioning`` never re-fetches it).
+
+        Variants without GLM channels keep the original single-source
+        resolution (predownloaded ``data_mrms.zarr`` → live ``ic_source``).
+        """
+        if int(getattr(self.model_mrms, "n_glm_channels", 0)) <= 0:
+            return resolve_ic_source(
+                cfg,
+                store_name="data_mrms.zarr",
+                live_source=cfg.model.mrms.ic_source,
+            )
+
+        model_cfg = cfg.model.mrms
+        max_dist_km = cfg.model.get("max_dist_km", None)
+        glm_vars = {str(v) for v in self.model_mrms.glm_variables}
+
+        # Resolve config nodes lazily (``.get``) — a campaign that relies on the
+        # predownloaded stores may omit the live ic_source / glm_data_source /
+        # grid blocks entirely; they're only needed for the live fallback.
+        radar_src = self._resolve_component_source(
+            cfg,
+            store_name="data_mrms.zarr",
+            raw_source_cfg=model_cfg.get("ic_source"),
+            grid_cfg=model_cfg.get("ic_grid"),
+            regridder_kind="nearest",
+            max_dist_km=max_dist_km,
+        )
+        glm_src = self._resolve_component_source(
+            cfg,
+            store_name="data_glm.zarr",
+            raw_source_cfg=model_cfg.get("load_args", {}).get("glm_data_source"),
+            grid_cfg=model_cfg.get("glm_grid"),
+            regridder_kind="bilinear",
+            max_dist_km=max_dist_km,
+        )
+
+        sources: dict[str, DataSource] = {"data_mrms": radar_src, "data_glm": glm_src}
+        variable_index = {
+            str(v): ("data_glm" if str(v) in glm_vars else "data_mrms")
+            for v in self.model_mrms.variables
+        }
+        logger.info(
+            "StormScope mrms: assembling GLM-bearing IC state from radar + GLM "
+            "component sources (composite)."
+        )
+        return CompositeSource(sources, variable_index)
+
+    def _resolve_component_source(
+        self,
+        cfg: DictConfig,
+        *,
+        store_name: str,
+        raw_source_cfg: Any,
+        grid_cfg: Any,
+        regridder_kind: str,
+        max_dist_km: float | None,
+    ) -> DataSource:
+        """Resolve one component of the composite MRMS IC source.
+
+        Returns a :class:`~src.data.PredownloadedSource` when the regridded
+        zarr ``<output.path>/<store_name>`` exists; otherwise instantiates
+        the live source and wraps it in the appropriate regridder so its
+        output lands on the model ``y`` / ``x`` grid.
+        """
+        cache_path = os.path.join(cfg.output.path, store_name)
+        if os.path.exists(cache_path):
+            logger.info(f"StormScope mrms: using predownloaded {store_name}")
+            return PredownloadedSource(cache_path)
+
+        if raw_source_cfg is None or grid_cfg is None:
+            raise ValueError(
+                f"StormScope mrms: no predownloaded '{store_name}' and the live "
+                "fallback is unconfigured (missing source and/or grid block). "
+                "Either run predownload.py first, or provide the live source and "
+                "its grid resolver in cfg.model.mrms."
+            )
+
+        logger.info(
+            f"StormScope mrms: no {store_name} cache — wrapping live source "
+            f"in a {regridder_kind} regridder onto the model grid."
+        )
+        raw_source = hydra.utils.instantiate(raw_source_cfg)
+        src_lat, src_lon = hydra.utils.instantiate(grid_cfg)
+        if regridder_kind == "bilinear":
+            regridder: Any = _bilinear_regridder(self.model_mrms, src_lat, src_lon)
+        else:
+            regridder = _nn_regridder(
+                self.model_mrms, src_lat, src_lon, max_dist_km, default_km=12.0
+            )
+        return RegriddedSource(raw_source, regridder)
 
     def _fetch_ic(
         self,
@@ -702,6 +906,41 @@ def _load_stormscope_model(model_cfg: DictConfig) -> Any:
         f"(model_name={resolved.get('model_name', 'default')})"
     )
     return model
+
+
+def _nn_regridder(
+    model: Any,
+    src_lat: Any,
+    src_lon: Any,
+    max_dist_km: float | None,
+    *,
+    default_km: float,
+) -> NearestNeighborRegridder:
+    """Build a nearest-neighbor regridder from a source grid onto ``model``'s
+    HRRR sub-region.  Used for radar / satellite channels."""
+    return NearestNeighborRegridder(
+        source_lats=src_lat,
+        source_lons=src_lon,
+        target_lats=model.latitudes,
+        target_lons=model.longitudes,
+        target_y=_as_np(model.y),
+        target_x=_as_np(model.x),
+        max_dist_km=(float(max_dist_km) if max_dist_km is not None else default_km),
+    )
+
+
+def _bilinear_regridder(model: Any, src_lat: Any, src_lon: Any) -> BilinearRegridder:
+    """Build a bilinear regridder from a source grid onto ``model``'s HRRR
+    sub-region.  Used for the sparse ``glm_density`` lightning field, matching
+    the model's internal :meth:`StormScopeMRMS.build_glm_interpolator`."""
+    return BilinearRegridder(
+        source_lats=src_lat,
+        source_lons=src_lon,
+        target_lats=model.latitudes,
+        target_lons=model.longitudes,
+        target_y=_as_np(model.y),
+        target_x=_as_np(model.x),
+    )
 
 
 def _infer_step_delta(model: Any) -> np.timedelta64:

--- a/recipes/eval/src/pipelines/stormscope.py
+++ b/recipes/eval/src/pipelines/stormscope.py
@@ -30,7 +30,6 @@ import pandas as pd
 import torch
 from loguru import logger
 from omegaconf import DictConfig
-from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource, fetch_data
@@ -43,6 +42,7 @@ from ..data import (
     ValidTimeForecastAdapter,
     resolve_ic_source,
 )
+from ..distributed import get_rank
 from ..regrid import BilinearRegridder, NearestNeighborRegridder, RegriddedSource
 from ..work import WorkItem
 from .base import Pipeline, PredownloadStore
@@ -292,11 +292,8 @@ class StormScopePipeline(Pipeline):
         # expose a set_rng hook; torch.manual_seed is the supported path.
         torch.manual_seed(item.seed)
 
-        # Rank only gates tqdm output below.  Default to 0 when the
-        # DistributedManager isn't initialized (unit tests, or single-process
-        # runs) rather than forcing initialization here — which requires an
-        # indexed accelerator on some backends and fails on CPU.
-        rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
+        # Rank only gates tqdm output below.
+        rank = get_rank()
 
         for step_idx in tqdm(
             range(self.nsteps),
@@ -645,14 +642,17 @@ class StormScopePipeline(Pipeline):
             logger.warning(
                 "StormScope mrms: model has GLM state channels but no "
                 "load_args.glm_data_source is configured — skipping GLM "
-                "predownload.  GLM will be fetched live at inference."
+                "predownload.  Inference will fail unless a predownloaded "
+                "data_glm.zarr (or a configured glm_data_source + glm_grid "
+                "for the live fallback) is provided."
             )
             return None
         if model_cfg.get("glm_grid") is None:
             logger.warning(
                 "StormScope mrms: glm_grid resolver not configured — cannot "
-                "regrid GLM at predownload.  GLM will be fetched live at "
-                "inference."
+                "regrid GLM at predownload.  Inference will fail unless a "
+                "predownloaded data_glm.zarr (or a configured glm_grid for "
+                "the live fallback) is provided."
             )
             return None
 

--- a/recipes/eval/src/regrid.py
+++ b/recipes/eval/src/regrid.py
@@ -49,7 +49,7 @@ from numpy.typing import ArrayLike
 
 from earth2studio.data import DataSource
 from earth2studio.utils.coords import CoordSystem
-from earth2studio.utils.interp import NearestNeighborInterpolator
+from earth2studio.utils.interp import LatLonInterpolation, NearestNeighborInterpolator
 from earth2studio.utils.type import TimeArray, VariableArray
 
 
@@ -248,6 +248,113 @@ class NearestNeighborRegridder(Regridder):
                 f"spatial dims, got {spatial_dims}"
             )
         return self._interp(x)
+
+
+class BilinearRegridder(Regridder):
+    """Bilinear regridder backed by earth2studio's ``LatLonInterpolation``.
+
+    Wraps :class:`earth2studio.utils.interp.LatLonInterpolation` to resample a
+    field from a source lat/lon grid onto an arbitrary (possibly curvilinear)
+    target grid.  The counterpart to :class:`NearestNeighborRegridder`: prefer
+    bilinear when a smooth field should be interpolated rather than snapped to
+    the closest source cell, and nearest-neighbor for categorical / masked
+    fields or when source and target resolutions are comparable.  Unlike the
+    nearest-neighbor regridder, bilinear interpolation is not thresholded by
+    distance; target points outside the source grid receive *fill_value*.
+
+    The heavy setup (building the interpolation index) runs once at
+    construction; :meth:`apply` is a fast gather that runs on whatever device
+    the regridder has been moved to via :meth:`to`.
+
+    A representative use in this recipe is StormScope's ``glm_density`` state
+    channel: :class:`earth2studio.models.px.StormScopeMRMS` regrids the sparse
+    0.1-degree lightning-count field bilinearly onto its model grid via
+    :meth:`StormScopeMRMS.build_glm_interpolator`, so predownloading through
+    this class (with the matching source/target grids and ``fill_value=0``)
+    yields values numerically identical to the model's live ``fetch_glm``
+    path — the inference run then reads them straight off disk with no
+    re-interpolation.
+
+    Parameters
+    ----------
+    source_lats, source_lons : torch.Tensor | ArrayLike
+        Source grid coordinates.  2D ``[H_src, W_src]`` meshgrids or 1D
+        vectors (promoted internally via ``meshgrid``).
+    target_lats, target_lons : torch.Tensor | ArrayLike
+        Target grid coordinates.  Either 2D meshgrids (for curvilinear grids
+        such as HRRR Lambert-conformal) or 1D vectors.  The target grid must
+        be contained within the source grid (a requirement of
+        ``LatLonInterpolation``).
+    target_y, target_x : ArrayLike
+        1D index coordinates of the target grid, written to the output zarr
+        alongside the regridded data.
+    target_dim_names : tuple[str, str]
+        Output spatial dimension names.  Default ``("y", "x")``; pass
+        ``("lat", "lon")`` for a regular target grid.
+    fill_value : float
+        Value assigned to target points outside the source grid (NaN from the
+        interpolator).  Default ``0.0``.
+    """
+
+    def __init__(
+        self,
+        source_lats: torch.Tensor | ArrayLike,
+        source_lons: torch.Tensor | ArrayLike,
+        target_lats: torch.Tensor | ArrayLike,
+        target_lons: torch.Tensor | ArrayLike,
+        *,
+        target_y: ArrayLike,
+        target_x: ArrayLike,
+        target_dim_names: tuple[str, str] = ("y", "x"),
+        fill_value: float = 0.0,
+    ) -> None:
+        src_lats = np.asarray(
+            source_lats.cpu() if isinstance(source_lats, torch.Tensor) else source_lats
+        )
+        src_lons = np.asarray(
+            source_lons.cpu() if isinstance(source_lons, torch.Tensor) else source_lons
+        )
+        if src_lats.ndim == 1 and src_lons.ndim == 1:
+            src_lats, src_lons = np.meshgrid(src_lats, src_lons, indexing="ij")
+        self._interp = LatLonInterpolation(
+            lat_in=src_lats,
+            lon_in=src_lons,
+            lat_out=target_lats,
+            lon_out=target_lons,
+        )
+        self._target_y = np.asarray(target_y)
+        self._target_x = np.asarray(target_x)
+        self._target_dim_names = tuple(target_dim_names)
+        self._fill_value = float(fill_value)
+        if len(self._target_dim_names) != 2:
+            raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
+
+    def to(self, device: str | torch.device) -> BilinearRegridder:
+        self._interp = self._interp.to(device)
+        return self
+
+    def target_coords(self) -> CoordSystem:
+        y_name, x_name = self._target_dim_names
+        coords: CoordSystem = OrderedDict()
+        coords[y_name] = self._target_y
+        coords[x_name] = self._target_x
+        return coords
+
+    def apply(
+        self,
+        x: torch.Tensor,
+        *,
+        spatial_dims: tuple[str, ...],
+    ) -> torch.Tensor:
+        if len(spatial_dims) != 2:
+            raise ValueError(
+                "BilinearRegridder expects exactly two trailing spatial dims, "
+                f"got {spatial_dims}"
+            )
+        # LatLonInterpolation buffers are float32; match dtype so torch.lerp /
+        # advanced indexing don't trip over a float64 source array from xarray.
+        out = self._interp(x.to(dtype=torch.float32))
+        return torch.nan_to_num(out, nan=self._fill_value)
 
 
 # ---------------------------------------------------------------------------

--- a/recipes/eval/src/regrid.py
+++ b/recipes/eval/src/regrid.py
@@ -322,12 +322,12 @@ class BilinearRegridder(Regridder):
             lat_out=target_lats,
             lon_out=target_lons,
         )
+        if len(tuple(target_dim_names)) != 2:
+            raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
         self._target_y = np.asarray(target_y)
         self._target_x = np.asarray(target_x)
         self._target_dim_names = tuple(target_dim_names)
         self._fill_value = float(fill_value)
-        if len(self._target_dim_names) != 2:
-            raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
 
     def to(self, device: str | torch.device) -> BilinearRegridder:
         self._interp = self._interp.to(device)

--- a/recipes/eval/src/regrid.py
+++ b/recipes/eval/src/regrid.py
@@ -45,6 +45,7 @@ from datetime import datetime
 import numpy as np
 import torch
 import xarray as xr
+from loguru import logger
 from numpy.typing import ArrayLike
 
 from earth2studio.data import DataSource
@@ -281,9 +282,10 @@ class BilinearRegridder(Regridder):
         Source grid coordinates.  2D ``[H_src, W_src]`` meshgrids or 1D
         vectors (promoted internally via ``meshgrid``).
     target_lats, target_lons : torch.Tensor | ArrayLike
-        Target grid coordinates.  Either 2D meshgrids (for curvilinear grids
-        such as HRRR Lambert-conformal) or 1D vectors.  The target grid must
-        be contained within the source grid (a requirement of
+        Target grid coordinates.  2D meshgrids (for curvilinear grids such as
+        HRRR Lambert-conformal) or 1D vectors (promoted internally via
+        ``meshgrid``, same as the source side).  The target grid must be
+        contained within the source grid (a requirement of
         ``LatLonInterpolation``).
     target_y, target_x : ArrayLike
         1D index coordinates of the target grid, written to the output zarr
@@ -308,6 +310,12 @@ class BilinearRegridder(Regridder):
         target_dim_names: tuple[str, str] = ("y", "x"),
         fill_value: float = 0.0,
     ) -> None:
+        # Validate cheap inputs before the expensive interpolator build
+        # (Delaunay triangulation over the full source grid).
+        self._target_dim_names = tuple(target_dim_names)
+        if len(self._target_dim_names) != 2:
+            raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
+
         src_lats = np.asarray(
             source_lats.cpu() if isinstance(source_lats, torch.Tensor) else source_lats
         )
@@ -316,18 +324,40 @@ class BilinearRegridder(Regridder):
         )
         if src_lats.ndim == 1 and src_lons.ndim == 1:
             src_lats, src_lons = np.meshgrid(src_lats, src_lons, indexing="ij")
+        # Promote 1D target vectors to a meshgrid too — LatLonInterpolation
+        # ravels its target and reshapes to the input shape, so a 1D target
+        # would otherwise interpolate only the diagonal points rather than the
+        # full lat x lon grid.
+        tgt_lats = np.asarray(
+            target_lats.cpu() if isinstance(target_lats, torch.Tensor) else target_lats
+        )
+        tgt_lons = np.asarray(
+            target_lons.cpu() if isinstance(target_lons, torch.Tensor) else target_lons
+        )
+        if tgt_lats.ndim == 1 and tgt_lons.ndim == 1:
+            tgt_lats, tgt_lons = np.meshgrid(tgt_lats, tgt_lons, indexing="ij")
         self._interp = LatLonInterpolation(
             lat_in=src_lats,
             lon_in=src_lons,
-            lat_out=target_lats,
-            lon_out=target_lons,
+            lat_out=tgt_lats,
+            lon_out=tgt_lons,
         )
+        # A fully-NaN interpolation map means no target point fell inside the
+        # source grid — every output would be silently zero-filled by apply().
+        # This is the classic longitude-convention mismatch (target in
+        # [-180, 180) vs. source in [0, 360)); warn rather than write an
+        # all-zero store with no signal.
+        if bool(torch.isnan(self._interp.i_map).all()):
+            logger.warning(
+                "BilinearRegridder: no target point falls inside the source "
+                "grid — the entire field will be filled with "
+                f"{float(fill_value)}. Check that source and target longitude "
+                "conventions match (e.g. both in [0, 360) or both in "
+                "[-180, 180))."
+            )
         self._target_y = np.asarray(target_y)
         self._target_x = np.asarray(target_x)
-        self._target_dim_names = tuple(target_dim_names)
         self._fill_value = float(fill_value)
-        if len(self._target_dim_names) != 2:
-            raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
 
     def to(self, device: str | torch.device) -> BilinearRegridder:
         self._interp = self._interp.to(device)

--- a/recipes/eval/src/regrid.py
+++ b/recipes/eval/src/regrid.py
@@ -358,7 +358,7 @@ class BilinearRegridder(Regridder):
 
         if len(tuple(target_dim_names)) != 2:
             raise ValueError(f"target_dim_names must be a pair, got {target_dim_names}")
-        
+
         self._target_y = np.asarray(target_y)
         self._target_x = np.asarray(target_x)
         self._fill_value = float(fill_value)

--- a/recipes/eval/src/scoring.py
+++ b/recipes/eval/src/scoring.py
@@ -37,13 +37,13 @@ import torch
 import xarray as xr
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
-from physicsnemo.distributed import DistributedManager
 from tqdm import tqdm
 
 from earth2studio.data import DataSource
 from earth2studio.statistics.weights import lat_weight
 from earth2studio.utils.coords import CoordSystem
 
+from .distributed import get_rank
 from .output import OutputManager
 from .work import write_scoring_marker
 
@@ -352,7 +352,21 @@ def load_verification_chunk(
         ``(lead_time, variable, <spatial...>)``.
     """
     valid_times = time + lead_times
-    da = source(list(valid_times), list(variables))
+    try:
+        da = source(list(valid_times), list(variables))
+    except KeyError as exc:
+        # The verification source (often a CompositeSource globbed over the
+        # predownloaded data_*.zarr stores) has no channel for a requested
+        # scoring variable — e.g. glm_density when data_glm.zarr is absent
+        # (interrupted predownload, or a pre-PR output dir).  Surface the
+        # scoring context rather than a bare CompositeSource KeyError.
+        raise KeyError(
+            f"Scoring requested variables {list(variables)} but the "
+            f"verification source could not supply all of them ({exc}). "
+            "Ensure predownload completed (e.g. data_glm.zarr exists for "
+            "glm_density), or drop the missing variable(s) from "
+            "cfg.scoring.variables / the campaign outputs."
+        ) from exc
 
     # da has dims (time, variable, <spatial...>); reorder consistently.
     spatial_dims = [d for d in da.dims if d not in {"time", "variable"}]
@@ -692,10 +706,8 @@ def run_scoring(
     else:
         valid_ranges = {}
 
-    # Rank only gates tqdm output below.  Guard on is_initialized() so we don't
-    # instantiate an uninitialized DistributedManager (which warns / errors);
-    # default to 0 for single-process and unit-test runs.
-    rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
+    # Rank only gates tqdm output below.
+    rank = get_rank()
 
     for time in tqdm(my_times, desc="Scoring", disable=rank != 0):
         # Accumulate chunk results per metric.

--- a/recipes/eval/src/scoring.py
+++ b/recipes/eval/src/scoring.py
@@ -692,7 +692,10 @@ def run_scoring(
     else:
         valid_ranges = {}
 
-    rank = DistributedManager().rank
+    # Rank only gates tqdm output below.  Guard on is_initialized() so we don't
+    # instantiate an uninitialized DistributedManager (which warns / errors);
+    # default to 0 for single-process and unit-test runs.
+    rank = DistributedManager().rank if DistributedManager.is_initialized() else 0
 
     for time in tqdm(my_times, desc="Scoring", disable=rank != 0):
         # Accumulate chunk results per metric.

--- a/recipes/eval/test/test_regrid.py
+++ b/recipes/eval/test/test_regrid.py
@@ -31,7 +31,7 @@ import numpy as np
 import pytest
 import torch
 import xarray as xr
-from src.regrid import NearestNeighborRegridder, RegriddedSource
+from src.regrid import BilinearRegridder, NearestNeighborRegridder, RegriddedSource
 
 # ---------------------------------------------------------------------------
 # Small helper: build a source / target grid pair whose nearest-neighbor
@@ -182,6 +182,122 @@ class TestNearestNeighborRegridderDataArray:
         assert out.dims == ("time", "y", "x")
         assert out.shape == (2, 4, 5)
         np.testing.assert_allclose(out.values, data)
+
+
+# ---------------------------------------------------------------------------
+# BilinearRegridder
+# ---------------------------------------------------------------------------
+
+
+class TestBilinearRegridder:
+    """Bilinear regridder used for StormScope's GLM (glm_density) channel."""
+
+    def test_target_coords_default_dim_names(self):
+        src_lat, src_lon = _regular_grid(4, 5)
+        regridder = BilinearRegridder(
+            source_lats=src_lat,
+            source_lons=src_lon,
+            target_lats=src_lat,
+            target_lons=src_lon,
+            target_y=np.arange(4),
+            target_x=np.arange(5),
+        )
+        coords = regridder.target_coords()
+        assert list(coords.keys()) == ["y", "x"]
+        np.testing.assert_array_equal(coords["y"], np.arange(4))
+        np.testing.assert_array_equal(coords["x"], np.arange(5))
+
+    def test_identity_mapping_preserves_values(self):
+        """Source grid == target grid → bilinear map reproduces the field."""
+        src_lat, src_lon = _regular_grid(4, 5)
+        regridder = BilinearRegridder(
+            source_lats=src_lat,
+            source_lons=src_lon,
+            target_lats=src_lat,
+            target_lons=src_lon,
+            target_y=np.arange(4),
+            target_x=np.arange(5),
+        )
+        values = torch.arange(4 * 5, dtype=torch.float32).reshape(4, 5)
+        out = regridder.apply(values, spatial_dims=("lat", "lon"))
+        assert out.shape == (4, 5)
+        torch.testing.assert_close(out, values)
+
+    def test_accepts_1d_source_vectors(self):
+        """GOESGLMGrid exposes 1D lat/lon vectors — they must be promoted."""
+        lats_1d = np.linspace(30.0, 31.5, 4, dtype=np.float32)
+        lons_1d = np.linspace(260.0, 262.0, 5, dtype=np.float32)
+        tgt_lat, tgt_lon = np.meshgrid(lats_1d, lons_1d, indexing="ij")
+        regridder = BilinearRegridder(
+            source_lats=lats_1d,
+            source_lons=lons_1d,
+            target_lats=tgt_lat,
+            target_lons=tgt_lon,
+            target_y=np.arange(4),
+            target_x=np.arange(5),
+        )
+        values = torch.arange(4 * 5, dtype=torch.float32).reshape(4, 5)
+        out = regridder.apply(values, spatial_dims=("lat", "lon"))
+        assert out.shape == (4, 5)
+        torch.testing.assert_close(out, values)
+
+    def test_out_of_range_target_filled_with_zero(self):
+        """Targets outside the source grid get the fill value (0), not NaN —
+        matching StormScopeMRMS.interpolate_glm."""
+        src_lat, src_lon = _regular_grid(4, 5, lat0=30.0, lon0=260.0, d=0.5)
+        # One target pixel sits far outside the source convex hull.
+        tgt_lat = np.array([[30.0, 30.5], [30.5, 80.0]], dtype=np.float32)
+        tgt_lon = np.array([[260.0, 260.5], [260.5, 200.0]], dtype=np.float32)
+        regridder = BilinearRegridder(
+            source_lats=src_lat,
+            source_lons=src_lon,
+            target_lats=tgt_lat,
+            target_lons=tgt_lon,
+            target_y=np.arange(2),
+            target_x=np.arange(2),
+        )
+        values = torch.ones(4, 5, dtype=torch.float32)
+        out = regridder.apply(values, spatial_dims=("lat", "lon"))
+        assert out[1, 1] == 0.0, "far-away target should be zero-filled"
+        assert not torch.isnan(out).any()
+
+    def test_rejects_non_pair_spatial_dims(self):
+        src_lat, src_lon = _regular_grid(4, 5)
+        regridder = BilinearRegridder(
+            source_lats=src_lat,
+            source_lons=src_lon,
+            target_lats=src_lat,
+            target_lons=src_lon,
+            target_y=np.arange(4),
+            target_x=np.arange(5),
+        )
+        with pytest.raises(ValueError, match="exactly two trailing spatial dims"):
+            regridder.apply(torch.zeros(4, 5), spatial_dims=("lat",))
+
+    def test_apply_dataarray_swaps_spatial_dim_names(self):
+        src_lat, src_lon = _regular_grid(4, 5)
+        regridder = BilinearRegridder(
+            source_lats=src_lat,
+            source_lons=src_lon,
+            target_lats=src_lat,
+            target_lons=src_lon,
+            target_y=np.arange(4),
+            target_x=np.arange(5),
+        )
+        data = np.arange(2 * 4 * 5, dtype=np.float32).reshape(2, 4, 5)
+        da = xr.DataArray(
+            data,
+            dims=("time", "lat", "lon"),
+            coords={
+                "time": np.array(["2023-01-01", "2023-01-02"], dtype="datetime64[ns]"),
+                "lat": np.arange(4),
+                "lon": np.arange(5),
+            },
+        )
+        out = regridder.apply_dataarray(da)
+        assert out.dims == ("time", "y", "x")
+        assert out.shape == (2, 4, 5)
+        np.testing.assert_allclose(out.values, data, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/recipes/eval/test/test_scoring.py
+++ b/recipes/eval/test/test_scoring.py
@@ -126,7 +126,7 @@ def _make_dist_mock(*, rank=0, world_size=1, distributed=False):
 # Paths to mock
 _DIST_PATH = "src.output.DistributedManager"
 _RANK0_PATH = "src.output.run_on_rank0_first"
-_SCORING_DIST_PATH = "src.scoring.DistributedManager"
+_SCORING_DIST_PATH = "src.scoring.get_rank"
 
 
 # ---------------------------------------------------------------------------
@@ -742,7 +742,7 @@ class TestRunScoring:
 
         with patch(_DIST_PATH, return_value=_make_dist_mock()):
             with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
-                with patch(_SCORING_DIST_PATH, return_value=_make_dist_mock()):
+                with patch(_SCORING_DIST_PATH, return_value=0):
                     with OutputManager(
                         cfg, store_name="scores.zarr", overwrite=True
                     ) as mgr:
@@ -805,7 +805,7 @@ class TestRunScoring:
 
             with patch(_DIST_PATH, return_value=_make_dist_mock()):
                 with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
-                    with patch(_SCORING_DIST_PATH, return_value=_make_dist_mock()):
+                    with patch(_SCORING_DIST_PATH, return_value=0):
                         with OutputManager(
                             cfg, store_name=store_name, overwrite=True
                         ) as mgr:
@@ -853,7 +853,7 @@ class TestRunScoring:
 
         with patch(_DIST_PATH, return_value=_make_dist_mock()):
             with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
-                with patch(_SCORING_DIST_PATH, return_value=_make_dist_mock()):
+                with patch(_SCORING_DIST_PATH, return_value=0):
                     with OutputManager(
                         cfg, store_name="scores.zarr", overwrite=True
                     ) as mgr:
@@ -1040,7 +1040,7 @@ class TestNanPolicy:
         """Execute the standard score-store-setup + run_scoring flow."""
         with patch(_DIST_PATH, return_value=_make_dist_mock()):
             with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
-                with patch(_SCORING_DIST_PATH, return_value=_make_dist_mock()):
+                with patch(_SCORING_DIST_PATH, return_value=0):
                     with OutputManager(
                         cfg, store_name="scores.zarr", overwrite=True
                     ) as mgr:
@@ -1270,7 +1270,7 @@ class TestValidRangesEndToEnd:
     def _run(self, cfg, inputs):
         with patch(_DIST_PATH, return_value=_make_dist_mock()):
             with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
-                with patch(_SCORING_DIST_PATH, return_value=_make_dist_mock()):
+                with patch(_SCORING_DIST_PATH, return_value=0):
                     with OutputManager(
                         cfg, store_name="scores.zarr", overwrite=True
                     ) as mgr:

--- a/recipes/eval/test/test_stormscope.py
+++ b/recipes/eval/test/test_stormscope.py
@@ -842,3 +842,153 @@ class TestBuildConditioningStore:
         assert store is not None
         # 4 distinct valid times when no rounding applies.
         assert len(store.times) == 4
+
+
+# ---------------------------------------------------------------------------
+# _build_glm_store — GLM (glm_density) predownload store
+# ---------------------------------------------------------------------------
+
+
+class _FakeGlmModel:
+    """StormScope-MRMS-shaped stub sufficient for ``_build_glm_store`` /
+    ``_resolve_mrms_ic_source``.
+
+    Advertises a ``glm_density`` state channel, the cropped HRRR sub-region
+    (``latitudes`` / ``longitudes``), and numpy ``y`` / ``x`` — the surface the
+    bilinear regridder reads.  No forward pass.
+    """
+
+    def __init__(self, *, with_glm: bool = True):
+        self.variables = ["refc", "refc_base"] + (["glm_density"] if with_glm else [])
+        self.glm_variables = np.array(["glm_density"]) if with_glm else np.array([])
+        self.n_glm_channels = 1 if with_glm else 0
+        self.latitudes = torch.zeros(4, 5, dtype=torch.float32)
+        self.longitudes = torch.zeros(4, 5, dtype=torch.float32)
+        self.y = np.arange(4)
+        self.x = np.arange(5)
+
+
+class TestBuildGlmStore:
+    """``StormScopePipeline._build_glm_store`` — the bilinear-regridded
+    ``data_glm.zarr`` store for GLM-bearing MRMS variants."""
+
+    def _make_model_cfg(self, *, with_glm_source=True, with_glm_grid=True):
+        mod = _grid_resolver_registered()
+        block: dict[str, Any] = {"load_args": {}}
+        if with_glm_source:
+            block["load_args"]["glm_data_source"] = {
+                "_target_": f"{mod}._StubDataSource",
+            }
+        if with_glm_grid:
+            block["glm_grid"] = {"_target_": f"{mod}.stub_grid"}
+        return OmegaConf.create(block)
+
+    def test_builds_bilinear_regridded_store(self):
+        from src.regrid import BilinearRegridder, RegriddedSource
+
+        pipeline = StormScopePipeline()
+        model = _FakeGlmModel()
+        model_cfg = self._make_model_cfg()
+        spatial_ref = OrderedDict([("y", model.y), ("x", model.x)])
+        fetch_times = [
+            np.datetime64("2023-12-05T12:00:00", "ns"),
+            np.datetime64("2023-12-05T12:10:00", "ns"),
+        ]
+
+        store = pipeline._build_glm_store(
+            model=model,
+            model_cfg=model_cfg,
+            fetch_times=fetch_times,
+            spatial_ref=spatial_ref,
+        )
+        assert store is not None
+        assert store.name == "data_glm"
+        assert store.role == "ic"
+        assert store.variables == ["glm_density"]
+        assert store.times == fetch_times
+        assert isinstance(store.source, RegriddedSource)
+        assert isinstance(store.source._regridder, BilinearRegridder)
+
+    def test_returns_none_without_glm_source(self):
+        pipeline = StormScopePipeline()
+        model = _FakeGlmModel()
+        model_cfg = self._make_model_cfg(with_glm_source=False)
+        store = pipeline._build_glm_store(
+            model=model,
+            model_cfg=model_cfg,
+            fetch_times=[np.datetime64("2023-12-05T12:00:00", "ns")],
+            spatial_ref=OrderedDict([("y", model.y), ("x", model.x)]),
+        )
+        assert store is None
+
+    def test_returns_none_without_glm_grid(self):
+        pipeline = StormScopePipeline()
+        model = _FakeGlmModel()
+        model_cfg = self._make_model_cfg(with_glm_grid=False)
+        store = pipeline._build_glm_store(
+            model=model,
+            model_cfg=model_cfg,
+            fetch_times=[np.datetime64("2023-12-05T12:00:00", "ns")],
+            spatial_ref=OrderedDict([("y", model.y), ("x", model.x)]),
+        )
+        assert store is None
+
+    def test_returns_none_without_glm_channels(self):
+        pipeline = StormScopePipeline()
+        model = _FakeGlmModel(with_glm=False)
+        model_cfg = self._make_model_cfg()
+        store = pipeline._build_glm_store(
+            model=model,
+            model_cfg=model_cfg,
+            fetch_times=[np.datetime64("2023-12-05T12:00:00", "ns")],
+            spatial_ref=OrderedDict([("y", model.y), ("x", model.x)]),
+        )
+        assert store is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_mrms_ic_source — radar + GLM composite vs single-source
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMrmsIcSource:
+    """``StormScopePipeline._resolve_mrms_ic_source`` assembles the MRMS IC.
+
+    For GLM-bearing variants the radar (``data_mrms.zarr``) and lightning
+    (``data_glm.zarr``) stores are recombined via a
+    :class:`~src.data.CompositeSource`; variants without GLM keep the legacy
+    single-source resolution.
+    """
+
+    def test_composite_when_both_stores_exist(self, tmp_path):
+        _write_yx_zarr(tmp_path / "data_mrms.zarr", ["refc", "refc_base"])
+        _write_yx_zarr(tmp_path / "data_glm.zarr", ["glm_density"])
+        cfg = OmegaConf.create(
+            {"output": {"path": str(tmp_path)}, "model": {"mrms": {}}}
+        )
+
+        pipeline = StormScopePipeline()
+        pipeline.model_mrms = _FakeGlmModel()
+        src = pipeline._resolve_mrms_ic_source(cfg)
+        assert isinstance(src, CompositeSource)
+
+        # Dispatch must reach both component stores.
+        t = np.array(["2023-12-05T12:00:00"], dtype="datetime64[ns]")
+        result = src(t, ["refc", "glm_density"])
+        assert result.sizes["variable"] == 2
+
+    def test_single_source_path_without_glm(self, tmp_path):
+        # No GLM channels → legacy single-source resolution.  No cache on disk,
+        # so the live source (a trivial built-in) is instantiated.
+        cfg = OmegaConf.create(
+            {
+                "output": {"path": str(tmp_path)},
+                "model": {
+                    "mrms": {"ic_source": {"_target_": "collections.OrderedDict"}}
+                },
+            }
+        )
+        pipeline = StormScopePipeline()
+        pipeline.model_mrms = _FakeGlmModel(with_glm=False)
+        src = pipeline._resolve_mrms_ic_source(cfg)
+        assert isinstance(src, OrderedDict)

--- a/recipes/eval/uv.lock
+++ b/recipes/eval/uv.lock
@@ -177,12 +177,96 @@ wheels = [
 ]
 
 [[package]]
+name = "arraylake"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "donfig", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "icechunk", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "ruamel-yaml", marker = "python_full_version >= '3.12'" },
+    { name = "structlog", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "zarr", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/03/8952b0cf57d42d95269046ac822b2b8d0cc12e90f4b34930cf3edb773e99/arraylake-1.2.0.tar.gz", hash = "sha256:f37a8a0aa10bb8397b6fbe76effc9f3ee010be93849743dc3208226c1ad648e5", size = 302585, upload-time = "2026-07-09T20:13:35.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/28/a71a2ce8a5924f7c83f1dbae067fa4b3a56e4fd8ad7c8d60f261684fd0aa/arraylake-1.2.0-py3-none-any.whl", hash = "sha256:2af4f9f7c73294c190ea39e570568ef439bff897ef267a8a875b0abc1d7fb38b", size = 106271, upload-time = "2026-07-09T20:13:34.24Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bitarray"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/eb/e97abd6b7c2245e19be529f6fd70c7dda04c449f4a11b6ddb30079d71ea6/bitarray-3.9.0.tar.gz", hash = "sha256:af5f91e61d868c8f457f66cd726ef31d69264f71edbaccd70fdbb13548c1d652", size = 156643, upload-time = "2026-07-10T07:26:09.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ec/4693fc6f05b5c4d5bd5c9721de280507e325c02eab39e0cee7563b38d584/bitarray-3.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d66b965ab369284c187c38c9cd5d6e638e863db856ee244c739ad5ec07769645", size = 152670, upload-time = "2026-07-10T07:23:51.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/a06dcd8f188dbdba6be3ac4b2d1dafc2b4092aec1ac53b837d33c8356ed3/bitarray-3.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c019a95da22eca2793dd80db95758ff82cfc17f8813fd6a926cca5fd93b1bd7f", size = 149545, upload-time = "2026-07-10T07:23:52.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6a/9e7cdd675deab50ad57c28f52297d950a23a9501d8a5b0b3469065da72f7/bitarray-3.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b9d16a362f454abe9ef7d362fb9260b0a7945e64a53d35effb10c7fd64da415", size = 342159, upload-time = "2026-07-10T07:23:53.692Z" },
+    { url = "https://files.pythonhosted.org/packages/22/62/bda7619bf3e810c7fbf0ef3354ccc581e9c7809221e8c1d0db1c776d0cd9/bitarray-3.9.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f118e3f43a01d7326c30d95eafda951e0823596f1659f4a5a54ab032341d5f4", size = 372904, upload-time = "2026-07-10T07:23:55.26Z" },
+    { url = "https://files.pythonhosted.org/packages/57/41/688008a859a18942abe5cca8af2a06f2ebede4d3fed52d09745698baca5b/bitarray-3.9.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc6db5b0d52ab31136da48d2913aad14e5ba3bfd5522d75c4d9bda2700c66768", size = 381298, upload-time = "2026-07-10T07:23:56.586Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7f/8b4b1addffe96f22cc2efaf48100bd88d99b6ad3bf209f3464694b29de1f/bitarray-3.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b6cbca02cdfb27a6fb6e0d4f9170a53da2c37fce70bc5afa6d58aab6d1f1af", size = 347291, upload-time = "2026-07-10T07:23:57.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/b411fd5bd0052f5e4089343aa2bd2e5b7ef7adc0772d8a7dc06a64fb35bb/bitarray-3.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9c45b31ddef2d4f50224cb5cbe1ac0af4909555340fdf88e65da5c9c7e912cb3", size = 340076, upload-time = "2026-07-10T07:23:59.068Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b0/78426b1dfae5ad5478d4d5fc341196ae71e39d230b8a9f7afb12fb841e6c/bitarray-3.9.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cc9cc3025e9453239843d1c4431c5aca700bec246e9071596b8240193e91af2f", size = 369949, upload-time = "2026-07-10T07:24:00.393Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/55/6a91dc36617fc9f1a01920e58b890c869439321526d3dfa83ef045eab17e/bitarray-3.9.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e79e4c283ed834b0587b0fde21ced22251a569255b338de1e466d901c8d07d5e", size = 364660, upload-time = "2026-07-10T07:24:01.879Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e4/62da749b416838bf061d18ca736be882e9ec04534dca4f6758d79df3fd9c/bitarray-3.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4e52b54a8e639da6e80ddeaca9aa3ca324ca20bdcd4cd51f6070ca4b334113a1", size = 344668, upload-time = "2026-07-10T07:24:03.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ff/a9dc020651e2d94c7d1f4dd343f29f8c1d88e9f2c24ad1b49561dde66530/bitarray-3.9.0-cp311-cp311-win32.whl", hash = "sha256:b664bd8174795df4f0353c9ff3d997f5ae764285753c785bf6aa0afab75a357a", size = 146058, upload-time = "2026-07-10T07:24:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/15074a393c142aec2a39133ab5e9504a7c4d24a66c6d1f780af98cc06137/bitarray-3.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:eb5e65d4c2da36446a4592f50e0393a0255e832bdd5d519391a216728cface15", size = 152955, upload-time = "2026-07-10T07:24:05.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fd/9e4dbe150f85249ed387d06b1428de602d52b0c092ee8d3fcbeb4a5aa64b/bitarray-3.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:2d7b0167098b7a423e8b8fcd2d4291aa99b97589e53b6b182c0b456a79a78cd5", size = 150910, upload-time = "2026-07-10T07:24:07.098Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/83e594b22122483cb1af90ae747b85e085469c396c9b319f42155f01a322/bitarray-3.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:541890dd453021a6f8155e7d091a6589652f703832a41c959eb139b487b67ad2", size = 152779, upload-time = "2026-07-10T07:24:08.305Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/19f2d66274da55c0ca5b815c3588c0fb4341586958eea7ac13d58b22884c/bitarray-3.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c5f11802751285f982a333192f1336ce94017eedb6ea5f8e05039484ca00b24d", size = 149502, upload-time = "2026-07-10T07:24:09.567Z" },
+    { url = "https://files.pythonhosted.org/packages/15/29/e7ac040455a66f5c584cd5af70d1018997966dc99e75ecbb3c2806922581/bitarray-3.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1acbb40c630d0429d5a7e8879896f43ddb998625d380d94664239dae9bb4978d", size = 345319, upload-time = "2026-07-10T07:24:10.968Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/ec4c5daae49bd12129cf5a838d823e92137192c8fee2da5c153ca6e175d2/bitarray-3.9.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e55a6e8e5c14546a90db3c5c93d68dc73c8d86ed19556aa58cd6d558286ae620", size = 375681, upload-time = "2026-07-10T07:24:12.31Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3d/abc67f0fbc641ea506ccb6424248066bb3318ac4f5c5359ad7be329ad4c3/bitarray-3.9.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f2d47d0f451f42c328544e9a8968d168e452934eef218e6e68e5b14b6711a3a", size = 385149, upload-time = "2026-07-10T07:24:13.661Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8f/13fa46e1121d194f25dad9a95061d0cf55a07bddf06d99e173b48ef9bf57/bitarray-3.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:353430288ff7e2a97029dea750d3095bf85089f8d7757dff52b46d71c0b635ff", size = 351870, upload-time = "2026-07-10T07:24:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/9a6f1ede6040ec7ecc3575c473af19a9af0da8360b187cb53f09d7130910/bitarray-3.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:63e934aecbad62ed3b591877b7f4ce2c9b7b28376ef70448cb657338911350c1", size = 342760, upload-time = "2026-07-10T07:24:16.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/be29cb182a5c7b4124dc3272c50606af0ae19f7501a4b79fe922fa83e99a/bitarray-3.9.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6272808ed86948389e3fb6723474691f4dd3475ccbd2f8b1232feec517b2c394", size = 372884, upload-time = "2026-07-10T07:24:17.778Z" },
+    { url = "https://files.pythonhosted.org/packages/26/36/17d988d1725f4f1e3e8b27cd7eb88e48a1297273bc86fb674a77e5daef97/bitarray-3.9.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c0aceb582baabb97612647193fd6160f9766250b7d1f034d1be7d5f2b2d88ca", size = 368761, upload-time = "2026-07-10T07:24:19.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cc/c53bda6f4d419b6c137c03f4a4a49af19df38ce201c77c689070339403cf/bitarray-3.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6e3fe6fc6bf914e1a538e955c1260f64ccb174136ac798811f2a5f904e437def", size = 348639, upload-time = "2026-07-10T07:24:20.641Z" },
+    { url = "https://files.pythonhosted.org/packages/81/aa/945305b3e16411576be84bc047612d00de6a1ced671290d96fb6dc95c281/bitarray-3.9.0-cp312-cp312-win32.whl", hash = "sha256:7ad4eb391e138958b69d9f1521e45e537ad4a66eba9ba90bb4a99ada6fa1fc90", size = 146349, upload-time = "2026-07-10T07:24:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/86/80/d0c50617ea2e0579b3c6c4839321a846bd8f0478d3c625f10250db114240/bitarray-3.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:71070085c168cb5cb0972c09c9f36995a34fab2807c15f2f64f0dee6014f1008", size = 153295, upload-time = "2026-07-10T07:24:23.841Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5f/280679f0581dbf8f6747c776e65eb722435c28a0b378b99c3f7a42539979/bitarray-3.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:3075370a7aaec476b0f3ce501f83cfa1797fa722619f7f130981403978b1ad89", size = 151050, upload-time = "2026-07-10T07:24:25.161Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4d/906327dbe7d8bb94a7e46bb403c7304e410e3f9d9963df9760867f590f39/bitarray-3.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:62e5a7520f3d2b632438f94c9b9bddf1b2c0e9154e69c8c62e32accf680b3fdc", size = 152778, upload-time = "2026-07-10T07:24:26.389Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3f/697f7ad7c00108d22db9cc918480f5981cbf569c419c354271bedd1b07c5/bitarray-3.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:867994fb56cbfe40c77b1c5d0527e4d6ef4141b3ea2aca2aa02bd89ca08ae2d2", size = 149496, upload-time = "2026-07-10T07:24:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/2852f600f24acadb0b8f3fb0e08a80da976b539061093c707571b057bb7a/bitarray-3.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:255090e32993dc0b10cd29ad49e21cd7349ed9cdb44d61ad970b4a698b7bd1e7", size = 344479, upload-time = "2026-07-10T07:24:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/82/149e201ff5d8512185199313328f2440b97b30daac193c1bf959f4e30089/bitarray-3.9.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21facaa003c1a6487eaada863fc93059ee2f542a9ca589f7c5716a1e4ceddfd0", size = 374709, upload-time = "2026-07-10T07:24:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3c/84ed3afc80a5fb95eec29915d0b7d27fe880b85b0f9c194f93e289a59737/bitarray-3.9.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c5636104b949b937ef47bcc700665befc2f5a1e906036cba6fdb978501adca11", size = 384245, upload-time = "2026-07-10T07:24:32.099Z" },
+    { url = "https://files.pythonhosted.org/packages/13/79/caba986e6770521b38c3870008649566dacf31b6a4b5ea43ec17ebd6a09a/bitarray-3.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17e721ed7695257f5f0a8147633f96a60b5ac13735c73d29b2409d1b5a484062", size = 350997, upload-time = "2026-07-10T07:24:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4a/2e1d729a4a40cfa3f5cee0e081b2e85d1cdb46aa821db1f373e853e767e8/bitarray-3.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:68f66a71bcfbedd1144b8d21b54fa77e32f90067fc3e49abc0a479392697c3cd", size = 342102, upload-time = "2026-07-10T07:24:35.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/87/5a9db50f49ab46facfb13256087a4dda9468dab29e32f2ef8c2c2dece842/bitarray-3.9.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e780526164e5c4051cf8618e73ecaf0c900c7c3ea2cdd99558b486e47cbe28c9", size = 371995, upload-time = "2026-07-10T07:24:37.508Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/c50e1df174b8d1d60c2e76a44a8052df43f08dd74f0c68895e6f9cf31464/bitarray-3.9.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f6abac81451d0d0ce5ee553b9c7e6b9de165642ffe949c1379e6f553f482066e", size = 367810, upload-time = "2026-07-10T07:24:39.132Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0c/217b120ed58847a543d8c9819bc626b3caf59b6bd15454de6f0b339a4a03/bitarray-3.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db0a55d52d9056187670e8e7e525a2aa5f4a74a4459e9455aa68c0198b4ac2fc", size = 347899, upload-time = "2026-07-10T07:24:40.606Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2d/6149c1d5d71dd3c0dbc169431498808fc35e2d557234895e7109decb1b3d/bitarray-3.9.0-cp313-cp313-win32.whl", hash = "sha256:e5799c01e961273136d95ade2164c689714bdfcdc443f9e2568b45df620248d2", size = 146369, upload-time = "2026-07-10T07:24:42.046Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7c/bea45e1a7a0914dd98bf1bc1f0c26ad3fc9c13b172a828e3512d358f3df4/bitarray-3.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:eba091b89bfaf931709e09b8bc564101c7c834d2978019784dd97e017e84d060", size = 153333, upload-time = "2026-07-10T07:24:43.317Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2ebc04e8704de30194d3f323231b67742ec990fc8adee481de12d942cf0d/bitarray-3.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:c13cb765f5dd30eefec0046cde1c2eee11b76cd749b045e54f1aa0a15057d219", size = 151070, upload-time = "2026-07-10T07:24:44.585Z" },
+]
+
+[[package]]
+name = "bitstring"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bitarray" },
+    { name = "tibs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/d3/de6fe4e7065df8c2f1ac1766f5fdccbe75bc18af2cf2dbeecd34d68e1518/bitstring-4.4.0.tar.gz", hash = "sha256:e682ac522bb63e041d16cbc9d0ca86a4f00194db16d0847c7efe066f836b2e37", size = 255209, upload-time = "2026-03-10T20:29:14.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/02/1a870bab76f2896d827aa4963be95e56675ffa1453e53525d13c43036edf/bitstring-4.4.0-py3-none-any.whl", hash = "sha256:feac49524fcf3ef27e6081e86f02b10d2adf6c3773bf22fbe0e7eea9534bc737", size = 76846, upload-time = "2026-03-10T20:29:12.832Z" },
 ]
 
 [[package]]
@@ -206,20 +290,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.42.84"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/88/89/2d647bd717da55a8cc68602b197f53a5fa36fb95a2f9e76c4aff11a9cfd1/boto3-1.42.84.tar.gz", hash = "sha256:6a84b3293a5d8b3adf827a54588e7dcffcf0a85410d7dadca615544f97d27579", size = 112816, upload-time = "2026-04-06T19:39:07.585Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/31/cdf4326841613d1d181a77b3038a988800fb3373ca50de1639fba9fa87de/boto3-1.42.84-py3-none-any.whl", hash = "sha256:4d03ad3211832484037337292586f71f48707141288d9ac23049c04204f4ab03", size = 140555, upload-time = "2026-04-06T19:39:06.009Z" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.42.84"
 source = { registry = "https://pypi.org/simple" }
@@ -231,15 +301,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/b7/1c03423843fb0d1795b686511c00ee63fed1234c2400f469aeedfd42212f/botocore-1.42.84.tar.gz", hash = "sha256:234064604c80d9272a5e9f6b3566d260bcaa053a5e05246db90d7eca1c2cf44b", size = 15148615, upload-time = "2026-04-06T19:38:56.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl", hash = "sha256:15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3", size = 14827061, upload-time = "2026-04-06T19:38:53.613Z" },
-]
-
-[[package]]
-name = "bracex"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
 ]
 
 [[package]]
@@ -275,8 +336,8 @@ name = "cattrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
@@ -689,16 +750,18 @@ wheels = [
 
 [[package]]
 name = "cuda-bindings"
-version = "12.9.4"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_machine != 's390x'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
 ]
 
 [[package]]
@@ -707,6 +770,49 @@ version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/f9/1b9b60a30fc463c14cdea7a77228131a0ccc89572e8df9cb86c9648271ab/cuda_pathfinder-1.5.2-py3-none-any.whl", hash = "sha256:0c5f160a7756c5b072723cbbd6d861e38917ef956c68150b02f0b6e9271c71fa", size = 49988, upload-time = "2026-04-06T23:01:05.17Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -784,6 +890,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -797,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "earth2grid"
-version = "2025.11.1+torch210"
+version = "2025.11.1+torch211"
 source = { git = "https://github.com/NVlabs/earth2grid.git?rev=11dcf1b0787a7eb6a8497a3a5a5e1fdcc31232d3#11dcf1b0787a7eb6a8497a3a5a5e1fdcc31232d3" }
 dependencies = [
     { name = "einops" },
@@ -817,8 +932,8 @@ dependencies = [
     { name = "h5py" },
     { name = "huggingface-hub" },
     { name = "loguru" },
-    { name = "nest-asyncio" },
     { name = "netcdf4" },
+    { name = "obstore" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pygrib" },
@@ -833,19 +948,18 @@ dependencies = [
 
 [package.optional-dependencies]
 data = [
+    { name = "arraylake", marker = "python_full_version >= '3.12'" },
     { name = "cdsapi" },
     { name = "cfgrib" },
     { name = "eccodes" },
     { name = "eccodeslib" },
     { name = "ecmwf-opendata" },
     { name = "eumdac" },
-    { name = "globus-sdk" },
     { name = "httpx" },
-    { name = "intake-esgf", version = "2025.10.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "intake-esgf", version = "2026.1.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "multi-storage-client", extra = ["boto3", "fsspec", "google-cloud-storage"] },
-    { name = "pandas" },
+    { name = "intake-esgf", marker = "python_full_version >= '3.12'" },
+    { name = "pcodec", marker = "python_full_version >= '3.12'" },
     { name = "planetary-computer" },
+    { name = "pybufrkit" },
     { name = "pyproj" },
     { name = "pystac-client" },
     { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -872,6 +986,13 @@ perturbation = [
 statistics = [
     { name = "nvidia-physicsnemo" },
 ]
+stormscope = [
+    { name = "earth2grid" },
+    { name = "natten" },
+    { name = "nvidia-physicsnemo" },
+    { name = "nvtx" },
+    { name = "scipy" },
+]
 utils = [
     { name = "earth2grid" },
     { name = "scipy" },
@@ -882,32 +1003,37 @@ requires-dist = [
     { name = "aiofiles", marker = "extra == 'all'", specifier = ">=23.0.0" },
     { name = "aiofiles", marker = "extra == 'serve'", specifier = ">=23.0.0" },
     { name = "anemoi-models", marker = "extra == 'aifs'", specifier = "==0.5.1" },
+    { name = "anemoi-models", marker = "extra == 'aifs2'", specifier = ">=0.9.3,<0.9.5" },
+    { name = "anemoi-models", marker = "extra == 'aifs2ens'", specifier = "==0.11.2" },
     { name = "anemoi-models", marker = "extra == 'aifsens'", specifier = "==0.5.1" },
-    { name = "anemoi-models", marker = "extra == 'all'", specifier = "==0.5.1" },
+    { name = "arraylake", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=1.0.0" },
+    { name = "arraylake", marker = "python_full_version >= '3.12' and extra == 'data'", specifier = ">=1.0.0" },
     { name = "azure-identity", marker = "extra == 'all'", specifier = ">=1.15.0" },
     { name = "azure-identity", marker = "extra == 'serve'", specifier = ">=1.15.0" },
     { name = "azure-storage-blob", marker = "extra == 'all'", specifier = ">=12.19.0" },
     { name = "azure-storage-blob", marker = "extra == 'serve'", specifier = ">=12.19.0" },
-    { name = "cbottle", marker = "python_full_version >= '3.12' and extra == 'all'", git = "https://github.com/NVlabs/cBottle.git?rev=8b8b358466e6b2f50d1779009790002ceb596e72" },
-    { name = "cbottle", marker = "python_full_version >= '3.12' and extra == 'cbottle'", git = "https://github.com/NVlabs/cBottle.git?rev=8b8b358466e6b2f50d1779009790002ceb596e72" },
+    { name = "cbottle", marker = "python_full_version >= '3.12' and extra == 'all'", git = "https://github.com/NickGeneva/cBottle.git?rev=e48c7eb518d49d4a92b2a1397d683e765c02c354" },
+    { name = "cbottle", marker = "python_full_version >= '3.12' and extra == 'cbottle'", git = "https://github.com/NickGeneva/cBottle.git?rev=e48c7eb518d49d4a92b2a1397d683e765c02c354" },
     { name = "cdsapi", marker = "extra == 'all'", specifier = ">=0.7.5" },
     { name = "cdsapi", marker = "extra == 'data'", specifier = ">=0.7.5" },
     { name = "cfgrib", marker = "extra == 'all'", git = "https://github.com/NickGeneva/cfgrib.git?rev=6a9af3173d7050b5fa5d221755f97e6ecb8c3433" },
     { name = "cfgrib", marker = "extra == 'data'", git = "https://github.com/NickGeneva/cfgrib.git?rev=6a9af3173d7050b5fa5d221755f97e6ecb8c3433" },
     { name = "cftime" },
+    { name = "climate-learn", marker = "extra == 'all'", git = "https://github.com/NickGeneva/ORBIT-2?rev=5b2d80a8ba4dc95029211ef2b8530d3663f65d39" },
+    { name = "climate-learn", marker = "extra == 'orbit'", git = "https://github.com/NickGeneva/ORBIT-2?rev=5b2d80a8ba4dc95029211ef2b8530d3663f65d39" },
     { name = "cryptography", marker = "extra == 'all'", specifier = ">=41.0.0" },
     { name = "cryptography", marker = "extra == 'serve'", specifier = ">=41.0.0" },
-    { name = "cucim-cu12", marker = "extra == 'all'", specifier = ">=25.4.0" },
-    { name = "cucim-cu12", marker = "extra == 'cyclone'", specifier = ">=25.4.0" },
-    { name = "cudf-cu12", marker = "extra == 'all'", specifier = "==26.2.*" },
-    { name = "cudf-cu12", marker = "extra == 'da-healda'", specifier = "==26.2.*" },
-    { name = "cudf-cu12", marker = "extra == 'da-interp'", specifier = "==26.2.*" },
-    { name = "cudf-cu12", marker = "extra == 'da-stormcast'", specifier = "==26.2.*" },
-    { name = "cupy-cuda12x", marker = "extra == 'all'", specifier = "<14.0.0" },
-    { name = "cupy-cuda12x", marker = "extra == 'cyclone'", specifier = "<14.0.0" },
-    { name = "cupy-cuda12x", marker = "extra == 'da-healda'", specifier = "<14.0.0" },
-    { name = "cupy-cuda12x", marker = "extra == 'da-interp'", specifier = "<14.0.0" },
-    { name = "cupy-cuda12x", marker = "extra == 'da-stormcast'", specifier = "<14.0.0" },
+    { name = "cucim-cu13", marker = "extra == 'all'", specifier = ">=25.4.0" },
+    { name = "cucim-cu13", marker = "extra == 'cyclone'", specifier = ">=25.4.0" },
+    { name = "cudf-cu13", marker = "extra == 'all'", specifier = ">=26.2.0" },
+    { name = "cudf-cu13", marker = "extra == 'da-healda'", specifier = ">=26.2.0" },
+    { name = "cudf-cu13", marker = "extra == 'da-interp'", specifier = ">=26.2.0" },
+    { name = "cudf-cu13", marker = "extra == 'da-stormcast'", specifier = ">=26.2.0" },
+    { name = "cupy-cuda13x", marker = "extra == 'all'" },
+    { name = "cupy-cuda13x", marker = "extra == 'cyclone'" },
+    { name = "cupy-cuda13x", marker = "extra == 'da-healda'" },
+    { name = "cupy-cuda13x", marker = "extra == 'da-interp'" },
+    { name = "cupy-cuda13x", marker = "extra == 'da-stormcast'" },
     { name = "dm-haiku", marker = "extra == 'all'", specifier = ">=0.0.14" },
     { name = "dm-haiku", marker = "extra == 'gencast'", specifier = ">=0.0.14" },
     { name = "dm-haiku", marker = "extra == 'graphcast'", specifier = ">=0.0.14" },
@@ -921,16 +1047,19 @@ requires-dist = [
     { name = "earth2grid", marker = "extra == 'stormscope'", git = "https://github.com/NVlabs/earth2grid.git?rev=11dcf1b0787a7eb6a8497a3a5a5e1fdcc31232d3" },
     { name = "earth2grid", marker = "extra == 'utils'", git = "https://github.com/NVlabs/earth2grid.git?rev=11dcf1b0787a7eb6a8497a3a5a5e1fdcc31232d3" },
     { name = "earthkit-regrid", marker = "extra == 'aifs'", specifier = "==0.4.0" },
+    { name = "earthkit-regrid", marker = "extra == 'aifs2'", specifier = ">=0.5.1" },
+    { name = "earthkit-regrid", marker = "extra == 'aifs2ens'", specifier = ">=0.5.1" },
     { name = "earthkit-regrid", marker = "extra == 'aifsens'", specifier = "==0.4.0" },
-    { name = "earthkit-regrid", marker = "extra == 'all'", specifier = "==0.4.0" },
     { name = "eccodes", marker = "extra == 'all'", specifier = ">=2.39.2" },
     { name = "eccodes", marker = "extra == 'data'", specifier = ">=2.39.2" },
     { name = "eccodeslib", marker = "extra == 'all'", specifier = ">=2.39.2" },
     { name = "eccodeslib", marker = "extra == 'data'", specifier = ">=2.39.2" },
-    { name = "ecmwf-opendata", marker = "extra == 'aifs'", specifier = ">=0.3.3" },
-    { name = "ecmwf-opendata", marker = "extra == 'aifsens'", specifier = ">=0.3.3" },
-    { name = "ecmwf-opendata", marker = "extra == 'all'", specifier = ">=0.3.3" },
-    { name = "ecmwf-opendata", marker = "extra == 'data'", specifier = ">=0.3.3" },
+    { name = "ecmwf-opendata", marker = "extra == 'aifs'", specifier = ">=0.3.29" },
+    { name = "ecmwf-opendata", marker = "extra == 'aifs2'", specifier = ">=0.3.29" },
+    { name = "ecmwf-opendata", marker = "extra == 'aifs2ens'", specifier = ">=0.3.29" },
+    { name = "ecmwf-opendata", marker = "extra == 'aifsens'", specifier = ">=0.3.29" },
+    { name = "ecmwf-opendata", marker = "extra == 'all'", specifier = ">=0.3.29" },
+    { name = "ecmwf-opendata", marker = "extra == 'data'", specifier = ">=0.3.29" },
     { name = "einops", marker = "extra == 'all'" },
     { name = "einops", marker = "extra == 'all'", specifier = ">=0.8.1" },
     { name = "einops", marker = "extra == 'atlas'" },
@@ -942,16 +1071,15 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.104.0" },
     { name = "fastapi", marker = "extra == 'serve'", specifier = ">=0.104.0" },
     { name = "flash-attn", marker = "extra == 'aifs'" },
+    { name = "flash-attn", marker = "extra == 'aifs2'" },
+    { name = "flash-attn", marker = "extra == 'aifs2ens'" },
     { name = "flash-attn", marker = "extra == 'aifsens'" },
-    { name = "flash-attn", marker = "extra == 'all'" },
     { name = "flax", marker = "extra == 'all'", specifier = ">=0.10.6" },
     { name = "flax", marker = "extra == 'gencast'", specifier = ">=0.10.6" },
     { name = "flax", marker = "extra == 'graphcast'", specifier = ">=0.10.6" },
     { name = "fme", marker = "extra == 'ace2'", git = "https://github.com/ai2cm/ace.git?rev=e211cad3e1a5cff0fa84e8d2f0ee67042eff3d4d" },
     { name = "fsspec", specifier = ">=2024.2.0" },
     { name = "gcsfs" },
-    { name = "globus-sdk", marker = "extra == 'all'", specifier = "<4.0.0" },
-    { name = "globus-sdk", marker = "extra == 'data'", specifier = "<4.0.0" },
     { name = "graphcast", marker = "extra == 'all'", git = "https://github.com/google-deepmind/graphcast.git?rev=7077d40a36db6541e3ed72ccaed1c0d202fa6014" },
     { name = "graphcast", marker = "extra == 'gencast'", git = "https://github.com/google-deepmind/graphcast.git?rev=7077d40a36db6541e3ed72ccaed1c0d202fa6014" },
     { name = "graphcast", marker = "extra == 'graphcast'", git = "https://github.com/google-deepmind/graphcast.git?rev=7077d40a36db6541e3ed72ccaed1c0d202fa6014" },
@@ -970,11 +1098,11 @@ requires-dist = [
     { name = "hydra-core", marker = "extra == 'serve'", specifier = ">=1.3.0" },
     { name = "importlib-metadata", marker = "extra == 'all'" },
     { name = "importlib-metadata", marker = "extra == 'dlwp'" },
-    { name = "intake-esgf", marker = "extra == 'all'", specifier = ">=2025.9.26" },
-    { name = "intake-esgf", marker = "extra == 'data'", specifier = ">=2025.9.26" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'all'", specifier = ">=0.4.26" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'gencast'", specifier = ">=0.4.26" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'graphcast'", specifier = ">=0.4.26" },
+    { name = "intake-esgf", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=2026.1.26" },
+    { name = "intake-esgf", marker = "python_full_version >= '3.12' and extra == 'data'", specifier = ">=2026.1.26" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'all'", specifier = ">=0.4.26" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'gencast'", specifier = ">=0.4.26" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'graphcast'", specifier = ">=0.4.26" },
     { name = "loguru" },
     { name = "makani", marker = "extra == 'all'", git = "https://github.com/NVIDIA/makani.git?rev=b38fcb2799d7dbc146fa60459f3f9823394a8bf1" },
     { name = "makani", marker = "extra == 'fcn3'", git = "https://github.com/NVIDIA/makani.git?rev=b38fcb2799d7dbc146fa60459f3f9823394a8bf1" },
@@ -986,19 +1114,18 @@ requires-dist = [
     { name = "moviepy", marker = "extra == 'sfno'" },
     { name = "multi-storage-client", marker = "extra == 'all'", specifier = ">=0.44.0" },
     { name = "multi-storage-client", marker = "extra == 'serve'", specifier = ">=0.44.0" },
-    { name = "multi-storage-client", extras = ["boto3", "fsspec", "google-cloud-storage"], marker = "extra == 'all'", specifier = ">=0.33.0" },
-    { name = "multi-storage-client", extras = ["boto3", "fsspec", "google-cloud-storage"], marker = "extra == 'data'", specifier = ">=0.33.0" },
     { name = "natten", marker = "python_full_version < '3.14' and extra == 'all'" },
     { name = "natten", marker = "python_full_version < '3.14' and extra == 'atlas'" },
     { name = "natten", marker = "python_full_version < '3.14' and extra == 'stormscope'" },
-    { name = "nest-asyncio" },
     { name = "netcdf4", specifier = ">=1.6.4,<1.7.3" },
     { name = "nvidia-physicsnemo", marker = "extra == 'all'", specifier = ">=1.0.1" },
     { name = "nvidia-physicsnemo", marker = "extra == 'all'", specifier = ">=1.3.0" },
     { name = "nvidia-physicsnemo", marker = "extra == 'all'", specifier = ">=2.0" },
+    { name = "nvidia-physicsnemo", marker = "extra == 'all'", specifier = ">=2.0,<=2.1.1" },
+    { name = "nvidia-physicsnemo", marker = "extra == 'all'", specifier = ">=2.1.0" },
     { name = "nvidia-physicsnemo", marker = "extra == 'atlas'", specifier = ">=1.3.0" },
     { name = "nvidia-physicsnemo", marker = "extra == 'corrdiff'", specifier = ">=2.0" },
-    { name = "nvidia-physicsnemo", marker = "extra == 'da-healda'", specifier = ">=2.0" },
+    { name = "nvidia-physicsnemo", marker = "extra == 'da-healda'", specifier = ">=2.0,<=2.1.1" },
     { name = "nvidia-physicsnemo", marker = "extra == 'da-stormcast'", specifier = ">=2.0" },
     { name = "nvidia-physicsnemo", marker = "extra == 'dlesym'", specifier = ">=1.0.1" },
     { name = "nvidia-physicsnemo", marker = "extra == 'dlwp'", specifier = ">=1.0.1" },
@@ -1009,13 +1136,14 @@ requires-dist = [
     { name = "nvidia-physicsnemo", marker = "extra == 'solarradiation-afno'", specifier = ">=1.0.1" },
     { name = "nvidia-physicsnemo", marker = "extra == 'statistics'", specifier = ">=1.0.1" },
     { name = "nvidia-physicsnemo", marker = "extra == 'stormcast'", specifier = ">=2.0" },
-    { name = "nvidia-physicsnemo", marker = "extra == 'stormscope'", specifier = ">=2.0" },
+    { name = "nvidia-physicsnemo", marker = "extra == 'stormscope'", specifier = ">=2.1.0" },
     { name = "nvidia-physicsnemo", marker = "extra == 'windgust-afno'", specifier = ">=1.0.1" },
     { name = "nvtx", marker = "extra == 'all'", specifier = ">=0.2.11" },
     { name = "nvtx", marker = "extra == 'corrdiff'", specifier = ">=0.2.11" },
     { name = "nvtx", marker = "extra == 'da-stormcast'", specifier = ">=0.2.11" },
     { name = "nvtx", marker = "extra == 'stormcast'", specifier = ">=0.2.11" },
     { name = "nvtx", marker = "extra == 'stormscope'", specifier = ">=0.2.11" },
+    { name = "obstore", specifier = ">=0.8" },
     { name = "omegaconf", marker = "extra == 'all'", specifier = ">=2.3.0" },
     { name = "omegaconf", marker = "extra == 'da-stormcast'", specifier = ">=2.3.0" },
     { name = "omegaconf", marker = "extra == 'dlesym'", specifier = ">=2.3.0" },
@@ -1024,23 +1152,25 @@ requires-dist = [
     { name = "onnx", marker = "extra == 'fengwu'" },
     { name = "onnx", marker = "extra == 'fuxi'" },
     { name = "onnx", marker = "extra == 'pangu'" },
-    { name = "onnxruntime-gpu", marker = "extra == 'all'", specifier = ">=1.21.0" },
-    { name = "onnxruntime-gpu", marker = "extra == 'fengwu'", specifier = ">=1.21.0" },
-    { name = "onnxruntime-gpu", marker = "extra == 'fuxi'", specifier = ">=1.21.0" },
-    { name = "onnxruntime-gpu", marker = "extra == 'pangu'", specifier = ">=1.21.0" },
+    { name = "onnxruntime-gpu", marker = "extra == 'all'", specifier = ">=1.21.0", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/" },
+    { name = "onnxruntime-gpu", marker = "extra == 'fengwu'", specifier = ">=1.21.0", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/" },
+    { name = "onnxruntime-gpu", marker = "extra == 'fuxi'", specifier = ">=1.21.0", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/" },
+    { name = "onnxruntime-gpu", marker = "extra == 'pangu'", specifier = ">=1.21.0", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/" },
     { name = "onnxscript", marker = "extra == 'all'" },
     { name = "onnxscript", marker = "extra == 'fengwu'" },
     { name = "onnxscript", marker = "extra == 'fuxi'" },
     { name = "onnxscript", marker = "extra == 'pangu'" },
-    { name = "pandas", specifier = "<3.0" },
+    { name = "pandas" },
     { name = "pandas", marker = "extra == 'ace2'", specifier = ">=2.3.2" },
-    { name = "pandas", marker = "extra == 'all'", specifier = "<3.0" },
-    { name = "pandas", marker = "extra == 'data'", specifier = "<3.0" },
+    { name = "pcodec", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=1.0.2" },
+    { name = "pcodec", marker = "python_full_version >= '3.12' and extra == 'data'", specifier = ">=1.0.2" },
     { name = "planetary-computer", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "planetary-computer", marker = "extra == 'data'", specifier = ">=0.5.0" },
     { name = "prometheus-client", marker = "extra == 'all'", specifier = ">=0.17.0" },
     { name = "prometheus-client", marker = "extra == 'serve'", specifier = ">=0.17.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
+    { name = "pybufrkit", marker = "extra == 'all'", specifier = ">=0.2.22" },
+    { name = "pybufrkit", marker = "extra == 'data'", specifier = ">=0.2.22" },
     { name = "pydantic", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "pydantic", marker = "extra == 'serve'", specifier = ">=2.0.0" },
     { name = "pygrib" },
@@ -1090,6 +1220,8 @@ requires-dist = [
     { name = "timm", marker = "extra == 'all'" },
     { name = "timm", marker = "extra == 'atlas'" },
     { name = "torch", specifier = ">=2.5.0" },
+    { name = "torch-geometric", marker = "extra == 'aifs2'", specifier = ">=2.6.0" },
+    { name = "torch-geometric", marker = "extra == 'aifs2ens'", specifier = ">=2.6.0" },
     { name = "torch-harmonics", marker = "extra == 'all'" },
     { name = "torch-harmonics", marker = "extra == 'all'", specifier = ">=0.7.4" },
     { name = "torch-harmonics", marker = "extra == 'all'", specifier = ">=0.8.0" },
@@ -1104,10 +1236,13 @@ requires-dist = [
     { name = "urllib3", marker = "extra == 'serve'", specifier = ">=1.26.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.24.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.24.0" },
+    { name = "xarray", marker = "extra == 'all'", specifier = "<2026.4.0" },
+    { name = "xarray", marker = "extra == 'gencast'", specifier = "<2026.4.0" },
+    { name = "xarray", marker = "extra == 'graphcast'", specifier = "<2026.4.0" },
     { name = "xarray", extras = ["parallel"], specifier = ">=2023.1.0" },
-    { name = "zarr", specifier = ">=3.1.0" },
+    { name = "zarr", specifier = ">=3.1.3" },
 ]
-provides-extras = ["ace2", "aifs", "aifsens", "all", "atlas", "aurora", "cbottle", "climatenet", "corrdiff", "cyclone", "da-healda", "da-interp", "da-stormcast", "data", "derived", "dlesym", "dlwp", "fcn", "fcn3", "fengwu", "fuxi", "gencast", "graphcast", "interp-modafno", "pangu", "perturbation", "precip-afno", "precip-afno-v2", "serve", "sfno", "solarradiation-afno", "statistics", "stormcast", "stormscope", "utils", "windgust-afno"]
+provides-extras = ["ace2", "aifs", "aifs2", "aifs2ens", "aifsens", "all", "atlas", "aurora", "cbottle", "climatenet", "corrdiff", "cyclone", "da-healda", "da-interp", "da-stormcast", "data", "derived", "dlesym", "dlwp", "fcn", "fcn3", "fengwu", "fuxi", "gencast", "graphcast", "interp-modafno", "orbit", "pangu", "perturbation", "precip-afno", "precip-afno-v2", "serve", "sfno", "solarradiation-afno", "statistics", "stormcast", "stormscope", "ucast", "utils", "windgust-afno"]
 
 [package.metadata.requires-dev]
 build = [
@@ -1157,7 +1292,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cartopy" },
-    { name = "earth2studio", extra = ["data", "dlwp", "fcn3", "perturbation", "statistics", "utils"] },
+    { name = "earth2studio", extra = ["data", "dlwp", "fcn3", "perturbation", "statistics", "stormscope", "utils"] },
     { name = "hydra-core" },
     { name = "matplotlib" },
     { name = "nvidia-physicsnemo" },
@@ -1178,7 +1313,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cartopy" },
-    { name = "earth2studio", extras = ["data", "dlwp", "fcn3", "perturbation", "statistics", "utils"], editable = "../../" },
+    { name = "earth2studio", extras = ["data", "dlwp", "fcn3", "perturbation", "statistics", "stormscope", "utils"], editable = "../../" },
     { name = "hydra-core", specifier = ">=1.3.0" },
     { name = "matplotlib" },
     { name = "nvidia-physicsnemo", specifier = ">=2.0" },
@@ -1269,14 +1404,14 @@ wheels = [
 
 [[package]]
 name = "ecmwf-opendata"
-version = "0.3.26"
+version = "0.3.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "multiurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/16/074aee6fd1fa21b6445fb8429a16c50dac91053b66f3c99ada86b09665e2/ecmwf_opendata-0.3.26.tar.gz", hash = "sha256:8b49eed2282c167e50663b38768631a5b6d758fd947c4ea764d37433ac92523a", size = 28873, upload-time = "2025-12-04T15:08:29.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/b6/b4ff53251724bab74f9ab6729ca9f2aff615db41ba1e4414781ae1750ad2/ecmwf_opendata-0.3.30.tar.gz", hash = "sha256:bf8b989fb9526e413e1aa51f7ae96d689df442c8339d6804561ad387dc39e7d7", size = 30446, upload-time = "2026-06-15T12:03:58.59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/74/7795b50a4a74dd0d9b8f8b028912878da0e64969eb4889e64b7a75aeef63/ecmwf_opendata-0.3.26-py3-none-any.whl", hash = "sha256:e158bab54f86908dbc634c1660a527bd1d27dbe26ba4d8484f622cd8565185d6", size = 21818, upload-time = "2025-12-04T15:08:28.531Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e7/f4742ee0b3588e7cb0e1506bad2604a90bad288321ac43b26c806a9f5704/ecmwf_opendata-0.3.30-py3-none-any.whl", hash = "sha256:df61a8efb260e53cf2c66beb89146cf116eeb6f0beaf6ed16e6315c412e05234", size = 23570, upload-time = "2026-06-15T12:03:57.536Z" },
 ]
 
 [[package]]
@@ -1286,6 +1421,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", marker = "python_full_version >= '3.12'" },
+    { name = "idna", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1469,14 +1617,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
 ]
 
 [[package]]
@@ -1484,9 +1632,9 @@ name = "globus-sdk"
 version = "3.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "requests" },
+    { name = "cryptography", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/93/a6f6686bb2beb038047abe203b48c7f995f6a96884679eedf7e9aa34300b/globus_sdk-3.65.0.tar.gz", hash = "sha256:a4b350b980809e86d768c8e327de9ddee4405b60cfb83429cdf831ac0c63d763", size = 275365, upload-time = "2025-10-03T01:56:45.402Z" }
 wheels = [
@@ -1855,6 +2003,24 @@ wheels = [
 ]
 
 [[package]]
+name = "icechunk"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zarr", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/41/ea6d2ebe3fced2be5ca4e8540b776d9544a31e30f0a90fe7968b28288aff/icechunk-2.1.1.tar.gz", hash = "sha256:a46637e2e079edcfb92a6cc2a7a0cfb990224b0be2fb1931f967361d17498fa0", size = 3528133, upload-time = "2026-07-08T20:30:01.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/9c/9cad0e3c6f4ab671816e513a10ddde6c13ca5b290ee38ae4f6611b098263/icechunk-2.1.1-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:660e8ad231cddad0f86cd26cc2f46a845d6b5cfed7bf023e9ceefbdb78b7d3e4", size = 17092044, upload-time = "2026-07-08T20:30:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ba/e7af165c67a8707e18f5e97233093a9d13153948334788f168002bfabffd/icechunk-2.1.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:8fe37a901d7ad6a6bedb074e60a521505cce11d418777b43d974601a53c03ed5", size = 15776756, upload-time = "2026-07-08T20:30:06.79Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5b/b02968cd97ef2d910dd46eadf03e078f630ddf14c869c3b0c05363e6739a/icechunk-2.1.1-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9131213e1d831e63a0f74d20792934f3e1c97d4084680788df0648f4c19cb985", size = 17473456, upload-time = "2026-07-08T20:30:04.128Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/d1a379c7206011da4d89ab32064ff98398eaf4cc32227189cfb443d252a1/icechunk-2.1.1-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34cc925a3d339dde989889d6f703bed3eb0d5d2e41887cf12a485c36122159eb", size = 17117003, upload-time = "2026-07-08T20:29:59.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/08/dcab15706126a1ac05639d6213ce34fdf72ff5c77a85542e09a9fcab4356/icechunk-2.1.1-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2ceef9b8b0d4988b35c33411e5c2da15364611ba8a88292f6d382fe6d216f452", size = 17338644, upload-time = "2026-07-08T20:30:11.397Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/6ca99877532b9f214ed62ead6c9921b5798d0ce1eed468ab0f71331bcd77/icechunk-2.1.1-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f6bbcb216f636fc6b53682297a6438eeb81f577e976b430ba58407d05f34bb31", size = 17886257, upload-time = "2026-07-08T20:30:13.761Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ca/14d4a288343b2e01e06888a86640e8ce3e16b6f2b8bd10616add382f71d4/icechunk-2.1.1-cp312-abi3-win_amd64.whl", hash = "sha256:b87329b7088301777f5dde7f6f4180938cf410768e4cb49d3b9cc064eda2b036", size = 16209937, upload-time = "2026-07-08T20:30:16.41Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1913,39 +2079,8 @@ wheels = [
 
 [[package]]
 name = "intake-esgf"
-version = "2025.10.22"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.12' and platform_machine != 's390x'",
-    "python_full_version < '3.12' and platform_machine == 's390x'",
-]
-dependencies = [
-    { name = "dask", marker = "python_full_version < '3.12'" },
-    { name = "globus-sdk", marker = "python_full_version < '3.12'" },
-    { name = "netcdf4", marker = "python_full_version < '3.12'" },
-    { name = "pandas", marker = "python_full_version < '3.12'" },
-    { name = "pystac-client", marker = "python_full_version < '3.12'" },
-    { name = "pyyaml", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "requests-cache", marker = "python_full_version < '3.12'" },
-    { name = "tqdm", marker = "python_full_version < '3.12'" },
-    { name = "xarray", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/31/22fdaecbac3e8830d3ecf47fb3516ff940ccb160447e6376e42c49d91a82/intake_esgf-2025.10.22.tar.gz", hash = "sha256:dcbb091612b1cd9168ae93b6ce6ab585cf3e1b9eefd47fe9d36954ced856311d", size = 97011, upload-time = "2025-10-22T17:58:04.992Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/f7/cd2a02950236c9527abaf08de03dbea67f82f3d0c9d595a92a58964c19bb/intake_esgf-2025.10.22-py3-none-any.whl", hash = "sha256:98a166416756a466099d37a09f68b110deff877d6676e76bfb55b0972fa08e53", size = 61879, upload-time = "2025-10-22T17:58:04.016Z" },
-]
-
-[[package]]
-name = "intake-esgf"
 version = "2026.1.26"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13' and platform_machine != 's390x'",
-    "python_full_version == '3.12.*' and platform_machine != 's390x'",
-    "python_full_version >= '3.13' and platform_machine == 's390x'",
-    "python_full_version == '3.12.*' and platform_machine == 's390x'",
-]
 dependencies = [
     { name = "dask", marker = "python_full_version >= '3.12'" },
     { name = "globus-sdk", marker = "python_full_version >= '3.12'" },
@@ -2097,15 +2232,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
     { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
     { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
-]
-
-[[package]]
-name = "lark"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -2434,48 +2560,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multi-storage-client"
-version = "0.45.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "jmespath" },
-    { name = "jsonschema" },
-    { name = "lark" },
-    { name = "opentelemetry-api" },
-    { name = "prettytable" },
-    { name = "psutil" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "tzdata" },
-    { name = "wcmatch" },
-    { name = "xattr" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/17/17b9149054cb0eef8a848d5e67fb87c7464b790033752412effe458ddc7b/multi_storage_client-0.45.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4553a8b7e7b24c9fda8e3f8e2d067e5b69eb427b8640cfed1019830097588cc0", size = 9011728, upload-time = "2026-03-24T17:36:26.763Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a8/7312befa401395b4901ab78c3fb35a3dc6f0734ad7377eb0dc2703a3bf61/multi_storage_client-0.45.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa35561f5d73cdd5996a0394a6acab878b51f32e1759aec806e81ed07249c5aa", size = 5397911, upload-time = "2026-03-24T17:40:57.58Z" },
-    { url = "https://files.pythonhosted.org/packages/54/c5/2f17d5ef4bf2964ddcdfe366e5ab19ea0d25fa5f0dfdb33410624ef85625/multi_storage_client-0.45.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c60a71cd0bbdf255e14378bfd79d499bf220eca34321bf770c19d181b73208ea", size = 5589127, upload-time = "2026-03-24T17:35:27.568Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/59/b2a05f8ecfdfe3c5324b8ff7ee17434df56130e2cd5f8b35d1c5b188c4de/multi_storage_client-0.45.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ef7dff8c27c1c092b58ba06a37aac0a2441a109202f36afc986b05e1e73f97a2", size = 9011744, upload-time = "2026-03-24T17:39:22.665Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/d0c25e18eadc5a6f14b1c4c53b781d7f669bd310046d35dc658ab0f98b4c/multi_storage_client-0.45.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1439d6acd6957c6d4e118305e08fb029c4b36814ca9c8070dcacc741b351ba9a", size = 5395849, upload-time = "2026-03-24T17:39:46.041Z" },
-    { url = "https://files.pythonhosted.org/packages/33/9b/0134d06d66a99e1fd39c6d2c1006cbca59e04db39d339a4de0bfcaacb188/multi_storage_client-0.45.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8960b5d661cbf79349186089f59a57a9f22703d41e99e73a17c9e0f1c2737f9", size = 5585758, upload-time = "2026-03-24T17:40:10.248Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/72/565fe8f0a6ce1639719fccc5049d9dbab4d007c94978254eca3134631b4c/multi_storage_client-0.45.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9de9f980d662ee741ef8ddfd84a72b6e5ab55cd91162f5182a6ad9bf75f4be8d", size = 9008456, upload-time = "2026-03-24T17:41:20.877Z" },
-    { url = "https://files.pythonhosted.org/packages/34/b2/72ca7f3d93a147edf47fe384e71146e4df0c679537acb7fe3436c6018335/multi_storage_client-0.45.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da7285874857102b2562d2d381cde115c6cdcc3b6d0c5bc1e30c5f41a00a1518", size = 5395483, upload-time = "2026-03-24T17:38:58.779Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/00/070aec0b31cae59633beaf3e696f8ecc84ae8c084aa414346bd71b95afc1/multi_storage_client-0.45.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e62bf1442931d9923d25ee7c5067a491a431294d8e9fbf56546c9ae3e1542537", size = 5585772, upload-time = "2026-03-24T17:35:53.259Z" },
-]
-
-[package.optional-dependencies]
-boto3 = [
-    { name = "boto3" },
-]
-fsspec = [
-    { name = "fsspec" },
-]
-google-cloud-storage = [
-    { name = "google-cloud-storage" },
-]
-
-[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2558,7 +2642,7 @@ wheels = [
 
 [[package]]
 name = "multiurl"
-version = "0.3.7"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
@@ -2566,9 +2650,9 @@ dependencies = [
     { name = "requests" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/ce/a00c9b44f43c4620ca004e4acb4c1e266b1ab48d2f6ad9e402f6bdbe44d4/multiurl-0.3.7.tar.gz", hash = "sha256:4201563fc8989baca7b525fdc69d4cd5a6c0cef4f303559710b9890021aab6d9", size = 18945, upload-time = "2025-07-29T11:57:04.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/35/a08c568e63fda8cb1b7f3168409c026d2b407ab6d82da09cea078b01c2d7/multiurl-0.3.9.tar.gz", hash = "sha256:799b7998bfabd4e15d51ba09d08eb5d0716762655bae6e09db00a14c3bfaeae6", size = 20044, upload-time = "2026-06-18T07:43:38.756Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/cf/be4e93afbfa0def2cd6fac9302071db0bd6d0617999ecbf53f92b9398de3/multiurl-0.3.7-py3-none-any.whl", hash = "sha256:054f42974064f103be0ed55b43f0c32fc435a47dc7353a9adaffa643b99fa380", size = 21524, upload-time = "2025-07-29T11:57:03.191Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f1/2374970b2ad0ab20e28a0cd12eec1c234567fef31064f0903396d55ae3f1/multiurl-0.3.9-py3-none-any.whl", hash = "sha256:5acedb53343bb47ff6188405dc33e10c1f1713591de8929a69b966d4d395d88e", size = 22610, upload-time = "2026-06-18T07:43:37.727Z" },
 ]
 
 [[package]]
@@ -2581,13 +2665,10 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
+name = "natten"
+version = "0.21.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/06/2f/e10aa0edfa2e203fc649a4a52ed9e946decc16824f4740cf61d85a7f9a88/natten-0.21.6.tar.gz", hash = "sha256:c26871225fa533f8a9433ccd4496e3c4dcf6d0e0da369a2f6b547d4321a25dc1", size = 2863866, upload-time = "2026-04-14T18:15:50.885Z" }
 
 [[package]]
 name = "netcdf4"
@@ -2741,142 +2822,157 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
+name = "nvidia-cublas"
+version = "13.1.0.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
 ]
 
 [[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
 ]
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+name = "nvidia-cufft"
+version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+name = "nvidia-nvjitlink"
+version = "13.0.88"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
 ]
 
 [[package]]
-name = "nvidia-nvshmem-cu12"
+name = "nvidia-nvshmem-cu13"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+name = "nvidia-nvtx"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
 name = "nvidia-physicsnemo"
-version = "2.0.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cftime" },
@@ -2901,10 +2997,11 @@ dependencies = [
     { name = "torchvision" },
     { name = "tqdm" },
     { name = "treelib" },
+    { name = "urllib3" },
     { name = "warp-lang" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/bd/72eb242134e355810821d2c42e8ca9f15c6757c309e02389fc6f2bd40f02/nvidia_physicsnemo-2.0.0-py3-none-any.whl", hash = "sha256:fcea6ac198a2925ab81c3f62011225f53b73e1212e5364aac939ab599c0dfd9d", size = 1637877, upload-time = "2026-03-09T16:14:55.312Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/21/c5304a154d5be6464f14b9663f88cb80de6cd2616cff60c00a43678482f8/nvidia_physicsnemo-2.1.1-py3-none-any.whl", hash = "sha256:86479174f725dd8f569f76f7e688f64721afd2c16421e8516973f46f8febbefc", size = 2129103, upload-time = "2026-06-08T23:34:39.168Z" },
 ]
 
 [[package]]
@@ -2934,6 +3031,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "obstore"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2f/f83afaab7945509d72245b2b00af0b4834ce78fdd2d9ae9f0ad1a3036a91/obstore-0.11.0.tar.gz", hash = "sha256:a2f55163bcd348b4a60d12e6893eac50eddc742bad8032a1705d49140b992204", size = 130565, upload-time = "2026-06-25T18:29:49.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b2/00c213e7e5ca8065f97e37e55294adab836e3f6a88b23e4029069aaecf95/obstore-0.11.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42f36546c7ac44dbab1173d2330a8a1b1a3f0e37950e553b8c904e3dd0744b25", size = 5491935, upload-time = "2026-06-25T18:28:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/6a6b9a5e15a8a37c24d14317a87648097c4888593b588510c03c030d2e90/obstore-0.11.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:687bb9d3962d568b7c439c5d0c6fea19b2749862a8e5c8eebd0c058c4eccde9e", size = 4672619, upload-time = "2026-06-25T18:28:33.852Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f9/6745ce8c4f7bfac19dc14a4438b48a2e93a689b92b0cecfc695e41a4e8b1/obstore-0.11.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:010b51578c7514a41719d795cdb7a1e6529be509dac3772e477187a59422bb97", size = 5072806, upload-time = "2026-06-25T18:28:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/991d3b3cdd851c0225e55f3dc45b47fd9e249827d188995011469f805132/obstore-0.11.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfaa8129a3f5d8518a3a75184d4b02348db0f6263177cd1f0951f6568243cc9e", size = 5303777, upload-time = "2026-06-25T18:28:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e9/90e56015a45b5e56a84fc3188c4e5fb088b288d41992c73a629e10df6760/obstore-0.11.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c790a5cb9ff2970d1f464a6a708d734dce9939e9f668cb6708c5dba5d61589b2", size = 5493871, upload-time = "2026-06-25T18:28:39.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/02/f1744091d59ce71c5523174eb860fbb298275c901e89b9ea6fbf3e654a33/obstore-0.11.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:827113e12fe8088e0281a9d57b90b2b8dbc8a6ffe3b15dadb9baa5feb3d266c1", size = 5361913, upload-time = "2026-06-25T18:28:42.089Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/59/3f47822683ee2b6db8685faa25829946d6343a561251ec2704548455d946/obstore-0.11.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2ff6d3ed553298828fb760b4aef6347fbcc7b5c5e3ce3f8381ce805c370021a", size = 5638724, upload-time = "2026-06-25T18:28:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/23/50/1df335fdf9b527b3933f1e94ab6fc720ad314260fab8591cb0b6668ff192/obstore-0.11.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:39d04b324fcf984e7050734ebda77b81764025b0c011750201a0d8954087f7aa", size = 5413508, upload-time = "2026-06-25T18:28:45.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/a259aba149b841ca7c91fea177df9972a60a636b54077beed1a35b254994/obstore-0.11.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:37c0d15d775b1370ef5204ee3919a5ddf7e2592d11815213105f8db031f2ab8d", size = 5619995, upload-time = "2026-06-25T18:28:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b4/ec25fdb4d6b060bc6eea647fc0e88f75fcc20fe8d16d67fb0dbe999d323b/obstore-0.11.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7f468caf9b6e0f12ff151e5fe618de5fc9192befa9bd02734b06de4efd2e49f6", size = 5299512, upload-time = "2026-06-25T18:28:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/29be060d06ec13e2af3d1b6cfb77b7c37f8be6c56b77295c945fefad73e4/obstore-0.11.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:42d8e8fad85be8ee488c1a9a9b7c6a42128abb84e67175da40d3d1165c1846df", size = 5427026, upload-time = "2026-06-25T18:28:51.317Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/577a965f440e9ea64243518663f9d16be7df8eafc7123818e8e841fa21ce/obstore-0.11.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9c8fd2a544e2e0b926669c47fcfb8d2314e234abc240ea165dae04ee42e1d7ac", size = 5869187, upload-time = "2026-06-25T18:28:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/18/8fdbaee22bfd5b9c44e1fdff8ca0508e2fe60c42bf9fc85f0c9c27b4ecf2/obstore-0.11.0-cp311-abi3-win_amd64.whl", hash = "sha256:6fb3d4678c0f4242d3109362e9b1df5d7b27765f43d5aacb2e81af53a75cb9ef", size = 5329384, upload-time = "2026-06-25T18:28:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/61/17/6ddc3e035a0adc3397bc2b9ea4ebe52db6711ad87ddf0180b7675fa25d6a/obstore-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c30aec09acff505e27b7392eb5e4b7bb7073d3f21e44ea43a64913369d83cba0", size = 5500652, upload-time = "2026-06-25T18:29:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/66/0e8ebfebf7151b401dee19373b3a699b179c3687bea5d684adbef2c7c67d/obstore-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:32ec11db91b85e4482baf2c8c0f43b469e8788765cd844839c84468516446181", size = 4681675, upload-time = "2026-06-25T18:29:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/84/717505cdf8e453ef16be74e6ca4204629722227c1cbecf3719a17513dd9a/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a7f574cf222156f95846fda755365085e8c825be48359f32fa57935fa79f172", size = 5078712, upload-time = "2026-06-25T18:29:27.502Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e4/a3a87a9ef6973cc59f8cd3543b74cde3bac81ff18bfdab80a460c95d5df0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:193d8af924c24ab60c342d64c55896f8cae026851182ade6f1b650789d17b84a", size = 5309116, upload-time = "2026-06-25T18:29:29.912Z" },
+    { url = "https://files.pythonhosted.org/packages/98/40/af6699c140cd4f5fb638ccad2053b096ebaa8b5fcd2a2c5176113c1bc847/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed68e3653f12a995bca4372cdccf8663bd3df2ce9750132d11c4c04489e2dc61", size = 5503037, upload-time = "2026-06-25T18:29:32.396Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/e83123e8e2d2075dd686ed1c13e462c19b9c57ec0a67c316bdde862c6def/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8d5aa13158e39d20e76730fdc81a50fd80f6d415a1dc327cf317e5c4e2e878", size = 5368241, upload-time = "2026-06-25T18:29:34.366Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/94/d1cba6347ed6e540765e6db2c2a262f8aba50ae40a0d47749465c42e94a0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca0a6bef07fc26990828528090c6b41860ca949d3cf1b81b24854674173b47ba", size = 5644399, upload-time = "2026-06-25T18:29:36.482Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/24/a9033feffb423d5f6a7bdc85041e9b9e1f67b2835fd484427d005ed17187/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:c9c6ccc06801afb0fc0e8f0e8c957f643c2c4f7e349eb36a736167e280709c6c", size = 5423124, upload-time = "2026-06-25T18:29:38.513Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e8/2ee75c66bc703670bbf1aa51c320a4d282efa85adf8e9fa3f7467c02513e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:9555f36a0724d34d747b38cda0cb55b3f650a22e8671614037c52190bf4da6cc", size = 5630049, upload-time = "2026-06-25T18:29:40.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/76b3099664d997747e5e7b11b322926d486d1471266941fc0103d912b666/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:f0c1527daf1c75d3f70ee3f6bef2767d8b07005cd7a5b43dc8c96a1323f3ac54", size = 5308482, upload-time = "2026-06-25T18:29:42.643Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/03594ac63d7b1a0e773b0c604c38003ee828e6d5348488eaeb2c57bdc29e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ed5910bde525d7d936d36dc78c7d4c07b57b6c9b55e402357b107103595d56ff", size = 5433377, upload-time = "2026-06-25T18:29:45.323Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/53/07226c948760264fb7ba253825ecbe5941abfac9875e6d1b2679cc82e3ef/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:65c0208ead516c1a79afced16f2cda9b5542886123e53ea0a8a7d5d56b86fba5", size = 5868708, upload-time = "2026-06-25T18:29:47.668Z" },
 ]
 
 [[package]]
@@ -2978,19 +3111,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/2e/27affcac63eaf2ef183a44fd1a1354b11da64a6c72fe6f3fdcf5571bcee5/onnx-1.21.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b58a4cfec8d9311b73dc083e4c1fa362069267881144c05139b3eba5dc3a840", size = 17617687, upload-time = "2026-03-27T21:33:12.619Z" },
     { url = "https://files.pythonhosted.org/packages/1c/5c/ac8ed15e941593a3672ce424280b764979026317811f2e8508432bfc3429/onnx-1.21.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1a9baf882562c4cebf79589bebb7cd71a20e30b51158cac3e3bbaf27da6163bd", size = 16449402, upload-time = "2026-03-27T21:33:15.555Z" },
     { url = "https://files.pythonhosted.org/packages/0e/aa/d2231e0dcaad838217afc64c306c8152a080134d2034e247cc973d577674/onnx-1.21.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bba12181566acf49b35875838eba49536a327b2944664b17125577d230c637ad", size = 16408273, upload-time = "2026-03-27T21:33:18.599Z" },
-]
-
-[[package]]
-name = "opentelemetry-api"
-version = "1.41.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
 ]
 
 [[package]]
@@ -3119,6 +3239,38 @@ wheels = [
 ]
 
 [[package]]
+name = "pcodec"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/04/463fb9af3d6d790a44d01db4c2890d84d089a918e730e70f841892127634/pcodec-1.0.2.tar.gz", hash = "sha256:f97cad59175e9353f1da9f5bbadce340d31858e992f4ebdf09acc78f424f08d4", size = 146715, upload-time = "2026-05-10T00:54:47.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/d4/412f56042c6545250173528b1137f732d1f5cb0c564f4d5d3e536ff3b2ea/pcodec-1.0.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d0eb432198988c31058a5cc461f544894f704e6c2bc4d185d63d48602eefa7d1", size = 560064, upload-time = "2026-05-10T00:54:40.505Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6d/96dc383b21ce11e981e17d4a37ab9f628c5ee92f9695602e9543a13d94ae/pcodec-1.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:377d2ac3174823c9856b883366405bc8c9e88149b17c936266fc5c1c4595a866", size = 523547, upload-time = "2026-05-10T00:54:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/59/cc11f445d8f434571349506f85dc49df1f950f933ae0bcbd67931745a865/pcodec-1.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5375369703b5bf5d3606097c12dabe4a5313f907da2ff1ba07ee1e6edf332b7", size = 548688, upload-time = "2026-05-10T00:54:00.891Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/87/9e025f527c3cf6d9a373f833a62c44e173a5a19bb889fb2cfa39601b632b/pcodec-1.0.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8eb97721c86de69dfa92709821d5f0ef8eba40aaa559d10435edbec35fde972", size = 562744, upload-time = "2026-05-10T00:54:09.156Z" },
+    { url = "https://files.pythonhosted.org/packages/35/30/0add6521622fa335a43fa88c2d9d982769355ccecc787b6900eb40c985a4/pcodec-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:897a59031c0de96631eea2b43c40f95b1c6794ad8abc7fa00c19e90e6d3c64ad", size = 585941, upload-time = "2026-05-10T00:54:24.713Z" },
+    { url = "https://files.pythonhosted.org/packages/83/db/7d1979a174594855d0dce6783e4a050b87855dc7f5718d62f61ca822dc81/pcodec-1.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6dd1436b120c08b113315c768928589b36aaaf58bc56ee3a8b81ebe50f1b3bf4", size = 607145, upload-time = "2026-05-10T00:54:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/af747cafd25f4a177e4349d1dee0a9d8b5d3d3e54de5d67b661100884dd7/pcodec-1.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:57d02cbf89ecb3966375cdd7e7544f6ad043842dac081dc6630bb340a3997b66", size = 475955, upload-time = "2026-05-10T00:54:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7c/dd83c1d4ff84617b713b90acb6d66368de23adb49dd10237711e07fe51b6/pcodec-1.0.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c0b59f4414bfa51b4fc02563efff888f6bc00ab3f73bdc04d1275b2b044ba859", size = 560906, upload-time = "2026-05-10T00:54:41.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e6/097e82d6e296e361e6b617fe7980661fc433ee039074cdcdd8a5269c6100/pcodec-1.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7182e1c9ddbc505be87fb54317ce091e8448862edc20dcadf6ba34e89e297c0d", size = 523322, upload-time = "2026-05-10T00:54:33.813Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/f5e0e0e176be0420228dfe0b9d014e93c43e744cefbfae7b9de8815b0dd6/pcodec-1.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4968cbbcfb3aa7f9acf92704665d49385ee7a9d1c6ca736f61037a11d2cf9259", size = 547758, upload-time = "2026-05-10T00:54:02.135Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/be/b28223ccf32449f3321fb457711c15e9e54500ab484a44ec677677b639c9/pcodec-1.0.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4fd4ba77c3a645d940bd5b55422c90caf349084c7f00564d7d36a8a55159ce36", size = 561868, upload-time = "2026-05-10T00:54:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ae/21894e94dd09d6f31551232305882a4b37938698875e0ec8b8e3d9f95132/pcodec-1.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07f2e43693c5215238b077f5a540e453540250141f248726a5d545836a80ebab", size = 587352, upload-time = "2026-05-10T00:54:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c6/48e987c851a778d64fb68d23f4dabe07cbe6046dfe159eb301a7b0372267/pcodec-1.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4dced31b0e84a39cdc952adf2405b1ec7add7aece3aa01d7a3d662ade905427", size = 605425, upload-time = "2026-05-10T00:54:18.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d2/46987cb95c3305933fa742c7432fd2d8df80c054d58ef26aa289dd19c206/pcodec-1.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8cc13c0701f416757aa7213b1e9184454e1b49ce857ef253a0f95ec2b997e759", size = 475725, upload-time = "2026-05-10T00:54:50.799Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5f/ea2d0b1519c7bf7c88ac2d534dcf91eeb43a89bb2176dd8d6012e2adc248/pcodec-1.0.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f889735a76997cc4ccc308a3190d5dcf491f707a9754add1d1d92a1906d8bcc0", size = 560658, upload-time = "2026-05-10T00:54:43.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a7/f7b7ac78684c2ceff6183b43b53351bcccbe19b90f614ee959a21304806a/pcodec-1.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:230ee7649f763f859b4348f5eb927c1a15d5134cb967a612ef9302cb68f24e82", size = 523018, upload-time = "2026-05-10T00:54:34.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c1/d1db5b5b808a1f6379b046118922cb3c62110f7312e6d9d27605a241d2ad/pcodec-1.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2a3e3f180335d8526674764b53e3fe18b91a9f4c79f5f2d5f73690fedf01105", size = 547660, upload-time = "2026-05-10T00:54:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/48/8e736b919f9fc445f811f8cdd0cf3f3f1c242810d113e34456249ef1efae/pcodec-1.0.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a95fb18bdcfafba82de65a43e949abee056a117f07f85a1ee16872aa62243e8d", size = 561119, upload-time = "2026-05-10T00:54:11.932Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5e/19a3bbfb6240dc8e95085d7c9a63641ef02d2d32f2178800ffb067629768/pcodec-1.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d130684f7b89154e51a303055324fc88539979791c92ed42605aa347d8b4f9be", size = 586882, upload-time = "2026-05-10T00:54:27.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/815017115058f016b4fb6c70271f6be7e4e8ba3d4667a558a753d26b4c72/pcodec-1.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:693fa7cdb2787dd66bfcb7011a392d6f0a26e55759b888c0d027d902bf7a9c70", size = 605155, upload-time = "2026-05-10T00:54:19.638Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/76/de47459d814652157dc81f52891bfdc94225c46eec9513cfa2a5ca8b0195/pcodec-1.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:ad421f1eba506703ed5de0e927e41900c6a2bd445b3a0fab2a70839b429a7686", size = 475190, upload-time = "2026-05-10T00:54:52.395Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3215,18 +3367,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prettytable"
-version = "3.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -3417,6 +3557,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pybufrkit"
+version = "0.2.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bitstring" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/7b/6cf909e086a8791ad3f9544c46030737c19ec1b793953526941138d0c0c7/pybufrkit-0.2.25.tar.gz", hash = "sha256:78894c001d3e171d92f0d0bb827d5fb3d9a1c89c63551d95cd4f7fec2a2162da", size = 7305412, upload-time = "2025-03-28T11:06:27.633Z" }
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3438,6 +3588,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -3554,7 +3709,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -3930,12 +4085,12 @@ name = "requests-cache"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "cattrs" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "url-normalize" },
-    { name = "urllib3" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "cattrs", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "url-normalize", marker = "python_full_version >= '3.12'" },
+    { name = "urllib3", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/41/cca56fdb48cbca8feb68770bce70cb315de2a1f7d6bf7ca62c437ac279f0/requests_cache-1.3.1.tar.gz", hash = "sha256:784e9d07f72db4fe234830a065230c59eb446489528f271ba288c640897e47c4", size = 99416, upload-time = "2026-03-04T18:05:50.918Z" }
 wheels = [
@@ -4113,18 +4268,6 @@ wheels = [
 ]
 
 [[package]]
-name = "s3transfer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
-]
-
-[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4212,11 +4355,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]
@@ -4299,6 +4442,15 @@ wheels = [
 ]
 
 [[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4321,7 +4473,7 @@ wheels = [
 
 [[package]]
 name = "tensordict"
-version = "0.12.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
@@ -4333,22 +4485,22 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/26/d85eb80e479a3bcf82d6484cbce48bcd0aa837e4f84b807b8a851bcfb822/tensordict-0.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:445502185e473207ba28e64c3788f6199446eb5f98d55262e0709ff11f633ddd", size = 888325, upload-time = "2026-04-08T10:00:12.719Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6b/b7acf3dee5a0b18100441335a6108732c57eed4af6260983c508764267e1/tensordict-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ee52c5a7392427ec2721c9ac7ad7a8843dc81e6e79b675edff85f02511fb6f12", size = 531750, upload-time = "2026-04-08T10:00:14.025Z" },
-    { url = "https://files.pythonhosted.org/packages/09/81/d8e7871795c065fc8246efffc466df48f7453fdb7b5dc10eb2ba3e7fd5d7/tensordict-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8d179af738d5900617e8ab9b2b739a4a0c332774a00cce0231d7824279a265c8", size = 536233, upload-time = "2026-04-08T10:00:15.258Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c1/fe23b2ee7bba80b55ff409cb7a903f2972fdc7211356272d43f2f922ac4d/tensordict-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:d6e2d37349b762a5c5fff60bf34f110e5e3d108f3b9a29f1666a61cd773839b3", size = 584567, upload-time = "2026-04-08T10:00:16.472Z" },
-    { url = "https://files.pythonhosted.org/packages/92/7c/195efa2b04dd8f8078082e0a191675301873163c72ad03094295d59321af/tensordict-0.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:dadb0957892d7cf398488c1ea3e8fa0ee3a6a9430d75dc564f844dcc6a82fefb", size = 889200, upload-time = "2026-04-08T10:00:18.001Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/54/aa692442e77a57b58f086b4798ce6ab09a698e5388d20ca33e64346b8567/tensordict-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2dba370dca2255bc2006072e96f3c35284f4c98bdece8e3ec154e30d43b2d7f", size = 532556, upload-time = "2026-04-08T10:00:19.29Z" },
-    { url = "https://files.pythonhosted.org/packages/34/a5/3edf37b0f1859817110232101f58a2b3e320de4c31b5759f17e3d386fcde/tensordict-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2addbcfb815fd0d23d59db801e80a9903623a61419ee358d87acdc9a157a306d", size = 536608, upload-time = "2026-04-08T10:00:20.663Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/e544d3b5c29872e5614942865a7b0f6d6552fafbfd33e0037923e03b6f3b/tensordict-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:c2a3b89949e3561cc7639533a058a72cd7afe35ba2de1749c294f58cc33c9243", size = 585866, upload-time = "2026-04-08T10:00:22.224Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f7/f492efec11f4ee692300cf23c94b0db73e8e73167a5a39ead8fd5b295e9f/tensordict-0.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c31b527e960e268e6d3d2cdbe1bdf9a75c466a8d64ac4fb33933de1d62891288", size = 889217, upload-time = "2026-04-08T10:00:23.919Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d7/25c7c453d3fbc9b176c4c67cc3ffccc8a89d925bdf85b06d80f1805ce0df/tensordict-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:acc97c23833d6a129cf9301086301c1e84b7036806c94bbc121e42603b563de2", size = 532825, upload-time = "2026-04-08T10:00:25.319Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/f3/2d4d169b20016ab3d912d03e19965ab45b1592b4e99f860368da106a7704/tensordict-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f2356fb015f498c27482f0c378611319daa341ed4be9677c83fe6e0989850811", size = 536608, upload-time = "2026-04-08T10:00:26.968Z" },
-    { url = "https://files.pythonhosted.org/packages/06/65/0eb5849f3421b1773fba58e27c0d32ccd38f6f3b97fe6de3d881af8544c8/tensordict-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:37c4f0dd960fbbe48bd827dfe4d58ea545a2e4105b049c3d978d68f77bd0e2c3", size = 585842, upload-time = "2026-04-08T10:00:28.26Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/35/801edb039ed844c1a4fe7fefb39f4aa292663e4d6dc214669ee7ad187f95/tensordict-0.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9094368051e394cef8ae3b2a5bfbb394df796cd501fbcba7d9fb37cd18fc6e8e", size = 894632, upload-time = "2026-04-08T10:00:29.607Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/31/e5e9f3a086605df30cedc0e5686a357e4ee7e44bbf7fce0bf186881bf8d4/tensordict-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:10b301341760c8f7b83c95eb660d81a78932246a93561401cac64d54d33494f4", size = 534227, upload-time = "2026-04-08T10:00:31.252Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d3/686e8da8083afaf7e7bc4485a32e382af2208a7626e261bf16cdd90c1f2d/tensordict-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1a8fd337d35e49b8c8be1b37fd24ca499e431af6cf99a008266af443a4742f40", size = 537771, upload-time = "2026-04-08T10:00:32.582Z" },
-    { url = "https://files.pythonhosted.org/packages/df/99/a670ba93b7bb9dcaf92fa9dc83120cc5e91dba7324aaaa5cfd76a849268e/tensordict-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:59308208a515462e4228cdc7da8ca879ca4a55497f2310ba817394a60f52fb39", size = 596689, upload-time = "2026-04-08T10:00:34.162Z" },
+    { url = "https://files.pythonhosted.org/packages/54/81/76855a0371bd3b4b9e372685b1659d4310d64626b3bf9d5fd190937a5b3d/tensordict-0.11.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:872d907ba67a820b063b839a3830d580a803db05f7b6b4012d1a237b80156597", size = 815365, upload-time = "2026-01-26T11:36:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/43/87/bcc10f8ed12112e58597da74826c22133aa39d3c4668f225b5c430fbf467/tensordict-0.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9e359a2b107f375a9226dc2c71c891c3fdc48bb5f30e11c052655794e860e6ce", size = 460058, upload-time = "2026-01-26T11:36:02.455Z" },
+    { url = "https://files.pythonhosted.org/packages/70/85/a850ce6d61cca041baeaad6e3ae85d80f848b1559ef9102304a60fa7c3e0/tensordict-0.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:612d0fc1340bb42b9c207fa788dac950716470a7a9031f8b09fa9d4551cd1ab9", size = 463186, upload-time = "2026-01-26T11:36:04.129Z" },
+    { url = "https://files.pythonhosted.org/packages/37/00/2d5f488bcfb5c86c795a07f76a6a84dc724ff4e4489e5db1f44513fa7ddc/tensordict-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:2cdf014575e3961c54c156a7b01e50da55e59472ebc74246b55b447887c92d41", size = 509219, upload-time = "2026-01-26T11:36:05.8Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7c/6b47df6f8749e873d5bcd3260a78a8c5de0d92fff4aaf2739de29c6e7089/tensordict-0.11.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:683840259eb7d29836751bff48249c2ee36b7f1ccff50dcaed843d96915d768a", size = 815976, upload-time = "2026-01-26T11:36:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b5/af7e9e8f3540cc2e6123b035fe0b1541c0514fadeb31862e14a6bb424ebc/tensordict-0.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8125611fa8187a49840c1e07480644749a2bdf8520a882de68dfffac79b73a61", size = 461002, upload-time = "2026-01-26T11:36:09.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/48/9363e462522eef0117c852a30c4f09ea86bd2c81b8792118ae5d63289729/tensordict-0.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7236c533d9076e8368952849c7bb9bf76a012324e22a133acd617ff8283fe59f", size = 465538, upload-time = "2026-01-26T11:36:10.866Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fc/659137f50d77fe868614963f322bfb47a1cd7ff685b3a34f00ffcd78d04f/tensordict-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:d62f24c4dbf5e0eed1231beeb482e5b183d2fcb9c9e199828506f5eec5ad8a86", size = 510247, upload-time = "2026-01-26T11:36:12.118Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/8d/64b04f4c3ae77cd1330f697950b8ac9785f815be152805b126321f4c9483/tensordict-0.11.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:fa1f77fc63b37c19fe8e3e684d7d9dcd0e7d39beaa1d4dd09e6369aab4f47036", size = 815987, upload-time = "2026-01-26T11:36:13.277Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6f/4ef78fdd6d0d33c1cbc9b13e7f3079bf46f1c9e53a728e986c6f664be774/tensordict-0.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:526a1391f4a13ec82b781078a9190fc0626bfdeedaf30a32ba84264db76fd5fb", size = 460959, upload-time = "2026-01-26T11:36:14.439Z" },
+    { url = "https://files.pythonhosted.org/packages/96/62/6322a759fc4b62c2ded50b3330bcb1e541d86734b86603d3e4c4c1442b16/tensordict-0.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:525bff4b95539b63fdb45e82c166c7481d039df604007baab69fbcfcb1310ac4", size = 465438, upload-time = "2026-01-26T11:36:15.971Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d1/2d00adaa35a0a37f9c796709a739904ab1c032f721dcef736eb8bd72a999/tensordict-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:5a63f53f20aa90ea23cac69ca4daf8db97d12dd0c1b51b855424bc48e411914c", size = 510202, upload-time = "2026-01-26T11:36:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/26/20/014904cd5e5b851ea7b1c9a46b91a5c3a850fc6807b640d7a9a09c8714aa/tensordict-0.11.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0c925186aabb04aaa080a1b0160f48dad0911d3dc42bfb5dabdc9ed60518fbd7", size = 822881, upload-time = "2026-01-26T11:36:18.381Z" },
+    { url = "https://files.pythonhosted.org/packages/60/85/4e54d398a53520f624d291f8a498d389fbbdf740d3a6b018d67c50feef55/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b3d465f72ddc8fac2b1f031f873f38d073dcca897d1c8751fa4e95142d848f", size = 462403, upload-time = "2026-01-26T11:36:19.506Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ec/bfc5384cea17fecca6980ee9e6fe5b75e55bab09bfe1975795107d8491ff/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a0df47c227c81ce6a3d7a7960a0ca2a9ab832a3460e9a4a88a3c5b929903e4", size = 465141, upload-time = "2026-01-26T11:36:20.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/b84caf450e1cce55f9b3cd64c3f9d56b3d0cd9265ea728500605fd71a971/tensordict-0.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e963e114e8c03d9b2a93b41899af6598a27db1c5fa17c78aeb0cc16ab9e143c5", size = 520028, upload-time = "2026-01-26T11:36:21.904Z" },
 ]
 
 [[package]]
@@ -4358,6 +4510,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tibs"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/cd/6cf028decf1c2df4d26077dd5d0532587d93d4917233d5e004133166a940/tibs-0.5.7.tar.gz", hash = "sha256:173dfbecb2309edd9771f453580c88cf251e775613461566b23dbd756b3d54cb", size = 78255, upload-time = "2026-03-12T13:06:29.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/2d/de2c579d3eea0f18212b5b16decb04568b7a0ef912d00581a77492609d4e/tibs-0.5.7-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:859f05315ffb307d3474c505d694f3a547f00730a024c982f5f60316a5505b3c", size = 411352, upload-time = "2026-03-12T13:06:52.016Z" },
+    { url = "https://files.pythonhosted.org/packages/74/71/4c21ccc5c2e1672f9cd91ed2c46604c250cffd9d386113772dded128b5cf/tibs-0.5.7-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:a883ca13a922a66b2c1326a9c188123a574741a72510a4bf52fd6f97db191e44", size = 383971, upload-time = "2026-03-12T13:06:50.143Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/399940ac5393772792a209911a5efa42cf55cf621771e48b863211ac5a2a/tibs-0.5.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f70bd250769381c73110d6f24feaf8b6fcd44f680b3cb28a20ea06db3d04fb6f", size = 416256, upload-time = "2026-03-12T13:06:24.222Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/481a73e74d398949f57d297b1809a10a951d252e7ec94b6715ed952ce500/tibs-0.5.7-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:76746f01b3db9dbd802f5e615f11f68df7a29ecef521b082dca53f3fa7d0084f", size = 428003, upload-time = "2026-03-12T13:06:23.064Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e0/72db1760a7f7fec1d5f3690e0855fbbccbcf0a4a2fd318c9d71f3b33f3a7/tibs-0.5.7-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:847709c108800ad6a45efaf9a040628278956938a4897f7427a2587013dc3b98", size = 455589, upload-time = "2026-03-12T13:06:53.144Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/26/9cd3395914bf705d6ae1e9a6c323f727e9dc88fef716327ce7f486e0b55a/tibs-0.5.7-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad61df93b50f875b277ab736c5d37b6bce56f9abce489a22f4e02d9daa2966e3", size = 459266, upload-time = "2026-03-12T13:06:21.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3b/267f19a008d13c704dc0b044138a56239272a43531ccb05464129d0fbd01/tibs-0.5.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e13b9c7ff2604b0146772025e1ac6f85c8c625bf6ac73736ff671eaf357dda41", size = 423466, upload-time = "2026-03-12T13:06:41.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d4/424ae3515e0e013ad83186074bf3beb53399b9052c00da703415ccc316ca/tibs-0.5.7-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a7ce857ef05c59dc61abadc31c4b9b1e3c62f9e5fb29217988c308936aea71e", size = 452080, upload-time = "2026-03-12T13:06:32.112Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/15/ab80beba83a134745439d33763e1d3b017f994abeb9c309a3ac9fd94e90e/tibs-0.5.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1d5521cc6768bfa6282a0c591ba06b079ab91b5c7d5696925ad2abac59779a54", size = 592311, upload-time = "2026-03-12T13:06:47.807Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/21/f5cf41c15431e63aeaefb494e714d48d9e9061b4e01fcc01d1987e2e5faa/tibs-0.5.7-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:477608f9b87e24a22ab6d50b81da04a5cb59bfa49598ff7ec5165035a18fb392", size = 703400, upload-time = "2026-03-12T13:06:16.968Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ec/b3bdb7dcc3de8513c5678a685f4e25bb85ef48526d7d535ddc592f9e8602/tibs-0.5.7-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:ac0aa2aae38f7325c91c261ce1d18f769c4c7033c98d6ea3ea5534585cf16452", size = 664623, upload-time = "2026-03-12T13:06:48.894Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/71/7b85af3ad1b2cd9871c8f50ba0eb17e54e12481b467678535e58aced0d98/tibs-0.5.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b56583db148e5094d781c3d746815dbcbb6378c6f813c8ce291efd4ab21da8b", size = 635199, upload-time = "2026-03-12T13:06:34.798Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/63/60220fb502beb857306afd4a5bac4a8617ae496f3b1f4968d127380fdefe/tibs-0.5.7-cp38-abi3-win32.whl", hash = "sha256:d4f3ff613d486650816bc5516760c0382a2cc0ca8aeddd8914d011bc3b81d9a2", size = 288454, upload-time = "2026-03-12T13:06:30.978Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ab/aab78827ba7e0d65fe346b86d1d61e0792c38d5f9b7547e0f71b7027c835/tibs-0.5.7-cp38-abi3-win_amd64.whl", hash = "sha256:a61d36155f8ab8642e1b6744e13822f72050fc7ec4f86ec6965295afa04949e2", size = 304135, upload-time = "2026-03-12T13:06:35.884Z" },
+    { url = "https://files.pythonhosted.org/packages/48/59/e9e6a610928a4bcbf04f0ac1436ee320aa8cbe95181f1aa32687c50e858b/tibs-0.5.7-cp38-abi3-win_arm64.whl", hash = "sha256:130bc68ff500fc8185677df7a97350b5d5339e6ba7e325bc3031337f6424ede7", size = 289272, upload-time = "2026-03-12T13:06:19.247Z" },
 ]
 
 [[package]]
@@ -4423,58 +4598,41 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
-    { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d8/15b9d9d3a6b0c01b883787bd056acbe5cc321090d4b216d3ea89a8fcfdf3/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:b7bd80f3477b830dd166c707c5b0b82a898e7b16f59a7d9d42778dd058272e8b", size = 79423461, upload-time = "2026-01-21T16:24:50.266Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/acea680005f098f79fd70c1d9d5ccc0cb4296ec2af539a0450108232fc0c/torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6", size = 419718178, upload-time = "2026-03-23T18:10:46.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8b/d7be22fbec9ffee6cff31a39f8750d4b3a65d349a286cf4aec74c2375662/torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a", size = 530604548, upload-time = "2026-03-23T18:10:03.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/9912d30b68845256aabbb4a40aeefeef3c3b20db5211ccda653544ada4b6/torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708", size = 114519675, upload-time = "2026-03-23T18:11:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
 ]
 
 [[package]]
@@ -4488,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "torchvision"
-version = "0.25.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -4496,22 +4654,22 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/be/c704bceaf11c4f6b19d64337a34a877fcdfe3bd68160a8c9ae9bea4a35a3/torchvision-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db74a551946b75d19f9996c419a799ffdf6a223ecf17c656f90da011f1d75b20", size = 1874923, upload-time = "2026-01-21T16:27:46.574Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/f143cd71232430de1f547ceab840f68c55e127d72558b1061a71d0b193cd/torchvision-0.25.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f49964f96644dbac2506dffe1a0a7ec0f2bf8cf7a588c3319fed26e6329ffdf3", size = 2344808, upload-time = "2026-01-21T16:27:43.191Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ae/ad5d6165797de234c9658752acb4fce65b78a6a18d82efdf8367c940d8da/torchvision-0.25.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:153c0d2cbc34b7cf2da19d73450f24ba36d2b75ec9211b9962b5022fb9e4ecee", size = 8070752, upload-time = "2026-01-21T16:27:33.748Z" },
-    { url = "https://files.pythonhosted.org/packages/23/19/55b28aecdc7f38df57b8eb55eb0b14a62b470ed8efeb22cdc74224df1d6a/torchvision-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:ea580ffd6094cc01914ad32f8c8118174f18974629af905cea08cb6d5d48c7b7", size = 4038722, upload-time = "2026-01-21T16:27:41.355Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f8/c0e1ef27c66e15406fece94930e7d6feee4cb6374bbc02d945a630d6426e/torchvision-0.25.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b75deafa2dfea3e2c2a525559b04783515e3463f6e830cb71de0fb7ea36fe233", size = 2344556, upload-time = "2026-01-21T16:27:40.125Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2f/f24b039169db474e8688f649377de082a965fbf85daf4e46c44412f1d15a/torchvision-0.25.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f25aa9e380865b11ea6e9d99d84df86b9cc959f1a007cd966fc6f1ab2ed0e248", size = 8072351, upload-time = "2026-01-21T16:27:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5b/1562a04a6a5a4cf8cf40016a0cdeda91ede75d6962cff7f809a85ae966a5/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:24e11199e4d84ba9c5ee7825ebdf1cd37ce8deec225117f10243cae984ced3ec", size = 1874918, upload-time = "2026-01-21T16:27:39.02Z" },
-    { url = "https://files.pythonhosted.org/packages/36/b1/3d6c42f62c272ce34fcce609bb8939bdf873dab5f1b798fd4e880255f129/torchvision-0.25.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5f271136d2d2c0b7a24c5671795c6e4fd8da4e0ea98aeb1041f62bc04c4370ef", size = 2309106, upload-time = "2026-01-21T16:27:30.624Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/60/59bb9c8b67cce356daeed4cb96a717caa4f69c9822f72e223a0eae7a9bd9/torchvision-0.25.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:855c0dc6d37f462482da7531c6788518baedca1e0847f3df42a911713acdfe52", size = 8071522, upload-time = "2026-01-21T16:27:29.392Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a5/9a9b1de0720f884ea50dbf9acb22cbe5312e51d7b8c4ac6ba9b51efd9bba/torchvision-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:cef0196be31be421f6f462d1e9da1101be7332d91984caa6f8022e6c78a5877f", size = 4321911, upload-time = "2026-01-21T16:27:35.195Z" },
-    { url = "https://files.pythonhosted.org/packages/52/99/dca81ed21ebaeff2b67cc9f815a20fdaa418b69f5f9ea4c6ed71721470db/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a8f8061284395ce31bcd460f2169013382ccf411148ceb2ee38e718e9860f5a7", size = 1896209, upload-time = "2026-01-21T16:27:32.159Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cc/2103149761fdb4eaed58a53e8437b2d716d48f05174fab1d9fcf1e2a2244/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:146d02c9876858420adf41f3189fe90e3d6a409cbfa65454c09f25fb33bf7266", size = 2310735, upload-time = "2026-01-21T16:27:22.327Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ad/f4c985ad52ddd3b22711c588501be1b330adaeaf6850317f66751711b78c/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c4d395cb2c4a2712f6eb93a34476cdf7aae74bb6ea2ea1917f858e96344b00aa", size = 8089557, upload-time = "2026-01-21T16:27:27.666Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cc/0ea68b5802e5e3c31f44b307e74947bad5a38cc655231d845534ed50ddb8/torchvision-0.25.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5e6b449e9fa7d642142c0e27c41e5a43b508d57ed8e79b7c0a0c28652da8678c", size = 4344260, upload-time = "2026-01-21T16:27:17.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bd/d552a2521bade3295b2c6e7a4a0d1022261cab7ca7011f4e2a330dbb3caa/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", size = 1863499, upload-time = "2026-03-23T18:12:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/33/bf/21b899792b08cae7a298551c68398a79e333697479ed311b3b067aab4bdc/torchvision-0.26.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1c55dc8affbcc0eb2060fbabbe996ae9e5839b24bb6419777f17848945a411b1", size = 7767527, upload-time = "2026-03-23T18:12:44.348Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/45/57bbf9e216850d065e66dd31a50f57424b607f1d878ab8956e56a1f4e36b/torchvision-0.26.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10b5f994c210f4f6d6761cf686f82d748554adf486cb0979770c3252868c8f", size = 7519925, upload-time = "2026-03-23T18:12:53.283Z" },
+    { url = "https://files.pythonhosted.org/packages/10/58/ed8f7754299f3e91d6414b6dc09f62b3fa7c6e5d63dfe48d69ab81498a37/torchvision-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:de6424b12887ad884f39a0ee446994ae3cd3b6a00a9cafe1bead85a031132af0", size = 3983834, upload-time = "2026-03-23T18:13:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/0762f77f53605d10c9477be39bb47722cc8e383bbbc2531471ce0e396c07/torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4", size = 1860809, upload-time = "2026-03-23T18:12:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/81/0b3e58d1478c660a5af4268713486b2df7203f35abd9195fea87348a5178/torchvision-0.26.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a39c7a26538c41fda453f9a9692b5ff9b35a5437db1d94f3027f6f509c160eac", size = 7727494, upload-time = "2026-03-23T18:12:46.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/d9ab5d29115aa05e12e30f1397a3eeae1d88a511241dc3bce48dc4342675/torchvision-0.26.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7e6213620bbf97742e5f79832f9e9d769e6cf0f744c5b53dad80b76db633691", size = 7521747, upload-time = "2026-03-23T18:12:36.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
+    { url = "https://files.pythonhosted.org/packages/66/28/b4ad0a723ed95b003454caffcc41894b34bd8379df340848cae2c33871de/torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23", size = 1951973, upload-time = "2026-03-23T18:12:48.781Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/7a89096e6cf2f3336353b5338ba925e0addf9d8601920340e6bdf47e8eb3/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:3daf9cc149cf3cdcbd4df9c59dae69ffca86c6823250442c3bbfd63fc2e26c61", size = 7728679, upload-time = "2026-03-23T18:12:26.196Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1d/4e1eebc17d18ce080a11dcf3df3f8f717f0efdfa00983f06e8ba79259f61/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:82c3965eca27e86a316e31e4c3e5a16d353e0bcbe0ef8efa2e66502c54493c4b", size = 7609138, upload-time = "2026-03-23T18:12:35.327Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
 ]
 
 [[package]]
@@ -4560,9 +4718,13 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
 ]
 
@@ -4616,7 +4778,7 @@ name = "url-normalize"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
+    { name = "idna", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/31/febb777441e5fcdaacb4522316bf2a527c44551430a4873b052d545e3279/url_normalize-2.2.1.tar.gz", hash = "sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37", size = 18846, upload-time = "2025-04-26T20:37:58.553Z" }
 wheels = [
@@ -4625,11 +4787,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -4672,37 +4834,16 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.1"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/1d/2193d186fc5f9766d8db17b64fad55b97405f1e35f9190623d8d95971519/warp_lang-1.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98df3533a6c40a33cce961f8efa991006b30c9d286356e4cd77ea8ce86928f1d", size = 24102436, upload-time = "2026-04-06T06:13:06.799Z" },
-    { url = "https://files.pythonhosted.org/packages/52/79/c30d6f57c98cc5bb850eb0bd0fce2405abb79a368ed5ef65ebb2b0c58dc0/warp_lang-1.12.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6bf01f10509488ba8eacaf4ec7fcf7cfbd503118b22e002ecba407b40a17424e", size = 136413384, upload-time = "2026-04-06T06:13:37.735Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/75/1af98a828a2b132a7a14515cdb050876c403349c7761730584f9f0a637a5/warp_lang-1.12.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:af6d680e79c1be6e46ddf80ecaa358f222804f882f4683260a7b4abd80a0981b", size = 137676174, upload-time = "2026-04-06T06:14:12.232Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/cd/efe4f259b707368f396a70b6567d0bf270e56db03d2142c0142d52acb656/warp_lang-1.12.1-py3-none-win_amd64.whl", hash = "sha256:826b2f93df8e47eac0c751a8eb5a0533e2fc5434158c8896a63be53bfbd728c7", size = 119729529, upload-time = "2026-04-06T06:14:38.181Z" },
-]
-
-[[package]]
-name = "wcmatch"
-version = "10.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bracex" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a2/712bcea055b80135e20a7a142f5dc1fa617bf3b5557dd4cc3afcc1048ab4/warp_lang-1.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ee06e2e76bff84088a09e64315e71ed0e55e94c936ec664d7b05ebd56f66a363", size = 25048790, upload-time = "2026-07-07T22:26:18.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ba/36023c3161c45f1c509c20c501b17980705fdd3b6c20b7ee9267f50f44a2/warp_lang-1.15.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:95c169f28bd7d6c78ac4ad62e2df1e61a096033748f757157fa4551aed80d010", size = 166711381, upload-time = "2026-07-07T22:26:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/2c06013209ad4edb1f9e52692d43738b4945fceaa6acc30f34e2d25fc087/warp_lang-1.15.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3c0711b39ad98ff924d29654b028ec4eaa02330e207ae3efc72445e9cde05b34", size = 171756145, upload-time = "2026-07-07T22:28:07.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/00/4de2563f88c882e6621349654cee770ce5ae86c8113b63c09bd8aa3e5274/warp_lang-1.15.0-py3-none-win_amd64.whl", hash = "sha256:06ef42c3ce522749268056653ea253645eb4a96ca164af74ae5113f0d55a6970", size = 149948459, upload-time = "2026-07-07T22:28:32.767Z" },
 ]
 
 [[package]]
@@ -4784,38 +4925,6 @@ wheels = [
 [package.optional-dependencies]
 parallel = [
     { name = "dask", extra = ["complete"] },
-]
-
-[[package]]
-name = "xattr"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/d5/25f7b19af3a2cb4000cac4f9e5525a40bec79f4f5d0ac9b517c0544586a0/xattr-1.3.0.tar.gz", hash = "sha256:30439fabd7de0787b27e9a6e1d569c5959854cb322f64ce7380fedbfa5035036", size = 17148, upload-time = "2025-10-13T22:16:47.353Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/64/292426ad5653e72c6e1325bbff22868a20077290d967cebb9c0624ad08b6/xattr-1.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:331a51bf8f20c27822f44054b0d760588462d3ed472d5e52ba135cf0bea510e8", size = 23448, upload-time = "2025-10-13T22:15:59.229Z" },
-    { url = "https://files.pythonhosted.org/packages/63/84/6539fbe620da8e5927406e76b9c8abad8953025d5f578d792747c38a8c0e/xattr-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:196360f068b74fa0132a8c6001ce1333f095364b8f43b6fd8cdaf2f18741ef89", size = 18553, upload-time = "2025-10-13T22:16:00.151Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/bb/c1c2e24a49f8d13ff878fb85aabc42ea1b2f98ce08d8205b9661d517a9cc/xattr-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:405d2e4911d37f2b9400fa501acd920fe0c97fe2b2ec252cb23df4b59c000811", size = 18848, upload-time = "2025-10-13T22:16:01.046Z" },
-    { url = "https://files.pythonhosted.org/packages/02/c2/a60aad150322b217dfe33695d8d9f32bc01e8f300641b6ba4b73f4b3c03f/xattr-1.3.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ae3a66ae1effd40994f64defeeaa97da369406485e60bfb421f2d781be3b75d", size = 38547, upload-time = "2025-10-13T22:16:01.973Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/58/2eca142bad4ea0a2be6b58d3122d0acce310c4e53fa7defd168202772178/xattr-1.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:69cd3bfe779f7ba87abe6473fdfa428460cf9e78aeb7e390cfd737b784edf1b5", size = 38753, upload-time = "2025-10-13T22:16:03.244Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/50/d032e5254c2c27d36bdb02abdf2735db6768a441f0e3d0f139e0f9f56638/xattr-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c5742ca61761a99ae0c522f90a39d5fb8139280f27b254e3128482296d1df2db", size = 38054, upload-time = "2025-10-13T22:16:04.656Z" },
-    { url = "https://files.pythonhosted.org/packages/04/24/458a306439aabe0083ca0a7b14c3e6a800ab9782b5ec0bdcec4ec9f3dc6c/xattr-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4a04ada131e9bdfd32db3ab1efa9f852646f4f7c9d6fde0596c3825c67161be3", size = 37562, upload-time = "2025-10-13T22:16:05.97Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/78/00bdc9290066173e53e1e734d8d8e1a84a6faa9c66aee9df81e4d9aeec1c/xattr-1.3.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dd4e63614722d183e81842cb237fd1cc978d43384166f9fe22368bfcb187ebe5", size = 23476, upload-time = "2025-10-13T22:16:06.942Z" },
-    { url = "https://files.pythonhosted.org/packages/53/16/5243722294eb982514fa7b6b87a29dfb7b29b8e5e1486500c5babaf6e4b3/xattr-1.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:995843ef374af73e3370b0c107319611f3cdcdb6d151d629449efecad36be4c4", size = 18556, upload-time = "2025-10-13T22:16:08.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5c/d7ab0e547bea885b55f097206459bd612cefb652c5fc1f747130cbc0d42c/xattr-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fa23a25220e29d956cedf75746e3df6cc824cc1553326d6516479967c540e386", size = 18869, upload-time = "2025-10-13T22:16:10.319Z" },
-    { url = "https://files.pythonhosted.org/packages/98/25/25cc7d64f07de644b7e9057842227adf61017e5bcfe59a79df79f768874c/xattr-1.3.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b4345387087fffcd28f709eb45aae113d911e1a1f4f0f70d46b43ba81e69ccdd", size = 38797, upload-time = "2025-10-13T22:16:11.624Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/24/cc350bcdbed006dfcc6ade0ac817693b8b3d4b2787f20e427fd0697042e4/xattr-1.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe92bb05eb849ab468fe13e942be0f8d7123f15d074f3aba5223fad0c4b484de", size = 38956, upload-time = "2025-10-13T22:16:13.121Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/b2/9416317ac89e2ed759a861857cda0d5e284c3691e6f460d36cc2bd5ce4d1/xattr-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6c42ef5bdac3febbe28d3db14d3a8a159d84ba5daca2b13deae6f9f1fc0d4092", size = 38214, upload-time = "2025-10-13T22:16:14.389Z" },
-    { url = "https://files.pythonhosted.org/packages/38/63/188f7cb41ab35d795558325d5cc8ab552171d5498cfb178fd14409651e18/xattr-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2aaa5d66af6523332189108f34e966ca120ff816dfa077ca34b31e6263f8a236", size = 37754, upload-time = "2025-10-13T22:16:15.306Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d3/6a1731a339842afcbb2643bc93628d4ab9c52d1bf26a7b085ca8f35bba6e/xattr-1.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:937d8c91f6f372788aff8cc0984c4be3f0928584839aaa15ff1c95d64562071c", size = 23474, upload-time = "2025-10-13T22:16:16.33Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/25/6741ed3d4371eaa2fae70b259d17a580d858ebff8af0042a59e11bb6385f/xattr-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e470b3f15e9c3e263662506ff26e73b3027e1c9beac2cbe9ab89cad9c70c0495", size = 18558, upload-time = "2025-10-13T22:16:17.251Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/84/cc450688abeb8647aa93a62c1435bb532db11313abfeb9d43b28b4751503/xattr-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f2238b2a973fcbf5fefa1137db97c296d27f4721f7b7243a1fac51514565e9ec", size = 18869, upload-time = "2025-10-13T22:16:18.607Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/49/0e2315225ba7557e9801f9f0168a0195a7e13a3223088081eb32d2760533/xattr-1.3.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f32bb00395371f4a3bed87080ae315b19171ba114e8a5aa403a2c8508998ce78", size = 38702, upload-time = "2025-10-13T22:16:19.539Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/8c/de4f4441c318ac38a5d3d7d4b8b940305a667e9320c34a45e57f6eb6b0e8/xattr-1.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:78df56bfe3dd4912548561ed880225437d6d49ef082fe6ccd45670810fa53cfe", size = 38869, upload-time = "2025-10-13T22:16:20.554Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/2a/38e0498c22aa733a9b5265f4929af4613e5b967659cf3e5f2f933b3ba118/xattr-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:864c34c14728f21c3ef89a9f276d75ae5e31dd34f48064e0d37e4bf0f671fc6e", size = 38210, upload-time = "2025-10-13T22:16:22.212Z" },
-    { url = "https://files.pythonhosted.org/packages/62/21/49b386eb8dcf42ac8e3ff55b6e8ea0a1e8b6b799571599c795265d2dc1b5/xattr-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1fd185b3f01121bd172c98b943f9341ca3b9ea6c6d3eb7fe7074723614d959ff", size = 37753, upload-time = "2025-10-13T22:16:23.959Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Update eval recipe for StormScope 3km_10min (GLM) default models

Updates the `eval` recipe to run the new default StormScope checkpoints
(`3km_10min`), which are pure-obs for GOES and add a gridded GLM lightning
state channel (`glm_density`) to the MRMS model. GLM is predownloaded and
regridded so inference stays cheap.

### StormScope / GLM support
- **`src/regrid.py`**: new `BilinearRegridder` (wraps `LatLonInterpolation`),
  the smooth-field counterpart to `NearestNeighborRegridder`. Used for the
  sparse GLM count field so predownloaded values match the model's internal
  `build_glm_interpolator` exactly.
- **`src/grids.py`**: new `glm_grid` resolver returning `GOESGLMGrid`'s 0.1°
  lat/lon.
- **`src/pipelines/stormscope.py`**:
  - Predownload now writes a third store `data_glm.zarr` (bilinear-regridded
    `glm_density`, over the IC window + all forecast valid times → also serves
    as GLM verification); `data_mrms.zarr` drops to radar-only vars.
  - MRMS IC is reassembled from `data_mrms.zarr` + `data_glm.zarr` via
    `CompositeSource` (predownloaded path), with a live fallback that wraps
    radar (nearest) and GLM (bilinear) onto the model grid.
  - Fixed ambiguous truth-test on the empty `conditioning_variables` numpy
    array (pure-obs GOES).

### Config / deps
- **`cfg/model/stormscope_goes_mrms.yaml`**: retargeted to `3km_10min` (GOES
  pure-obs, MRMS + `glm_data_source`/`glm_grid`); set `amp: true` +
  `compile: true` — `compile` is required at this domain size (NATTEN flex
  attention builds a sparse block mask under `torch.compile`; the eager path
  materializes a dense `[B,H,Q,KV]` mask and OOMs).
- **`cfg/campaign/stormscope_2023_convection.yaml`**: 10-min stride, full ABI
  set + `refc_base` + `glm_density` in outputs/scoring/report.
- **`pyproject.toml`** / **`uv.lock`**: add the `stormscope` earth2studio extra.

### Pipeline robustness (shared)
- Guard all `DistributedManager().rank` reads on `is_initialized()` and stop
  force-calling `DistributedManager.initialize()` in `run()`/`run_item()`
  (`base.py`, `forecast.py`, `dlesym.py`, `stormscope.py`, `scoring.py`).
  Rank only gates tqdm; defaults to 0 when uninitialized. Fixes CPU/unit-test
  failures where `init_process_group` requires an indexed accelerator.
- **`src/pipelines/dlesym.py`**: relaxed the strict `isinstance(..., DLESyM)`
  check in `_mask_invalid_ocean` to a capability check
  (`hasattr(..., "retrieve_valid_ocean_outputs")`).

### Docs / tests
- **`README.md`**: rewrote the StormScope sections (three stores, bilinear GLM
  regrid, `3km_10min` default, pure-obs GOES → no `cond_goes.zarr`).
- **`test/test_regrid.py`**: `BilinearRegridder` coverage (identity, 1D-vector
  promotion, zero-fill, dim validation, DataArray round-trip).
- **`test/test_stormscope.py`**: `_build_glm_store` and `_resolve_mrms_ic_source`
  (composite vs single-source) tests.

### Notes for reviewers
- The `DistributedManager` guards and the DLESyM duck-type change touch shared
  pipeline code (all pipelines), not just StormScope. All recipe test are passing
- Known unrelated noise: MRMS/GOESGLM emit benign "Unclosed client session"
  aiohttp warnings during predownload — an s3fs/aiobotocore cleanup quirk to be
  resolved by the ongoing obstore migration, not addressed here.


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
