### PR TITLE
Add support for OPERA undetect fill values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zarr-reading data sources (`ARCO`, `WB2ERA5` and other WeatherBench 2 sources, and
   the `rx` prescriptive sources) now read via `obstore`-backed zarr stores instead of
   fsspec
+- Updated the OPERA data source to represent undetect values as `-99.0`, while
+  retaining `NaN` for no-data values.
 
 ### Deprecated
 

--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -191,6 +191,9 @@ class OPERA:
     region:eu dataclass:observation product:precip product:radar
     """
 
+    # MRMS refc stores no-echo as -99 dBZ; fill OPERA no-detection as -99.0 to match.
+    _NO_DETECTION_FILL: float = -99.0
+
     # Class-level lat/lon grid cache keyed by (ysize, xsize).
     _grid_cache: dict[tuple[int, int], tuple[np.ndarray, np.ndarray]] = {}
 
@@ -231,9 +234,11 @@ class OPERA:
             key=_key,
         )
 
-    @staticmethod
-    def _apply_linear_scaling(raw: np.ndarray, what: dict[str, Any]) -> np.ndarray:
-        """Apply ODIM gain/offset scaling and replace nodata/undetect with NaN."""
+    @classmethod
+    def _apply_linear_scaling(
+        cls, raw: np.ndarray, what: dict[str, Any]
+    ) -> np.ndarray:
+        """Apply ODIM gain/offset scaling; nodata→NaN, undetect→NO_DETECTION_FILL."""
         gain = float(what.get("gain", 1.0))
         offset = float(what.get("offset", 0.0))
         nodata = what.get("nodata")
@@ -242,7 +247,7 @@ class OPERA:
         if nodata is not None:
             result[raw == nodata] = np.nan
         if undetect is not None:
-            result[raw == undetect] = np.nan
+            result[raw == undetect] = cls._NO_DETECTION_FILL
         return result
 
     @staticmethod

--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -158,6 +158,9 @@ class OPERA:
     pixel resolutions, a :exc:`ValueError` is raised — request each resolution
     group separately.
 
+    OPERA undetect values (active radar echo but no detectable precipitation) are
+    set to -99.0 dbZ, and nodata values are set to NaN (no active radar echo).
+    All other values are scaled by the gain and offset parameters in the ODIM HDF5 file.
 
     Parameters
     ----------
@@ -236,7 +239,7 @@ class OPERA:
 
     @classmethod
     def _apply_linear_scaling(cls, raw: np.ndarray, what: dict[str, Any]) -> np.ndarray:
-        """Apply ODIM gain/offset scaling; nodata→NaN, undetect→NO_DETECTION_FILL."""
+        """Apply ODIM gain/offset scaling; replace nodata with NaN and undetect with NO_DETECTION_FILL."""
         gain = float(what.get("gain", 1.0))
         offset = float(what.get("offset", 0.0))
         nodata = what.get("nodata")

--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -235,9 +235,7 @@ class OPERA:
         )
 
     @classmethod
-    def _apply_linear_scaling(
-        cls, raw: np.ndarray, what: dict[str, Any]
-    ) -> np.ndarray:
+    def _apply_linear_scaling(cls, raw: np.ndarray, what: dict[str, Any]) -> np.ndarray:
         """Apply ODIM gain/offset scaling; nodata→NaN, undetect→NO_DETECTION_FILL."""
         gain = float(what.get("gain", 1.0))
         offset = float(what.get("offset", 0.0))

--- a/test/data/test_opera.py
+++ b/test/data/test_opera.py
@@ -119,6 +119,29 @@ def test_opera_cache(cache, tmp_path, monkeypatch):
 
 
 # ==========================================================================
+# 2b. Linear scaling / undetect fill
+# ==========================================================================
+
+
+@pytest.mark.timeout(5)
+def test_opera_apply_linear_scaling_undetect_fill():
+    raw = np.array([0, 1, 2, 3], dtype=np.uint8)
+    what = {
+        "gain": 0.5,
+        "offset": -32.0,
+        "nodata": 0,
+        "undetect": 2,
+    }
+    scaled = OPERA._apply_linear_scaling(raw, what)
+    assert scaled.dtype == np.float32
+    np.testing.assert_allclose(scaled[0], np.nan)
+    np.testing.assert_allclose(scaled[1], -31.5)
+    np.testing.assert_allclose(scaled[2], OPERA._NO_DETECTION_FILL)
+    np.testing.assert_allclose(scaled[3], -30.5)
+    assert OPERA._NO_DETECTION_FILL == -99.0
+
+
+# ==========================================================================
 # 3. Mock tests — no network, ODYSSEY era grid
 # ==========================================================================
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

This PR updates the OPERA dataloader to properly handle `undetect` fill values during ingestion. Previously, these values were replaced with `np.nan`. This change instead replaces them with -99.0, allowing them to remain distinguishable from `nodata` values, which continue to be represented by `np.nan`.

This PR also adds a test to verify that `undetect` and `nodata` values are filled as expected.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies
NA
