### PR TITLE
Fix ISD schema: source type uint16 → string, enforce float32 dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Changed ISD schema `source` type to string since the field is alphanumeric. Enforced
+  `float32` dtypes for `lat`, `lon`, `elev`, and `observation`.
 - Fixed NNJA observation sources blocking the shared fsspec IO loop with
   CPU-bound PrepBUFR decode work, which stalled concurrent fetches from other
   data sources.

--- a/earth2studio/data/isd.py
+++ b/earth2studio/data/isd.py
@@ -116,18 +116,14 @@ class ISD:
             pa.field(
                 "type",
                 pa.string(),
-                nullable=True,
                 metadata={"isd_name": "REPORT_TYPE"},
             ),
             pa.field(
                 "source",
                 pa.string(),
-                nullable=True,
                 metadata={"isd_name": "SOURCE"},
             ),
-            pa.field(
-                "elev", pa.float32(), nullable=True, metadata={"isd_name": "ELEVATION"}
-            ),
+            pa.field("elev", pa.float32(), metadata={"isd_name": "ELEVATION"}),
             pa.field("station", pa.string(), metadata={"isd_name": "STATION"}),
             pa.field("observation", pa.float32()),
             pa.field("variable", pa.string()),

--- a/earth2studio/data/isd.py
+++ b/earth2studio/data/isd.py
@@ -121,7 +121,7 @@ class ISD:
             ),
             pa.field(
                 "source",
-                pa.uint16(),
+                pa.string(),
                 nullable=True,
                 metadata={"isd_name": "SOURCE"},
             ),
@@ -282,6 +282,7 @@ class ISD:
         if not df.empty:
             df = df.rename(columns=self.column_map())
             df["station"] = df["station"].astype(str)
+            df["source"] = df["source"].astype(str)
             # Normalize longitude from [-180, 180) to [0, 360)
             if "lon" in df.columns:
                 df["lon"] = pd.to_numeric(df["lon"], errors="coerce")
@@ -334,7 +335,13 @@ class ISD:
             value_name="observation",
         )
         df_long = df_long.dropna(subset=["observation"]).reset_index(drop=True)
-        return df_long[[name for name in schema.names]]
+        df_long = df_long[[name for name in schema.names]]
+        for field in schema:
+            if field.name in df_long.columns and pa.types.is_floating(field.type):
+                df_long[field.name] = df_long[field.name].astype(
+                    field.type.to_pandas_dtype()
+                )
+        return df_long
 
     async def _fetch_station_year(self, station_id: str, year: int) -> pd.DataFrame:
         """Async method for fetching csv to given station


### PR DESCRIPTION
## Summary

- **`source` type corrected:** `SCHEMA` declared `source` as `pa.uint16()`, but the NOAA ISD `SOURCE` field is alphanumeric — values like `'I'` (manual ASOS/AWOS), `'6'`, etc. occur in practice. `pa.uint16()` is factually wrong; changed to `pa.string()`. An explicit `.astype(str)` cast is added alongside the existing `station` cast so that stations whose year-file happens to contain only numeric `SOURCE` values (which `pd.read_csv` would infer as `int64`) are also normalised to `str`.

- **Float dtypes enforced:** `pd.read_csv` defaults all numeric columns to `float64`. `lat`, `lon`, `elev`, and `observation` are declared `pa.float32()` in `SCHEMA` but were silently returned as `float64`. Added the same field-level cast loop already used in `GHCNHourly._create_observation_dataframe`:
  ```python
  for field in schema:
      if field.name in df_long.columns and pa.types.is_floating(field.type):
          df_long[field.name] = df_long[field.name].astype(field.type.to_pandas_dtype())
  ```

## Alternative considered

An alternative is a full PyArrow round-trip:
```python
pa.Table.from_pandas(df_long, schema=schema, safe=False).to_pandas()
```
This enforces all field types in one call, but it re-encodes every column — including `string` and `timestamp` fields that are already correctly represented as pandas `object`/`datetime64[ns]` — for no benefit. The targeted float-cast loop is consistent with `GHCNHourly`, cheaper, and makes the intent explicit.

## Reproduction script

```python
import datetime
import numpy as np
from earth2studio.data import ISD

ds = ISD(stations=["99999903054", "72211253982"], time_tolerance=np.timedelta64(10, "m"))
df = ds([datetime.datetime(2025, 4, 3, 19, 0, 0)], ["u10m"])
print(df)
print(df.dtypes)
```

Before this fix, `source` dtype was `object` but contained `int64` values for pure-numeric stations, and `lat`/`lon`/`elev`/`observation` were `float64`. After:
```
time           datetime64[ns]
lat                   float32
lon                   float32
type                   object
source                 object   # str values: 'I', '6', ...
elev                  float32
station                object
observation           float32
variable               object
```