### PR TITLE
Add InterpCRPSDiT for CRPS temporal interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   number of pending tasks (capped at 64)
 - Added shared obstore byte-range helpers (`obstore_store_from_url`,
   `obstore_read_range`, `obstore_fetch_to_cache`) in `earth2studio.data.utils`
+- Added `DataReplay`, a prognostic adapter that steps any `DataSource` through the
+  prognostic-iterator interface, yielding the source's own reanalysis/analysis frames
+  instead of a forecast rollout -- e.g. supplying the coarse input to a temporal
+  interpolator, providing a reference trajectory to score forecasts against, or
+  sub-sampling a finer source in time.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   number of pending tasks (capped at 64)
 - Added shared obstore byte-range helpers (`obstore_store_from_url`,
   `obstore_read_range`, `obstore_fetch_to_cache`) in `earth2studio.data.utils`
+- Added `InterpCRPSDiT`, a one-shot endpoint-pinned CRPS temporal-interpolation model
+  (DiT backbone) that upsamples a base model's coarse trajectory to finer sub-steps (down to sub-hourly),
+  with optional regional sub-domain inference via `set_domain`.
 - Added `DataReplay`, a prognostic adapter that steps any `DataSource` through the
   prognostic-iterator interface, yielding the source's own reanalysis/analysis frames
   instead of a forecast rollout -- e.g. supplying the coarse input to a temporal

--- a/docs/modules/models_px.rst
+++ b/docs/modules/models_px.rst
@@ -55,6 +55,7 @@ Thus are typically used to generate forecast predictions.
       GenCastMini
       GraphCastOperational
       GraphCastSmall
+      InterpCRPSDiT
       InterpModAFNO
       Pangu24
       Pangu6

--- a/docs/modules/models_px.rst
+++ b/docs/modules/models_px.rst
@@ -41,6 +41,7 @@ Thus are typically used to generate forecast predictions.
       Atlas
       Aurora
       CBottleVideo
+      DataReplay
       DiagnosticWrapper
       DLESyM
       DLESyMLatLon

--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -519,6 +519,26 @@ uv add earth2studio --extra interp-modafno
 :::
 ::::
 :::::
+:::::{tab-item} InterpCRPSDiT
+Notes: Requires a base prognostic model to be installed.
+
+::::{tab-set}
+:::{tab-item} pip
+
+```bash
+pip install earth2studio[interp-crps-dit]
+```
+
+:::
+:::{tab-item} uv
+
+```bash
+uv add earth2studio --extra interp-crps-dit
+```
+
+:::
+::::
+:::::
 ::::::
 
 #### Diagnostics

--- a/earth2studio/models/px/__init__.py
+++ b/earth2studio/models/px/__init__.py
@@ -40,6 +40,7 @@ from earth2studio.models.px.fuxi import FuXi
 from earth2studio.models.px.gencast_mini import GenCastMini
 from earth2studio.models.px.graphcast_operational import GraphCastOperational
 from earth2studio.models.px.graphcast_small import GraphCastSmall
+from earth2studio.models.px.interpcrpsdit import InterpCRPSDiT
 from earth2studio.models.px.interpmodafno import InterpModAFNO
 from earth2studio.models.px.pangu import Pangu3, Pangu6, Pangu24
 from earth2studio.models.px.persistence import Persistence

--- a/earth2studio/models/px/__init__.py
+++ b/earth2studio/models/px/__init__.py
@@ -25,6 +25,7 @@ from earth2studio.models.px.atlas import Atlas
 from earth2studio.models.px.aurora import Aurora
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.cbottle_video import CBottleVideo
+from earth2studio.models.px.datareplay import DataReplay
 from earth2studio.models.px.dlesym import DLESyM, DLESyMLatLon
 from earth2studio.models.px.dlesym_v0_isccp_era5 import (
     DLESyMv0_ISCCP_ERA5,

--- a/earth2studio/models/px/datareplay.py
+++ b/earth2studio/models/px/datareplay.py
@@ -147,7 +147,6 @@ class DataReplay(torch.nn.Module, PrognosticMixin):
             Coordinate system dictionary.
         """
         output_coords = self._input_coords.copy()
-        output_coords["lead_time"] = np.array([self.step])
         target = self.input_coords()
         handshake_dim(input_coords, "variable", -3)
         handshake_dim(input_coords, "lat", -2)
@@ -158,7 +157,7 @@ class DataReplay(torch.nn.Module, PrognosticMixin):
         output_coords["batch"] = input_coords["batch"]
         output_coords["time"] = input_coords.get("time", np.empty(0))
         output_coords["lead_time"] = (
-            output_coords["lead_time"] + input_coords["lead_time"][-1]
+            np.array([self.step]) + input_coords["lead_time"][-1]
         )
         return output_coords
 
@@ -218,6 +217,12 @@ class DataReplay(torch.nn.Module, PrognosticMixin):
         -------
         tuple[torch.Tensor, CoordSystem]
             The fetched frame and its coordinate system, one ``step`` ahead.
+
+        Notes
+        -----
+        ``front_hook`` / ``rear_hook`` are **not** applied here -- they fire only in
+        :meth:`create_iterator` (matching :class:`~earth2studio.models.px.persistence.Persistence`).
+        Use :meth:`create_iterator` when hook transformations are required.
         """
         self._require_time(coords)
         out_coords = self.output_coords(coords)

--- a/earth2studio/models/px/datareplay.py
+++ b/earth2studio/models/px/datareplay.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+from collections.abc import Generator, Iterator
+
+import numpy as np
+import torch
+
+from earth2studio.data import DataSource, fetch_data
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.px.utils import PrognosticMixin
+from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.type import CoordSystem
+
+
+class DataReplay(torch.nn.Module, PrognosticMixin):
+    """Adapt any :class:`~earth2studio.data.DataSource` into a prognostic model, so a stored or
+    observed dataset can be stepped through the same iterator interface as a forecast model.
+
+    Each step after the initial condition fetches ``source`` at the next valid time (advancing
+    ``lead_time`` by ``step``) instead of forecasting, yielding the source's own frames as the
+    trajectory. Any pipeline built around the prognostic iterator can then be driven by
+    reanalysis/analysis frames rather than a forecast rollout -- for example, supplying source frames
+    to a downstream model (such as a temporal interpolator), building a reference trajectory to score
+    forecasts against, or sub-sampling a finer source in time. It complements
+    :class:`~earth2studio.models.px.persistence.Persistence` (which echoes the initial state forward)
+    by instead pulling a fresh frame each step. For the forecast-as-trajectory case, prefer
+    :class:`~earth2studio.data.ForecastSource`.
+
+    ``step`` sets the spacing between emitted frames (equivalently, the ``lead_time`` increment, and the
+    sub-sampling interval when ``source`` is available at a finer resolution).
+
+    Notes
+    -----
+    * **Deterministic / single realization.** ``source`` is fetched once and broadcast across the batch
+      (ensemble) dim -- all members get the same coarse frame; member diversity must come from the
+      downstream model (a stochastic source is sampled once, not per member).
+    * **On-grid source required.** The fetched data is not regridded; ``_fetch`` raises if the source
+      grid does not match ``domain_coords`` (crop/interpolate the source beforehand if it differs), and
+      also raises on non-finite (fill/masked) values since the downstream model has no NaN handling.
+    * **Stateless.** No history window, no checkpoint state -- a resume re-queries ``source``, so a
+      resumed run reproduces the original only insofar as the source itself is reproducible. The step-0 initial condition is assumed to be
+      ``source`` at ``time0`` (true when the same object is passed to the run's ``data`` and here).
+
+    Parameters
+    ----------
+    source : DataSource
+        The data source to replay (queried by absolute valid time).
+    variable : str | list[str]
+        Variables to emit (Earth2Studio ids), in the order the downstream model expects.
+    domain_coords : CoordSystem
+        Spatial coordinates (``lat``/``lon``) the source is expected to provide.
+    step : np.timedelta64 | int | float, optional
+        Spacing between emitted frames (also the ``lead_time`` increment). ``int``/``float`` is
+        interpreted as whole hours (a non-integral float raises). Default ``np.timedelta64(6, "h")``.
+    """
+
+    def __init__(
+        self,
+        source: DataSource,
+        variable: str | list[str],
+        domain_coords: CoordSystem,
+        step: np.timedelta64 | int | float = np.timedelta64(6, "h"),
+    ) -> None:
+        super().__init__()
+        if isinstance(variable, str):
+            variable = [variable]
+        if isinstance(
+            step, bool
+        ):  # bool subclasses int; reject before the numeric branch
+            raise TypeError(
+                f"step must be int/float hours or np.timedelta64, got {type(step)}"
+            )
+        if isinstance(
+            step, np.timedelta64
+        ):  # checked first: np.timedelta64 subclasses np.integer
+            if np.isnat(step):
+                raise ValueError("step must be a finite positive duration, got NaT")
+        elif isinstance(step, (int, float, np.integer, np.floating)):
+            if not np.isfinite(float(step)):
+                raise ValueError(
+                    f"int/float step must be finite whole hours, got {step}"
+                )
+            if float(step) != int(step):
+                raise ValueError(f"int/float step must be whole hours, got {step}")
+            step = np.timedelta64(int(step), "h")
+        else:
+            raise TypeError(
+                f"step must be int/float hours or np.timedelta64, got {type(step)}"
+            )
+        if step <= np.timedelta64(0, "h"):
+            raise ValueError(f"step must be positive, got {step}")
+        self.source = source
+        self.step = step
+        self._variable = np.array(variable)
+        self._domain = OrderedDict(domain_coords)
+        self._input_coords = OrderedDict(
+            {
+                "batch": np.empty(0),
+                "time": np.empty(0),
+                "lead_time": np.array([np.timedelta64(0, "h")]),
+                "variable": np.array(variable),
+            }
+        )
+        for key, value in self._domain.items():
+            self._input_coords[key] = value
+
+    def __str__(self) -> str:
+        return "DataReplay"
+
+    def input_coords(self) -> CoordSystem:
+        """Input coordinate system.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary (``batch, time, lead_time, variable, lat, lon``).
+        """
+        return self._input_coords.copy()
+
+    @batch_coords()
+    def output_coords(self, input_coords: CoordSystem) -> CoordSystem:
+        """Output coordinate system: one coarse ``step`` past the input lead time.
+
+        Parameters
+        ----------
+        input_coords : CoordSystem
+            Input coordinate system to transform.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary.
+        """
+        output_coords = self._input_coords.copy()
+        output_coords["lead_time"] = np.array([self.step])
+        target = self.input_coords()
+        handshake_dim(input_coords, "variable", -3)
+        handshake_dim(input_coords, "lat", -2)
+        handshake_dim(input_coords, "lon", -1)
+        handshake_coords(input_coords, target, "variable")
+        handshake_coords(input_coords, target, "lat")
+        handshake_coords(input_coords, target, "lon")
+        output_coords["batch"] = input_coords["batch"]
+        output_coords["time"] = input_coords.get("time", np.empty(0))
+        output_coords["lead_time"] = (
+            output_coords["lead_time"] + input_coords["lead_time"][-1]
+        )
+        return output_coords
+
+    @torch.inference_mode()
+    def _fetch(
+        self,
+        times: np.ndarray,
+        offset: np.timedelta64,
+        batch: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        # Fetch the source at ``times + offset``; shape (batch, time, 1, var, lat, lon).
+        # Raises if the source grid does not match ``domain_coords`` (no silent regrid/mislabel).
+        # Returns a materialized (contiguous) tensor so the broadcast batch dim does not alias storage.
+        data, out = fetch_data(
+            self.source,
+            time=times,
+            variable=self._variable,
+            lead_time=np.array([offset]),
+            device=device,
+        )
+        for ax in ("lat", "lon"):
+            got, want = np.asarray(out[ax]), np.asarray(self._domain[ax])
+            if got.shape != want.shape or not np.allclose(got, want):
+                raise ValueError(
+                    f"source {ax} grid (n={got.shape}) does not match domain_coords (n={want.shape}); "
+                    "DataReplay does not regrid -- provide a source already on the domain grid."
+                )
+        if not torch.isfinite(data).all():
+            raise ValueError(
+                "DataReplay: source returned non-finite values (fill/ocean-masked field?); "
+                "the downstream model has no NaN handling -- provide gap-filled data."
+            )
+        return data.unsqueeze(0).expand(batch, *data.shape).contiguous()
+
+    @staticmethod
+    def _require_time(coords: CoordSystem) -> None:
+        if "time" not in coords or len(np.atleast_1d(coords["time"])) == 0:
+            raise ValueError(
+                "DataReplay requires coords['time'] (absolute valid time(s)); none provided."
+            )
+
+    @batch_func()
+    def __call__(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """Advance one coarse step: fetch the source at ``time + lead_time + step``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor (used only for batch size / device / dtype).
+        coords : CoordSystem
+            Input coordinate system; must contain ``time``.
+
+        Returns
+        -------
+        tuple[torch.Tensor, CoordSystem]
+            The fetched frame and its coordinate system, one ``step`` ahead.
+        """
+        self._require_time(coords)
+        out_coords = self.output_coords(coords)
+        data = self._fetch(
+            coords["time"], self.step + coords["lead_time"][-1], x.shape[0], x.device
+        )
+        return data.to(x.dtype), out_coords
+
+    @batch_func()
+    def _default_generator(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
+        self._require_time(coords)
+        # Validate input dim order + grid up front, so the iterator rejects a variable/lat/lon mismatch
+        # instead of silently mislabelling fetched frames.
+        self.output_coords(coords)
+        # front_hook transforms the provided input before the replay begins. DataReplay has no forward
+        # pass, so it fires once on the input that defines the step-0 initial condition and the query times.
+        x, coords = self.front_hook(x, coords)
+        # Step 0: the provided initial condition is the source at time0 (the last input lead slice).
+        # rear_hook transforms every emitted frame (the IC and each fetched frame); the default identity
+        # hook leaves them unmodified, preserving the verbatim-replay contract.
+        coords0 = coords.copy()
+        coords0["lead_time"] = coords["lead_time"][-1:]
+        yield self.rear_hook(x[:, :, -1:], coords0)
+        k = 1
+        while True:
+            offset = coords["lead_time"][-1] + k * self.step
+            data = self._fetch(coords["time"], offset, x.shape[0], x.device).to(x.dtype)
+            out = coords.copy()
+            out["lead_time"] = np.array([offset])
+            yield self.rear_hook(data, out)
+            k += 1
+
+    def create_iterator(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> Iterator[tuple[torch.Tensor, CoordSystem]]:
+        """Iterator yielding the initial condition, then successive source frames at each coarse step.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor.
+        coords : CoordSystem
+            Input coordinate system; must contain ``time``.
+
+        Yields
+        ------
+        tuple[torch.Tensor, CoordSystem]
+            Each coarse-step frame and its coordinate system.
+        """
+        yield from self._default_generator(x, coords)

--- a/earth2studio/models/px/interpcrpsdit.py
+++ b/earth2studio/models/px/interpcrpsdit.py
@@ -1,0 +1,1110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import warnings
+from collections import OrderedDict
+from collections.abc import Generator, Iterator
+from datetime import datetime
+from typing import Literal, cast, get_args
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import xarray as xr
+
+from earth2studio.models.auto import AutoModelMixin, Package
+from earth2studio.models.batch import batch_coords, batch_func
+from earth2studio.models.px.base import PrognosticModel
+from earth2studio.models.px.utils import PrognosticMixin
+from earth2studio.utils import handshake_dim
+from earth2studio.utils.coords import CoordSystem, map_coords
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+
+try:
+    from physicsnemo import Module as PhysicsNemoModule
+    from physicsnemo.utils.zenith_angle import cos_zenith_angle
+except ImportError:
+    OptionalDependencyFailure("interp-crps-dit")
+    PhysicsNemoModule = None
+    cos_zenith_angle = None
+
+VARIABLES = [
+    "u10m",
+    "v10m",
+    "u100m",
+    "v100m",
+    "t2m",
+    "sp",
+    "msl",
+    "tcwv",
+    "u50",
+    "u100",
+    "u150",
+    "u200",
+    "u250",
+    "u300",
+    "u400",
+    "u500",
+    "u600",
+    "u700",
+    "u850",
+    "u925",
+    "u1000",
+    "v50",
+    "v100",
+    "v150",
+    "v200",
+    "v250",
+    "v300",
+    "v400",
+    "v500",
+    "v600",
+    "v700",
+    "v850",
+    "v925",
+    "v1000",
+    "z50",
+    "z100",
+    "z150",
+    "z200",
+    "z250",
+    "z300",
+    "z400",
+    "z500",
+    "z600",
+    "z700",
+    "z850",
+    "z925",
+    "z1000",
+    "t50",
+    "t100",
+    "t150",
+    "t200",
+    "t250",
+    "t300",
+    "t400",
+    "t500",
+    "t600",
+    "t700",
+    "t850",
+    "t925",
+    "t1000",
+    "q50",
+    "q100",
+    "q150",
+    "q200",
+    "q250",
+    "q300",
+    "q400",
+    "q500",
+    "q600",
+    "q700",
+    "q850",
+    "q925",
+    "q1000",
+]
+# Physical surface invariants appended to the invariant stack (between the base statics and cos_zenith).
+PHYS_EXTRA = ["log_z0", "lai", "rs_min", "theta_sat", "field_capacity", "wilting_point"]
+# Spatial length scales (grid cells) of the multi-scale latent noise; each becomes one channel of the
+# per-member latent z (drawn as white noise, blurred with sigma = scale/2 in _draw_noise) driving ensemble spread.
+NOISE_SCALES = (2, 4, 8, 16, 32, 64)
+# Min/max coarse bracket width (h between consecutive source frames) the checkpoint was trained on;
+# used only to warn on off-distribution gaps in output_coords (out-of-range still runs). The gap is fed to the DiT as a constant
+# conditioning channel, affine-normalized to ~unit scale as (gap_h - 6) / 3 (training-time mean 6, scale 3;
+# see gap_val in _interpolate) -- the 6 and 3 are the standardization constants, unrelated to this 3-10 range.
+_GAP_MIN_H, _GAP_MAX_H = 3, 10
+# The only channels the model was trained to tolerate missing. Dropping any other (core) channel is
+# off-distribution and is rejected.
+OptionalVariable = Literal["sp", "u100m", "v100m", "tcwv"]
+OPTIONAL_VARIABLES = list(get_args(OptionalVariable))
+# Training grid height: 721-lat sources are cropped to this (dropping the -90 pole row) to match training.
+_TRAIN_LAT = 720
+
+
+def _gaussian_radius(sigma: float) -> int:
+    # Kernel half-width for a Gaussian blur: the standard 3-sigma truncation, floored at 1 so a usable
+    # (>=3-tap) kernel is returned even for small sigma. Sets the oversize pad _gaussian_blur_valid expects.
+    return max(1, int(round(3.0 * sigma)))
+
+
+def _gaussian_blur_valid(x: torch.Tensor, sigma: float) -> torch.Tensor:
+    # Valid (no-pad) separable Gaussian blur; ``x`` must be oversized by the kernel radius on each side.
+    # Divides by the analytic ``sum(k*k)`` so unit-variance white noise stays unit-variance (stationary
+    # variance, no reflect-pad edge artifact). Reproduces the noise generator used at training.
+    r = _gaussian_radius(sigma)
+    t = torch.arange(-r, r + 1, device=x.device, dtype=x.dtype)
+    k = torch.exp(-0.5 * (t / sigma) ** 2)
+    k = k / k.sum()
+    c = x.shape[1]
+    kh = k.view(1, 1, -1, 1).expand(c, 1, 2 * r + 1, 1)
+    kw = k.view(1, 1, 1, -1).expand(c, 1, 1, 2 * r + 1)
+    x = F.conv2d(x, kh, groups=c)
+    x = F.conv2d(x, kw, groups=c)
+    return x / (k * k).sum()
+
+
+def _znorm(a: np.ndarray) -> np.ndarray:
+    # Global z-score (field mean/std, eps 1e-6), matching the training-time invariant normalization.
+    a = a.astype("float32")
+    return ((a - a.mean()) / (a.std() + 1e-6)).astype("float32")
+
+
+@check_optional_dependencies()
+class InterpCRPSDiT(torch.nn.Module, AutoModelMixin, PrognosticMixin):
+    """One-shot, endpoint-pinned CRPS temporal interpolation with a DiT backbone (73 variables at
+    0.25 degree resolution, 720x1440).
+
+    The DiT backbone always operates on the full 73-channel state internally; the public output is those
+    73 variables minus any ``drop_variables`` (channels the base does not supply), so a base with fewer
+    variables can drive it and the output carries only the variables actually available.
+
+    Interpolates a base model's widely-spaced trajectory to ``num_interp_steps`` sub-steps per bracket.
+    For each interior fraction ``tau`` and per-member latent ``z`` the field is produced in a single
+    forward as ``out(tau) = (1 - tau) x0 + tau xT + sin(pi tau) f(x0, xT, cond, z)`` -- a linear base
+    plus a DiT correction ``f`` whose ``sin(pi tau)`` envelope drives it to zero at both endpoints. The
+    bracket endpoints are not modelled: they are copied from the base model's coarse frames (after those
+    frames are mapped onto the output grid); only the interior ``tau`` are modelled. Ensemble spread comes entirely from the
+    per-member latent ``z`` (the model is trained with a CRPS objective, which rewards a spread that
+    matches forecast uncertainty).
+
+    A "bracket" is one coarse interval between two consecutive source frames; its width (gap) is taken
+    from the wrapped ``px_model`` and may be any of the trained 3-10 h widths (set automatically). The
+    output resolution is ``gap / num_interp_steps`` (e.g. a 6 h gap with ``num_interp_steps=36`` -> 10
+    min); ``num_interp_steps`` must divide the coarse gap in minutes. A regional sub-domain is available
+    via :meth:`set_domain`, which slices the conditioning maps + output grid to a bounding box.
+
+    Warning
+    -------
+    A base forecast/reanalysis model must be set (``px_model`` / :meth:`load_model`) before running. Its
+    coarse step must be divisible by ``num_interp_steps``; a step outside the trained 3-10 h range only
+    warns (off-distribution, but still run). The DiT runs in fp32 by default; ``amp_dtype`` runs its
+    forward under bf16/fp16 autocast (weights stay fp32; autocast downcasts eligible operations).
+
+    Parameters
+    ----------
+    dit : torch.nn.Module
+        The DiT network that predicts the correction ``f`` (a physicsnemo Module) with ``natten2d_rope`` attention.
+    center, scale : torch.Tensor
+        Per-variable normalization, shape (1, 73, 1, 1).
+    static_inv : torch.Tensor
+        Time-invariant conditioning maps (12, H, W): sin/cos lat, sin/cos lon, lsm, orog + 6 physical.
+    lat2d, lon2d : torch.Tensor
+        (H, W) latitude/longitude grids (degrees); define the output grid + the live cos-zenith channel.
+    px_model : PrognosticModel, optional
+        Base model producing the coarse trajectory (set before running).
+    num_interp_steps : int, optional
+        Sub-steps per bracket; must divide the coarse gap (min). Output resolution = gap/num_interp_steps
+        (6 h gap: 6 -> 1 h, 36 -> 10 min). Default 6.
+    lon_pad : int, optional
+        Circular longitude pad (cols) that reduces the date-line seam (the DiT attention has no built-in
+        longitude wraparound); 0 disables, by default 128.
+    seed : int | None, optional
+        If set, ensemble-member noise is drawn from a per-device generator seeded by this value; members
+        are distinct and reproducible for a fixed run layout. The per-member draw depends on how the
+        ensemble is chunked (``batch_size``) and on the number of init times per call, so seeded results
+        are not bit-identical when that layout changes. ``None`` (default) uses the global RNG
+        (nondeterministic run-to-run).
+    drop_variables : list[OptionalVariable] | None, optional
+        Variables the base model does not supply (or that should be ignored). The base need only provide
+        the remaining variables; each dropped channel is expanded to its climatological center internally
+        (normalized zero, flagged absent to the DiT via the presence mask) and is **not** included in the
+        output -- so the model emits ``VARIABLES`` minus these. This lets a base that lacks them drive the
+        interpolator (e.g. a 69-variable model missing ``u100m, v100m, sp, tcwv``). Must be a subset of the
+        trained-optional channels ``sp, u100m, v100m, tcwv``; dropping any other (core) channel raises.
+        Default None.
+    amp_dtype : torch.dtype | None, optional
+        DiT inference precision. ``None`` (default) runs fp32 (autocast disabled). ``torch.bfloat16`` /
+        ``torch.float16`` runs the forward under autocast (weights stay fp32; autocast downcasts eligible
+        operations). Only the
+        DiT correction ``f`` is computed at reduced precision: the linear base + envelope pin run in fp32,
+        so the copied endpoints at ``tau=0/1`` are unaffected.
+
+    Note
+    ----
+    Each interior frame is produced by a single network forward pass (a full bracket runs one forward
+    per interior sub-step); there is no iterative SDE/ODE solver.
+    Trained and validated only on ERA5: the bracket endpoints are the verbatim base-model states
+    (correct for any base), but the interior is learned (a statistical interpolation, with no
+    physical/conservation guarantee), so with a non-ERA5 source (e.g. GFS) the inputs differ from the
+    ERA5 training data and interior quality may degrade.
+
+    Badges
+    ------
+    region:global class:mrf product:wind product:temp product:atmos year:2026 gpu:80gb
+    """
+
+    def __init__(
+        self,
+        dit: torch.nn.Module,
+        center: torch.Tensor,
+        scale: torch.Tensor,
+        static_inv: torch.Tensor,
+        lat2d: torch.Tensor,
+        lon2d: torch.Tensor,
+        px_model: PrognosticModel | None = None,
+        num_interp_steps: int = 6,
+        lon_pad: int = 128,
+        seed: int | None = None,
+        drop_variables: list[OptionalVariable] | None = None,
+        amp_dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        if num_interp_steps < 1:
+            raise ValueError(f"num_interp_steps must be >= 1, got {num_interp_steps}")
+        if amp_dtype not in (None, torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"amp_dtype must be None (fp32), torch.bfloat16, or torch.float16, got {amp_dtype}"
+            )
+        self.dit = dit
+        self.px_model = px_model
+        self.num_interp_steps = num_interp_steps
+        self.lon_pad = lon_pad
+        # DiT inference precision (see the amp_dtype docstring); None -> fp32.
+        self.amp_dtype = amp_dtype
+        self.seed = (
+            seed  # None -> global RNG (nondeterministic); int -> reproducible members
+        )
+        self._gen: torch.Generator | None = (
+            None  # lazily created per-device when seed is set
+        )
+        self.noise_scales = NOISE_SCALES
+        self.variables = np.array(VARIABLES)
+        # Dropped input variables: zeroed in x0/xT (normalized space) and flagged 0 in the presence mask.
+        drop = drop_variables or []
+        bad = [v for v in drop if v not in OPTIONAL_VARIABLES]
+        if bad:
+            raise ValueError(
+                f"drop_variables must be a subset of the trained-optional channels {OPTIONAL_VARIABLES}; got {bad}"
+            )
+        self.drop_idx = np.array([VARIABLES.index(v) for v in drop], dtype=int)
+        # Present (emitted) channels: the base need only supply these. Dropped channels are declared
+        # unavailable -- expanded to center internally (normalized zero for the DiT) and never emitted.
+        _dropped = set(self.drop_idx.tolist())
+        self.present_idx = np.array(
+            [i for i in range(len(VARIABLES)) if i not in _dropped], dtype=int
+        )
+        self.present_variables = np.array([VARIABLES[i] for i in self.present_idx])
+        self.register_buffer("center", center)
+        self.register_buffer("scale", scale)
+        self.register_buffer("static_inv", static_inv)
+        self.register_buffer("lat2d", lat2d)
+        self.register_buffer("lon2d", lon2d)
+        # cached CPU numpy grids for the (numpy-only) cos-zenith call + output_coords -- buffers never change.
+        self._lat_np = lat2d.detach().cpu().numpy()
+        self._lon_np = lon2d.detach().cpu().numpy()
+        self._lat1d = self._lat_np[
+            :, 0
+        ]  # regular grid -> 1D lat/lon: the run grid the DiT sees
+        self._lon1d = self._lon_np[0, :]
+        # Sub-domain halo (top, bottom, left, right) px trimmed from every emitted frame, and the
+        # trimmed output grid. Defaults (no halo, out == run) are set by set_domain when it slices.
+        self._halo = (0, 0, 0, 0)
+        self._out_lat1d = self._lat1d
+        self._out_lon1d = self._lon1d
+        # Per-side floor so the DiT's NATTEN kernel fits the latent grid. This 64 is only a pre-load
+        # default; load_model overwrites it with the architecture's attn_kernel x patch for the real DiT.
+        self._min_domain_cells = 64
+
+    def __str__(self) -> str:
+        return "InterpCRPSDiT"
+
+    # ------------------------------------------------------------------ coords
+    def input_coords(self) -> CoordSystem:
+        """Input coordinate system, derived from the wrapped ``px_model`` (its grid). The base frame is
+        fed to ``px_model`` on its own grid and only then reconciled onto the model's run grid with
+        ``map_coords``, so the input contract is the ``px_model`` grid.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary (``batch, time, lead_time, variable, lat, lon``).
+        """
+        if self.px_model is None:
+            raise ValueError("Base model, px_model, must be set")
+        input_coords = OrderedDict(
+            {
+                "batch": np.empty(0),
+                "time": np.empty(0),
+                "lead_time": np.empty(0),
+                "variable": np.empty(0),
+                "lat": np.empty(0),
+                "lon": np.empty(0),
+            }
+        )
+        for key, value in self.px_model.input_coords().items():
+            if key in input_coords:
+                input_coords[key] = value
+        return input_coords
+
+    def _gap_minutes(self) -> int:
+        # Coarse bracket width (gap) in minutes, from the wrapped px_model's step.
+        if self.px_model is None:
+            raise ValueError("px_model must be set before computing the coarse gap")
+        ic = self.px_model.input_coords()
+        oc = self.px_model.output_coords(ic)
+        gap_m = float(
+            (oc["lead_time"][-1] - ic["lead_time"][-1]) / np.timedelta64(1, "m")
+        )
+        gap_min = round(gap_m)
+        if gap_min <= 0 or abs(gap_m - gap_min) > 1e-6:
+            raise ValueError(
+                f"px_model coarse step must be a positive whole number of minutes, got {gap_m} min"
+            )
+        return gap_min
+
+    @batch_coords()
+    def output_coords(self, input_coords: CoordSystem) -> CoordSystem:
+        """Output coordinate system: the model grid at the sub-step cadence (coarse gap /
+        num_interp_steps), one sub-step past the input lead time. Raises if the coarse gap is not
+        divisible by ``num_interp_steps`` and warns if it is outside the trained 3-10 h range, and
+        checks the input exposes variable/lat/lon dims in the expected positions (grid values + variable
+        set are reconciled later by ``map_coords``).
+
+        Parameters
+        ----------
+        input_coords : CoordSystem
+            Input coordinate system to transform.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary.
+
+        Raises
+        ------
+        ValueError
+            If the coarse gap (in minutes) is not divisible by ``num_interp_steps``.
+
+        Warns
+        -----
+        UserWarning
+            If the coarse gap is outside the trained 3-10 h range. The run is still allowed (the gap
+            conditioning channel simply extrapolates), but the interior is off-distribution and
+            unvalidated.
+        """
+        gap_min = self._gap_minutes()
+        gap_h = gap_min / 60.0
+        if not (_GAP_MIN_H <= gap_h <= _GAP_MAX_H):
+            warnings.warn(
+                f"coarse gap {gap_h:g} h is outside the trained "
+                f"[{_GAP_MIN_H}, {_GAP_MAX_H}] h range; the gap conditioning channel is "
+                "extrapolated, so results are off-distribution and unvalidated.",
+                stacklevel=2,
+            )
+        if gap_min % self.num_interp_steps != 0:
+            raise ValueError(
+                f"num_interp_steps={self.num_interp_steps} must divide the {gap_min}-min coarse gap"
+            )
+        step_min = gap_min // self.num_interp_steps
+        # Reported (output) grid = the trimmed bounding box interior; may differ from the run grid under a halo.
+        output_coords = OrderedDict(
+            {
+                "batch": np.empty(0),
+                "time": np.empty(0),
+                "lead_time": np.array([np.timedelta64(step_min, "m")]),
+                "variable": np.array(self.present_variables),
+                "lat": np.asarray(self._out_lat1d, dtype=np.float64),
+                "lon": np.asarray(self._out_lon1d, dtype=np.float64),
+            }
+        )
+        # Report the model's own output grid regardless of the input grid: the base
+        # frame is fed to px_model on its grid, then map_coords-reconciled onto the run grid (721->720, or
+        # a global base -> sub-domain bounding box) in _default_generator. We only require the spatial dims to be
+        # present in the expected positions; grid values + variable set are reconciled by map_coords
+        # (which raises if a required variable is missing).
+        handshake_dim(input_coords, "variable", -3)
+        handshake_dim(input_coords, "lat", -2)
+        handshake_dim(input_coords, "lon", -1)
+        output_coords["batch"] = input_coords.get("batch", np.empty(0))
+        output_coords["time"] = input_coords.get("time", np.empty(0))
+        output_coords["lead_time"] = (
+            output_coords["lead_time"] + input_coords["lead_time"][-1]
+        )
+        return output_coords
+
+    def run_coords(self) -> CoordSystem:
+        """The lat/lon grid a wrapped ``px_model`` must cover -- the full model grid, or, after
+        :meth:`set_domain`, the sub-domain run grid (bounding box + halo, aligned to the patch size). A
+        larger grid that contains it is accepted and cropped.
+
+        Unlike :meth:`input_coords` (which derives lat/lon from ``px_model`` and so is unavailable until
+        a base model is attached), this reads the fixed run grid directly, so it is the grid to build a
+        regional ``px_model`` against right after ``set_domain``.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary with the run-grid ``lat``/``lon``.
+        """
+        return OrderedDict(
+            {
+                "lat": np.asarray(self._lat1d, dtype=np.float64),
+                "lon": np.asarray(self._lon1d, dtype=np.float64),
+            }
+        )
+
+    # ------------------------------------------------------------------ sub-domain
+    @staticmethod
+    def _snap_to_patch(lo: int, hi: int, n: int, p: int) -> tuple[int, int]:
+        # Snap a run window [lo, hi) to multiples of the DiT patch size ``p`` (the detokenizer needs the
+        # pixel grid divisible by patch). Grows the low edge down and the high edge up; if the high edge
+        # would exceed ``n`` it floors to the largest in-bounds multiple (so the extent stays divisible).
+        # At the grid boundary that floor can drop below the requested bounding box and yield a negative halo
+        # trim -- ``set_domain`` detects that case and raises.
+        lo = (lo // p) * p
+        hi = ((hi + p - 1) // p) * p
+        if hi > n:
+            hi = (n // p) * p
+        return lo, hi
+
+    def set_domain(
+        self,
+        lat_min: float,
+        lat_max: float,
+        lon_min: float,
+        lon_max: float,
+        halo: int = 0,
+        min_cells: int | None = None,
+    ) -> "InterpCRPSDiT":
+        """Restrict the (global) model to a regional sub-domain for a lat/lon bounding box.
+
+        Returns a new :class:`InterpCRPSDiT` that shares the loaded ``dit`` but whose invariant stack /
+        output grid are sliced to the smallest block of the current grid covering ``[lat_min, lat_max] x
+        [lon_min, lon_max]``. No learnable weight depends on the grid size (RoPE/NATTEN state rebinds per
+        forward), so the DiT runs on the cropped grid directly, subject to the per-side minimum size and
+        patch-divisibility constraints this method enforces. Longitude wrap is
+        disabled (``lon_pad=0``) because a regional block is not periodic.
+
+        The wrapped ``px_model`` is carried over. Its coarse trajectory is reconciled onto the run grid
+        (the bounding box expanded by ``halo``, aligned to the patch size) with ``map_coords``, so it may supply that grid
+        directly (e.g. a regional :class:`~earth2studio.models.px.datareplay.DataReplay`, available as
+        :meth:`run_coords`) or a larger grid that contains it (e.g. a global base is cropped to the bounding box).
+
+        ``halo`` (px, default 0 = off): run on a block expanded by ``halo`` real cells per side and trim
+        it off every emitted frame -- intended to push the DiT's boundary artifact off the returned bounding box
+        interior along the (non-periodic) sub-domain edge (a plausible mitigation, not validated on this
+        path); clamps + warns at the global grid edge.
+
+        Warning
+        -------
+        The shared ``dit`` rebinds its latent-grid state in place per forward, so a parent and its
+        sub-domains (or several sub-domains) are safe to run sequentially but not concurrently against
+        the same ``dit`` -- run concurrent domains in separate processes. Interior skill is unvalidated
+        outside the trained global ERA5 distribution. The returned sub-domain is placed on the parent's
+        current device; if you later move the parent with ``.to(...)`` it will not propagate to an
+        already-returned sub (the sub holds its own cloned invariant/grid buffers) -- move the sub
+        explicitly, or call ``set_domain`` after the parent is on its final device.
+
+        Parameters
+        ----------
+        lat_min, lat_max, lon_min, lon_max : float
+            Bounding box (degrees); must lie inside the current grid. Longitude does not wrap the
+            date line (require ``lon_min < lon_max`` within the grid's longitude span).
+        halo : int, optional
+            Real cells added per side then trimmed off the output (boundary-artifact guard), by default 0.
+        min_cells : int | None, optional
+            Per-side floor on the run grid (NATTEN kernel must fit the latent). Defaults to the model's
+            ``_min_domain_cells`` (derived from the architecture at load, ``attn_kernel x patch``; 64 before loading).
+
+        Returns
+        -------
+        InterpCRPSDiT
+            A fixed sub-domain model with its own ``input_coords`` (run grid) / ``output_coords`` (bounding box).
+
+        Raises
+        ------
+        ValueError
+            If the bounding box is degenerate, ``halo`` is negative, ``min_cells`` is less than 1, the
+            box lies outside the current grid or selects no cells, patch-size snapping at the grid
+            boundary shrinks the run window below the requested bounding box, or the run window is smaller than
+            the ``min_cells`` per-side floor (the NATTEN kernel must fit the latent grid).
+        """
+        lat1d, lon1d = np.asarray(self._lat1d), np.asarray(self._lon1d)
+        if lat_min >= lat_max or lon_min >= lon_max:
+            raise ValueError(
+                "require lat_min < lat_max and lon_min < lon_max (no date-line wrap)"
+            )
+        if halo < 0:
+            raise ValueError(f"halo must be non-negative, got {halo}")
+        if min_cells is not None and min_cells < 1:
+            raise ValueError(f"min_cells must be >= 1, got {min_cells}")
+        if (
+            lat_min < lat1d.min()
+            or lat_max > lat1d.max()
+            or lon_min < lon1d.min()
+            or lon_max > lon1d.max()
+        ):
+            raise ValueError(
+                f"bounding box lat[{lat_min},{lat_max}] lon[{lon_min},{lon_max}] is outside the current grid "
+                f"lat[{lat1d.min()},{lat1d.max()}] lon[{lon1d.min()},{lon1d.max()}]"
+            )
+        inside_lat = (lat1d >= lat_min) & (lat1d <= lat_max)
+        inside_lon = (lon1d >= lon_min) & (lon1d <= lon_max)
+        if not inside_lat.any() or not inside_lon.any():
+            raise ValueError(
+                "bounding box selects no grid cells (smaller than one grid cell?); widen it"
+            )
+        rows, cols = np.where(inside_lat)[0], np.where(inside_lon)[0]
+        i0, i1 = int(rows[0]), int(rows[-1]) + 1
+        j0, j1 = int(cols[0]), int(cols[-1]) + 1
+        hn, wn = lat1d.shape[0], lon1d.shape[0]
+        ph, pw = self.dit.patch_size
+        # Expand by the halo (real surrounding cells), clamp to the grid edge, then patch-snap the window.
+        i0e, i1e = max(0, i0 - halo), min(hn, i1 + halo)
+        j0e, j1e = max(0, j0 - halo), min(wn, j1 + halo)
+        if halo and (
+            i0 - i0e < halo or i1e - i1 < halo or j0 - j0e < halo or j1e - j1 < halo
+        ):
+            warnings.warn(
+                "halo clamped at the grid edge; a residual edge artifact may remain there",
+                stacklevel=2,
+            )
+        i0e, i1e = self._snap_to_patch(i0e, i1e, hn, ph)
+        j0e, j1e = self._snap_to_patch(j0e, j1e, wn, pw)
+        halo_trim = (i0 - i0e, i1e - i1, j0 - j0e, j1e - j1)
+        if any(t < 0 for t in halo_trim):
+            raise ValueError(
+                f"patch_size={ph, pw} snapping shrank the run window below the bounding box "
+                "(grid dim not a multiple of patch_size); widen the bounding box"
+            )
+        min_cells = self._min_domain_cells if min_cells is None else min_cells
+        if min(i1e - i0e, j1e - j0e) < min_cells:
+            raise ValueError(
+                f"run grid {i1e - i0e}x{j1e - j0e} is below the {min_cells}-cell per-side minimum "
+                "(the DiT's NATTEN kernel must fit the latent grid); widen the bounding box or lower min_cells"
+            )
+        sub = InterpCRPSDiT(
+            dit=self.dit,  # shared by reference -- sequential use only (see Warning)
+            center=self.center,
+            scale=self.scale,
+            static_inv=self.static_inv[:, i0e:i1e, j0e:j1e].clone(),
+            lat2d=self.lat2d[i0e:i1e, j0e:j1e].clone(),
+            lon2d=self.lon2d[i0e:i1e, j0e:j1e].clone(),
+            px_model=self.px_model,
+            num_interp_steps=self.num_interp_steps,
+            lon_pad=0,  # regional block is not longitude-periodic
+            seed=self.seed,
+            drop_variables=cast(
+                "list[OptionalVariable]", [VARIABLES[int(i)] for i in self.drop_idx]
+            ),
+            amp_dtype=self.amp_dtype,
+        )
+        sub._halo = halo_trim
+        sub._out_lat1d = lat1d[
+            i0:i1
+        ]  # bounding box interior (run rows minus halo) -> matches _trim
+        sub._out_lon1d = lon1d[j0:j1]
+        sub._min_domain_cells = (
+            self._min_domain_cells
+        )  # inherit the model floor (a per-call min_cells
+        # override is one-shot: it gates this crop but is not persisted onto the returned sub)
+        # Place the sub on the parent's current device: its own (sliced) buffers are otherwise built on
+        # the slice's device and would desync from the shared dit if the parent had been moved with .to().
+        return sub.to(self.center.device)
+
+    # ------------------------------------------------------------------ loading
+    @classmethod
+    def load_default_package(cls) -> Package:
+        """Load the default model package.
+
+        Returns
+        -------
+        Package
+            The default model package. The weights are not yet hosted, so the returned URL is a
+            placeholder; to load a local or custom bundle, pass your own ``Package`` to
+            :meth:`load_model` instead.
+        """
+        # TODO: PLACEHOLDER Hugging Face URL -- replace with the real repo once the package is uploaded.
+        return Package(
+            "hf://nvidia/earth2studio-interp-crps-dit",
+            cache_options={
+                "cache_storage": Package.default_cache("interp_crps_dit"),
+                "same_names": True,
+            },
+        )
+
+    @classmethod
+    @check_optional_dependencies()
+    def load_model(
+        cls,
+        package: Package,
+        px_model: PrognosticModel | None = None,
+        num_interp_steps: int = 6,
+        drop_variables: list[OptionalVariable] | None = None,
+        amp_dtype: torch.dtype | None = None,
+    ) -> PrognosticModel:
+        """Load from a package: the DiT checkpoint, normalization stats, and the invariant stack.
+
+        Parameters
+        ----------
+        package : Package
+            Package holding ``CRPSModel.mdlus``, ``set_phys.nc``, ``global_means.npy``,
+            ``global_stds.npy``.
+        px_model : PrognosticModel, optional
+            Base model producing the coarse trajectory (may be set later instead).
+        num_interp_steps : int, optional
+            Sub-steps per bracket (must divide the coarse gap in minutes), by default 6.
+        drop_variables : list[OptionalVariable] | None, optional
+            Optional variables the base does not supply (subset of ``sp, u100m, v100m, tcwv``); each is
+            expanded to center internally and omitted from the output. Default None. See the class
+            docstring for the full contract.
+        amp_dtype : torch.dtype | None, optional
+            DiT inference precision (``None`` = fp32; ``torch.bfloat16``/``torch.float16`` = autocast),
+            by default None.
+
+        Returns
+        -------
+        PrognosticModel
+            The loaded ``InterpCRPSDiT``.
+
+        Raises
+        ------
+        ValueError
+            If ``set_phys.nc`` latitude is not descending (90 -> -90) or an invariant channel is
+            non-finite, or if the normalization arrays are not exactly ``len(VARIABLES)`` finite
+            channels with strictly positive scales.
+        """
+        try:
+            package.resolve("config.json")  # HF tracking download statistics
+        except FileNotFoundError:
+            pass
+
+        dit = PhysicsNemoModule.from_checkpoint(package.resolve("CRPSModel.mdlus"))
+        dit.eval()
+
+        nvar = len(VARIABLES)
+        mean = np.load(package.resolve("global_means.npy")).reshape(-1)
+        std = np.load(package.resolve("global_stds.npy")).reshape(-1)
+        for name, arr in (("global_means.npy", mean), ("global_stds.npy", std)):
+            if arr.shape[0] != nvar:
+                raise ValueError(
+                    f"{name} must have {nvar} channels, got {arr.shape[0]}"
+                )
+            if not np.isfinite(arr).all():
+                raise ValueError(f"{name} contains non-finite values")
+        if not (std > 0).all():
+            raise ValueError(
+                "global_stds.npy must be strictly positive (nonzero scale)"
+            )
+        center = torch.as_tensor(mean.reshape(1, nvar, 1, 1), dtype=torch.float32)
+        scale = torch.as_tensor(std.reshape(1, nvar, 1, 1), dtype=torch.float32)
+
+        # Build the 12-channel static invariant stack from set_phys.nc, reproducing the training-time
+        # invariant ordering + normalization exactly. cos_zenith is appended live.
+        with xr.open_dataset(package.resolve("set_phys.nc")) as ds:
+            lat = np.asarray(ds["latitude"].values, dtype=np.float64)
+            lon = np.asarray(ds["longitude"].values, dtype=np.float64)
+            if lat[0] <= lat[-1]:
+                raise ValueError(
+                    "set_phys.nc latitude must be descending (90 -> -90) to match training"
+                )
+
+            def _get(v: str) -> np.ndarray:
+                a = ds[v]
+                a = a.isel(valid_time=0) if "valid_time" in a.dims else a
+                return np.asarray(a.values, dtype="float32")
+
+            h, w = len(lat), len(lon)
+            latr, lonr = np.deg2rad(lat), np.deg2rad(lon)
+            sin_lat = np.broadcast_to(np.sin(latr)[:, None], (h, w))
+            cos_lat = np.broadcast_to(np.cos(latr)[:, None], (h, w))
+            sin_lon = np.broadcast_to(np.sin(lonr)[None, :], (h, w))
+            cos_lon = np.broadcast_to(np.cos(lonr)[None, :], (h, w))
+            chans = [
+                sin_lat,
+                cos_lat,
+                sin_lon,
+                cos_lon,
+                _znorm(_get("lsm")),
+                _znorm(_get("z")),
+            ]
+            chans += [_znorm(_get(v)) for v in PHYS_EXTRA]
+            static = np.stack(
+                [np.asarray(c, dtype="float32") for c in chans]
+            )  # (12, H, W)
+            lat2d: np.ndarray
+            lon2d: np.ndarray
+            lon2d, lat2d = np.meshgrid(lon, lat)  # (H, W)
+
+        # 721 -> 720 crop (drop the -90 row) to match the training grid, if needed. order is
+        # order matters here: _znorm above ran on the full nc grid, then we crop -- matching training (which
+        # z-scores on the native grid). Do not crop before _znorm (would shift the invariant stats).
+        static = static[:, :_TRAIN_LAT, :]
+        lat2d, lon2d = lat2d[:_TRAIN_LAT, :], lon2d[:_TRAIN_LAT, :]
+        if not np.isfinite(static).all():
+            raise ValueError("non-finite invariant channel(s) in set_phys.nc")
+
+        model = cls(
+            dit,
+            center=center,
+            scale=scale,
+            static_inv=torch.as_tensor(static, dtype=torch.float32),
+            lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+            lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+            px_model=px_model,
+            num_interp_steps=num_interp_steps,
+            drop_variables=drop_variables,
+            amp_dtype=amp_dtype,
+        )
+        # Derive the sub-domain per-side floor from the arch (largest attention kernel x patch, so the
+        # neighborhood-attention kernel fits the latent grid). Best-effort: keep the default if the
+        # DiT does not expose ``attn_kernel``.
+        kernels = [
+            int(v)
+            for m in dit.modules()
+            if (k := getattr(m, "attn_kernel", None)) is not None
+            for v in (k if isinstance(k, (tuple, list)) else (k,))
+        ]
+        if kernels:
+            model._min_domain_cells = max(kernels) * max(dit.patch_size)
+        return model
+
+    # ------------------------------------------------------------------ internals
+    def _cpad(self, x: torch.Tensor) -> torch.Tensor:
+        # Circular longitude pad by ``lon_pad`` columns (identity when 0). Genuinely periodic for any pad
+        # width via modulo indexing -- a slice-based pad would clamp (and later crop to zero) when lon_pad
+        # exceeds the grid width. Output width is ``W + 2 * lon_pad``; matches the slice form for pad <= W.
+        p = self.lon_pad
+        if p == 0:
+            return x
+        idx = torch.arange(-p, x.shape[-1] + p, device=x.device) % x.shape[-1]
+        return x[..., idx]
+
+    def _trim(self, x: torch.Tensor) -> torch.Tensor:
+        # Trim the sub-domain halo border off a run-grid frame (last two dims); identity with no halo.
+        top, bot, left, right = self._halo
+        if not (top or bot or left or right):
+            return x
+        h, w = x.shape[-2], x.shape[-1]
+        return x[..., top : h - bot, left : w - right]
+
+    def _dit_forward(self, x: torch.Tensor, tau: torch.Tensor) -> torch.Tensor:
+        # Resolution-rebind + precision-controlled DiT forward: bind the latent grid to this (H, W), then
+        # run the correction ``f`` under the configured autocast (fp32 unless ``amp_dtype`` is set).
+        # Rebind the RoPE/NATTEN latent grid + detokenizer patch counts for this (H, W) -- the only
+        # per-resolution state (no learnable weight depends on the grid). Mutates self.dit in place:
+        # instances sharing one DiT (e.g. sub-domains) must run sequentially, not concurrently.
+        ph, pw = self.dit.patch_size
+        # Fail fast on a non-patch-divisible grid: integer division would silently truncate the latent
+        # patch counts and misalign the detokenizer (load_model's crop and set_domain's snapping keep it aligned).
+        if x.shape[-2] % ph != 0 or x.shape[-1] % pw != 0:
+            raise ValueError(
+                f"grid {tuple(x.shape[-2:])} not divisible by patch_size {(ph, pw)}"
+            )
+        lh, lw = x.shape[-2] // ph, x.shape[-1] // pw
+        det = getattr(self.dit.detokenizer, "proj", self.dit.detokenizer)
+        det.h_patches, det.w_patches = lh, lw
+        # Precision: fp32 by default (disable any ambient autocast). If amp_dtype is set, run the forward
+        # under autocast at that dtype: weights stay fp32 and autocast downcasts eligible ops, so no checkpoint
+        # recast is needed (the linear base and envelope pin in _sample_tau run in fp32).
+        ctx = (
+            torch.autocast(device_type=x.device.type, enabled=False)
+            if self.amp_dtype is None
+            else torch.autocast(device_type=x.device.type, dtype=self.amp_dtype)
+        )
+        with ctx:
+            return self.dit(
+                x.float(),
+                tau.float(),
+                condition=None,
+                attn_kwargs={"latent_hw": (lh, lw)},
+            )
+
+    def _draw_noise(
+        self, b: int, h: int, w: int, device: torch.device, dtype: torch.dtype
+    ) -> torch.Tensor:
+        # Batched multi-scale latent (b, n_noise, H, W): draw-larger-then-valid-blur per scale so the
+        # variance is spatially stationary. Members are drawn independently from an advancing generator --
+        # the per-device generator seeded by ``self.seed`` if set (reproducible), else the global RNG
+        # (which E2S ensemble pipelines seed upstream); either way distinct members, no cross-chunk
+        # collision. Longitude-periodic when lon_pad>0 so the circular pad wraps near-continuously.
+        periodic = self.lon_pad > 0
+        gen = None
+        if (
+            self.seed is not None
+        ):  # per-device generator that advances across draws (see docstring)
+            if self._gen is None or self._gen.device != torch.device(device):
+                self._gen = torch.Generator(device=device)
+                self._gen.manual_seed(self.seed)
+            gen = self._gen
+        chans = []
+        for scale in self.noise_scales:
+            sigma = scale / 2.0
+            r = _gaussian_radius(sigma)
+            if periodic:
+                noise = torch.randn(
+                    b,
+                    1,
+                    h + 2 * r,
+                    w,
+                    device=device,
+                    dtype=torch.float32,
+                    generator=gen,
+                )
+                idx = torch.arange(-r, w + r, device=device) % w
+                noise = noise[..., idx]
+            else:
+                noise = torch.randn(
+                    b,
+                    1,
+                    h + 2 * r,
+                    w + 2 * r,
+                    device=device,
+                    dtype=torch.float32,
+                    generator=gen,
+                )
+            chans.append(_gaussian_blur_valid(noise, sigma))
+        return torch.cat(chans, dim=1).to(dtype)
+
+    def _build_cond(
+        self,
+        when: datetime,
+        gap_val: float,
+        batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        # Build the DiT conditioning maps for one output frame -- the ``cond`` block that ``_sample_tau``
+        # concatenates with the endpoints and latent (``[x0, xT, cond, z]``) so the learned correction
+        # ``f`` is conditioned on geography, time, bracket width, and input presence (not just the two
+        # endpoints). Called once per emitted timestamp in ``_interpolate`` (cos_zenith is time-varying,
+        # so it must be rebuilt per frame rather than cached).
+        # Layout (batch, 87, H, W) = invariants(13: static 12 + live cos_zenith) + gap(1) + mask(73):
+        #   - invariants: static geography (sin/cos lat-lon, lsm, orog, physical fields), cos_zenith last
+        #   - gap: the coarse bracket width, normalized to (gap_h - 6)/3 (see gap_val in _interpolate)
+        #   - mask: ones, with dropped variables set to 0 so the DiT sees them as intentionally-absent
+        h, w = self.static_inv.shape[-2], self.static_inv.shape[-1]
+        cz = cos_zenith_angle(when, self._lon_np, self._lat_np)
+        cz = torch.as_tensor(
+            np.asarray(cz, dtype="float32"), device=device, dtype=dtype
+        )[None, None]
+        inv = torch.cat(
+            [
+                self.static_inv.to(dtype)[None].expand(batch, -1, -1, -1),
+                cz.expand(batch, -1, -1, -1),
+            ],
+            dim=1,
+        )  # (batch, 13, H, W) with cos_zenith last
+        gap = torch.full((batch, 1, h, w), float(gap_val), device=device, dtype=dtype)
+        mask = torch.ones(batch, len(self.variables), h, w, device=device, dtype=dtype)
+        if len(self.drop_idx):
+            mask[:, self.drop_idx] = 0.0
+        return torch.cat([inv, gap, mask], dim=1)
+
+    @torch.inference_mode()
+    def _sample_tau(
+        self,
+        x0n: torch.Tensor,
+        xTn: torch.Tensor,
+        cond: torch.Tensor,
+        tau: float,
+        z: torch.Tensor,
+    ) -> torch.Tensor:
+        # One interpolation at fraction ``tau`` for a normalized batch (B,73,H,W) with a given latent
+        # ``z`` (B,n_noise,H,W): circular-pad -> DiT -> envelope pin -> crop. Returns normalized.
+        p = self.lon_pad
+        x0p, xTp = self._cpad(x0n), self._cpad(xTn)
+        inp = torch.cat([x0p, xTp, self._cpad(cond), self._cpad(z)], dim=1)
+        taut = torch.full(
+            (x0n.shape[0],), float(tau), device=x0n.device, dtype=x0n.dtype
+        )
+        f = self._dit_forward(inp, taut)
+        t = taut.reshape(-1, 1, 1, 1)
+        out = (
+            (1.0 - t) * x0p + t * xTp + torch.sin(math.pi * t) * f
+        )  # envelope pin on padded grid
+        return out[..., p : p + x0n.shape[-1]] if p > 0 else out
+
+    def _pad_present_to_full(self, x_present: torch.Tensor) -> torch.Tensor:
+        # Expand a base frame carrying only the present variables back to the full variable set,
+        # filling dropped channels with their center so they normalize to zero for the DiT. Identity
+        # when nothing is dropped. Variable axis is dim -3 (batch, time, lead, var, lat, lon).
+        if not len(self.drop_idx):
+            return x_present
+        shape = list(x_present.shape)
+        shape[-3] = len(self.variables)
+        full = x_present.new_empty(shape)
+        full[..., self.present_idx, :, :] = x_present
+        full[..., self.drop_idx, :, :] = (
+            self.center[0, self.drop_idx]
+            .reshape(len(self.drop_idx), 1, 1)
+            .to(x_present.dtype)
+        )
+        return full
+
+    @torch.inference_mode()
+    def _interpolate(
+        self, x0: torch.Tensor, x1: torch.Tensor, coords: CoordSystem
+    ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
+        # Yield the interior sub-steps between two coarse (physical-unit) states x0, x1. One latent per
+        # (ensemble member, init time) is drawn per bracket and reused across sub-steps (coherent).
+        # Dropped channels arrive center-filled from _pad_present_to_full, so they normalize to zero here
+        # (training-consistent) with no explicit masking needed.
+        x0n = (x0 - self.center) / self.scale
+        x1n = (x1 - self.center) / self.scale
+        gap_min = self._gap_minutes()
+        gap_val = (gap_min / 60.0 - 6.0) / 3.0
+        step_min = gap_min // self.num_interp_steps
+        base_lead = coords["lead_time"][-1]
+        nt = x0n.shape[1]  # number of init times
+        b, hh, ww = len(coords["batch"]), x0n.shape[-2], x0n.shape[-1]
+        # One latent per (member, init time), drawn once per bracket and reused across sub-steps so a
+        # member's interior stays temporally coherent. Drawing (b*nt) members keeps distinct init times'
+        # noise independent; z[:, ti] then selects time ti's per-member latent. (nt==1 is the common case
+        # and draws identically to a plain (b) draw.)
+        z = self._draw_noise(b * nt, hh, ww, x0n.device, x0n.dtype).reshape(
+            b, nt, -1, hh, ww
+        )
+        for interp_step in range(1, self.num_interp_steps):
+            tau = interp_step / self.num_interp_steps
+            # Sub-step coords: advance lead from the bracket start; report the trimmed output grid. Built
+            # directly (not via output_coords) so the interior runs on the run grid (incl. the halo border)
+            # while the emitted frame is the trimmed bounding box -- no per-step re-handshake against the run grid.
+            sub = OrderedDict(coords)
+            sub["lead_time"] = np.array(
+                [base_lead + np.timedelta64(step_min * interp_step, "m")]
+            )
+            sub["variable"] = np.array(self.present_variables)
+            sub["lat"] = np.asarray(self._out_lat1d, dtype=np.float64)
+            sub["lon"] = np.asarray(self._out_lon1d, dtype=np.float64)
+            out = torch.zeros_like(x0n)
+            # x0n is (batch, time, lead, var, H, W). The base px_model emits one frame per step, so the
+            # lead dim is always 1 and the inner `lti` loop runs once (not a general multi-lead sweep).
+            # `batch` is the ensemble dim; `z[:, ti]` gives each init time `ti` its own per-member latent,
+            # so multiple init times get independent noise while a member stays coherent across the bracket.
+            for ti, t in enumerate(sub["time"]):
+                for lti, lt in enumerate(sub["lead_time"]):
+                    when = datetime.fromisoformat(str(t + lt)[:19])
+                    cond = self._build_cond(when, gap_val, b, x0n.device, x0n.dtype)
+                    out[:, ti, lti] = self._sample_tau(
+                        x0n[:, ti, lti], x1n[:, ti, lti], cond, tau, z[:, ti]
+                    )
+            emitted = self._trim(out * self.scale + self.center)
+            if len(self.drop_idx):  # emit only the present (non-dropped) variables
+                emitted = emitted[..., self.present_idx, :, :]
+            yield (emitted, sub)
+
+    # ------------------------------------------------------------------ public
+    @batch_func()
+    def __call__(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """Run one step: return the initial condition (step 0).
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor.
+        coords : CoordSystem
+            Input coordinate system.
+
+        Returns
+        -------
+        tuple[torch.Tensor, CoordSystem]
+            The initial-condition frame and its coordinate system.
+        """
+        return next(self._default_generator(x, coords))
+
+    @batch_func()
+    def _default_generator(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
+        if self.px_model is None:
+            raise ValueError(
+                "Base model, px_model, must be set before executing the model."
+            )
+        x0 = None
+        coords0: CoordSystem | None = None
+        # Reconcile each base frame onto the run grid: map_coords crops the common
+        # 721-lat base grid to the model's 720 (a contiguous slice), or a global base to a sub-domain
+        # bounding box+halo, so a standard 0.25 deg prognostic can drive the interpolator. x_run keeps
+        # the run grid the interior interpolation needs (incl. the halo border); a second map_coords then
+        # slices it to the trimmed output grid for emission (keeping the base lead_time verbatim).
+        run_target = OrderedDict(
+            {
+                "variable": np.array(self.present_variables),
+                "lat": np.asarray(self._lat1d, dtype=np.float64),
+                "lon": np.asarray(self._lon1d, dtype=np.float64),
+            }
+        )
+        for fc_step, (x, coords) in enumerate(self.px_model.create_iterator(x, coords)):
+            # front_hook transforms each incoming base frame before it drives the bracket. It feeds both
+            # the emitted endpoint and the anchor (x0) carried into the next bracket, so a hooked input
+            # stays consistent across the rollout.
+            x, coords = self.front_hook(x, coords)
+            if fc_step == 0 and not (
+                np.all(np.isin(self._lat1d, coords["lat"]))
+                and np.all(np.isin(self._lon1d, coords["lon"]))
+            ):
+                # The run grid is not a subset of the base grid, so map_coords will nearest-regrid rather
+                # than crop -- a signal the base is not the expected 0.25 deg grid (still runs, ERA5-trained).
+                warnings.warn(
+                    "px_model grid does not contain the model run grid; the base is being nearest-regridded "
+                    "onto it (expected an exact 0.25 deg grid). Interpolation proceeds but may be degraded.",
+                    stacklevel=2,
+                )
+            # Map only the present (non-dropped) variables from the base, then expand back to the full
+            # variable set with center at the dropped positions (normalized zero for the DiT). The base
+            # therefore need only supply VARIABLES minus drop_variables (e.g. a 69-variable model).
+            x_present, coords_present = map_coords(x, coords, run_target)
+            x_run = self._pad_present_to_full(x_present)
+            coords_run = OrderedDict(coords_present)
+            coords_run["variable"] = np.array(self.variables)
+            # Crop the run-grid frame down to the trimmed output grid to emit the coarse endpoint.
+            # The output_coords(...) target does two things:
+            #   1. gives map_coords the output grid to crop to (variable + _out_lat1d/lon), and
+            #   2. as a side effect, validates the gap (raises if not divisible by num_interp_steps,
+            #      warns if outside the trained 3-10 h range).
+            # output_coords also advances lead_time, but that does not matter: map_coords ignores
+            # lead_time, so emit_coords keeps the frame's original (coarse-endpoint) lead_time.
+            x_emit, emit_coords = map_coords(
+                x_run, coords_run, self.output_coords(coords_run)
+            )
+            # rear_hook: transform each emitted frame just before yield. It acts only on the emitted
+            # tensor (x_emit / interior xo), never on x_run, so the interpolation anchor (x0) stays
+            # unhooked and the rollout state cannot be corrupted by an output-modifying hook.
+            if fc_step == 0:
+                x0, coords0 = x_run, coords_run
+                yield self.rear_hook(x_emit, emit_coords)
+            else:
+                for xo, co in self._interpolate(x0, x_run, coords0):
+                    yield self.rear_hook(xo, co)
+                # the coarse endpoint, trimmed to the output grid
+                yield self.rear_hook(x_emit, emit_coords)
+                x0, coords0 = x_run, coords_run
+
+    def create_iterator(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> Iterator[tuple[torch.Tensor, CoordSystem]]:
+        """Time-integrating iterator: yield the initial condition, then the interpolated sub-steps.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor.
+        coords : CoordSystem
+            Input coordinate system.
+
+        Yields
+        ------
+        tuple[torch.Tensor, CoordSystem]
+            Each emitted frame (verbatim endpoints + interpolated interior) and its coordinate system.
+        """
+        yield from self._default_generator(x, coords)

--- a/earth2studio/models/px/interpcrpsdit.py
+++ b/earth2studio/models/px/interpcrpsdit.py
@@ -146,8 +146,9 @@ def _gaussian_radius(sigma: float) -> int:
 
 def _gaussian_blur_valid(x: torch.Tensor, sigma: float) -> torch.Tensor:
     # Valid (no-pad) separable Gaussian blur; ``x`` must be oversized by the kernel radius on each side.
-    # Divides by the analytic ``sum(k*k)`` so unit-variance white noise stays unit-variance (stationary
-    # variance, no reflect-pad edge artifact). Reproduces the noise generator used at training.
+    # The separable blur multiplies the marginal (per-pixel) variance of white noise by S**2 (each of the
+    # two orthogonal 1D passes contributes a factor S = sum(k**2)); dividing by S restores unit marginal
+    # variance -- stationary, no reflect-pad edge artifact. Reproduces the noise generator used at training.
     r = _gaussian_radius(sigma)
     t = torch.arange(-r, r + 1, device=x.device, dtype=x.dtype)
     k = torch.exp(-0.5 * (t / sigma) ** 2)

--- a/earth2studio/models/px/interpcrpsdit.py
+++ b/earth2studio/models/px/interpcrpsdit.py
@@ -192,6 +192,8 @@ class InterpCRPSDiT(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
     Warning
     -------
+    The model weights are not yet hosted, so :meth:`load_default_package` returns a placeholder URL that
+    fails to download; pass your own local ``Package`` to :meth:`load_model` until they are published.
     A base forecast/reanalysis model must be set (``px_model`` / :meth:`load_model`) before running. Its
     coarse step must be divisible by ``num_interp_steps``; a step outside the trained 3-10 h range only
     warns (off-distribution, but still run). The DiT runs in fp32 by default; ``amp_dtype`` runs its
@@ -624,14 +626,23 @@ class InterpCRPSDiT(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     def load_default_package(cls) -> Package:
         """Load the default model package.
 
+        .. warning::
+            The model weights are **not yet hosted**: the returned package points at a placeholder
+            Hugging Face URL, so downloading it (e.g. via :meth:`load_model`) will fail until the weights
+            are published. Until then, pass your own local ``Package`` to :meth:`load_model` instead.
+
         Returns
         -------
         Package
-            The default model package. The weights are not yet hosted, so the returned URL is a
-            placeholder; to load a local or custom bundle, pass your own ``Package`` to
-            :meth:`load_model` instead.
+            The default model package (placeholder URL; see the warning above).
         """
         # TODO: PLACEHOLDER Hugging Face URL -- replace with the real repo once the package is uploaded.
+        warnings.warn(
+            "InterpCRPSDiT weights are not yet hosted: load_default_package() returns a placeholder "
+            "Hugging Face URL that will fail to download. Pass a local Package(...) to load_model() "
+            "until the weights are published.",
+            stacklevel=2,
+        )
         return Package(
             "hf://nvidia/earth2studio-interp-crps-dit",
             cache_options={

--- a/examples/02_medium_range/07_crps_temporal_interpolation.py
+++ b/examples/02_medium_range/07_crps_temporal_interpolation.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# %%
+"""
+Probabilistic Temporal Interpolation (CRPS DiT)
+===============================================
+
+Ensemble temporal interpolation with the ``InterpCRPSDiT`` model.
+
+Where :py:class:`~earth2studio.models.px.InterpModAFNO` produces a single deterministic sub-hourly
+trajectory, ``InterpCRPSDiT`` is a probabilistic (ensemble) interpolator. For each gap between two
+coarse frames it reproduces the two endpoints exactly and fills in the frames between them with a
+learned correction scaled by a ``sin(pi tau)`` envelope that vanishes at the endpoints; every ensemble
+member draws its own random latent, so members coincide at the shared endpoints and diverge through the
+interior; the ``sin(pi tau)`` envelope weights the learned correction toward the middle of the gap,
+where the pinned endpoints constrain the field least.
+It was trained with CRPS, a score that rewards ensemble spread that reflects forecast uncertainty.
+
+Because that spread is produced by the model itself, we drive it with
+:py:func:`earth2studio.run.ensemble` and a :py:class:`~earth2studio.perturbation.Zero` (no-op)
+perturbation -- all members share one initial condition and the diversity comes entirely from the
+model. ``run.ensemble``'s ``batch_size`` then caps GPU memory by running members in chunks, so peak GPU
+memory is set by the chunk size rather than the total ensemble size (output storage and runtime still
+scale with the member count).
+
+In this example you will learn:
+
+- Replay an ERA5 trajectory as the coarse input via ``DataReplay``
+- Produce a many-member ensemble from a single initial condition (the spread comes from the model)
+- Use ``run.ensemble(batch_size=...)`` to keep peak GPU memory bounded as the ensemble grows
+- Compare the mid-gap ensemble against the ERA5 reference field
+- Zoom into a region with ``set_domain`` and go to 15-min output -- hurricane central-pressure tracks
+  for three storms vs hourly ERA5
+- Wrap a forecast model (SFNO) instead of a reanalysis replay
+
+.. note::
+
+   ``InterpCRPSDiT`` weights are not yet hosted
+   (:meth:`~earth2studio.models.px.InterpCRPSDiT.load_default_package` returns a placeholder
+   URL). To run this before they are hosted, load a local bundle instead of the default package --
+   replace the ``load_default_package()`` call below with ``Package("/path/to/bundle")``
+   (``from earth2studio.models.auto import Package``).
+"""
+# /// script
+# dependencies = [
+#   "torch==2.11.0", # Pinned for torch-harmonics compatibility
+#   "earth2studio[sfno,interp-crps-dit] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "matplotlib",
+# ]
+# ///
+
+# %%
+# Set Up
+# ------
+# We use ARCO ERA5 as the data source so that (a) the replayed bracket endpoints are ERA5 reference states
+# and (b) we have the ERA5 reference mid-bracket (3 h) field to validate against. ARCO is on the 721-lat native
+# grid and the model uses 720 lat (it drops the -90 pole row), but the interpolator reconciles any
+# 0.25 deg base onto its own grid internally, so we point ``DataReplay`` straight at ARCO on its native
+# grid -- no manual regridding.
+#
+# This example needs the following:
+#
+# - Interpolation Model: :py:class:`earth2studio.models.px.InterpCRPSDiT`.
+# - Base trajectory: :py:class:`earth2studio.models.px.DataReplay` over ARCO ERA5.
+# - Datasource: :py:class:`earth2studio.data.ARCO`.
+# - Perturbation: :py:class:`earth2studio.perturbation.Zero` (spread comes from the model, not the IC).
+
+# %%
+import os
+from collections import OrderedDict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from earth2studio.data import ARCO
+from earth2studio.io import ZarrBackend
+from earth2studio.models.px import SFNO, DataReplay, InterpCRPSDiT
+from earth2studio.models.px.interpcrpsdit import VARIABLES
+from earth2studio.perturbation import Zero
+from earth2studio.run import ensemble
+
+os.makedirs("outputs", exist_ok=True)
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+# Load the interpolator and wrap a DataReplay over ARCO ERA5 (6 h coarse step -> hourly output), on
+# ARCO's native grid. The interpolator crops the 721-lat base to its own 720-lat grid internally.
+# We run the DiT in bf16 (``amp_dtype``): the forward runs under bf16 autocast (weights stay fp32;
+# autocast downcasts eligible operations), which can reduce activation memory. The linear base + endpoint
+# pin still run in fp32, so the emitted coarse frames are unchanged. Drop ``amp_dtype`` for the fp32 default if you have the memory.
+data = ARCO()
+replay = DataReplay(
+    data, VARIABLES, OrderedDict(lat=data.ARCO_LAT, lon=data.ARCO_LON), step=6
+)
+package = InterpCRPSDiT.load_default_package()
+model = (
+    InterpCRPSDiT.load_model(
+        package, px_model=replay, num_interp_steps=6, amp_dtype=torch.bfloat16
+    )
+    .to(device)
+    .eval()
+)
+
+t0 = np.datetime64(
+    "2005-08-28T12:00:00"
+)  # global/SFNO snapshot time (also Katrina's Gulf bracket below)
+
+# %%
+# Global Ensemble Over One 6 h Bracket
+# ------------------------------------
+# Interpolate the 12Z -> 18Z bracket to hourly for a 4-member ensemble. The ``Zero`` perturbation
+# leaves every member's initial condition identical, so the spread is produced entirely by the
+# model's per-member latent. ``batch_size=1`` runs the members one at a time, so peak VRAM is
+# independent of the ensemble size. We then compare the 3 h ensemble against the ERA5 reference field.
+
+# %%
+nmembers = 4
+io = ensemble(
+    [t0],
+    6,
+    nmembers,
+    model,
+    data,
+    ZarrBackend(),
+    Zero(),
+    batch_size=1,
+    output_coords={"variable": np.array(["tcwv"])},
+    device=device,
+)
+# io dims: (ensemble, time, lead_time, lat, lon); hourly leads 0..6 h, so index 3 is the 3 h midpoint.
+# tcwv (total column water vapour) has fine filamentary structure that
+# shows the interpolation quality far better than a smooth field such as t2m.
+members_mid = np.asarray(io["tcwv"])[
+    :, 0, 3
+]  # (nmembers, 720, 1440) on the model's 720-lat grid
+# ERA5 reference on the same 720 grid: ARCO's 721 lat with the -90 pole row dropped (== the model grid).
+truth_mid = np.asarray(data(np.array([t0 + np.timedelta64(3, "h")]), ["tcwv"]).values)[
+    0, 0, :720
+]
+
+fig, axs = plt.subplots(2, 3, figsize=(15, 6))
+vmin, vmax = float(truth_mid.min()), float(truth_mid.max())
+panels = [("ERA5 reference (3 h)", truth_mid), ("Ensemble mean", members_mid.mean(0))]
+panels += [(f"Member {m}", members_mid[m]) for m in range(nmembers)]
+for ax, (title, fld) in zip(axs.ravel(), panels):
+    # interpolation="none": show pixels 1:1 (no antialias/blur); the PNG below is lossless.
+    im = ax.imshow(
+        fld, cmap="turbo", vmin=vmin, vmax=vmax, aspect="auto", interpolation="none"
+    )
+    ax.set_title(title)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    fig.colorbar(im, ax=ax, fraction=0.025, label="tcwv [kg m$^{-2}$]")
+plt.tight_layout()
+plt.savefig("outputs/07_global_midpoint_ensemble.png", dpi=200)
+
+# %%
+# Regional Sub-Domain: Sub-Hourly Central-Pressure Ensembles for Three Hurricanes
+# -------------------------------------------------------------------------------
+# ``set_domain`` slices the invariant stack + output grid to a bounding box and returns a new model that
+# shares the network; the DiT runs on the cropped grid in a single forward pass. We go sub-hourly
+# (15-min output) and sweep three US-Gulf-Coast landfalling hurricanes through
+# the same box, tracking each storm's central pressure (min MSLP over the patch). We reuse the global
+# ``replay`` unchanged -- the interpolator crops each global frame to the bounding box for us. The ensemble is
+# pinned to the 6-hourly ERA5 endpoints; the hourly ERA5 points in between are the
+# reference for whether the 15-min curve tracks the reference deepening.
+
+# %%
+# halo=32: a wide (8 deg) border of extra cells that set_domain trims off the output, which pushes the
+# non-periodic sub-domain edge farther from the returned storm area.
+sub = model.set_domain(
+    lat_min=18.0, lat_max=34.0, lon_min=262.0, lon_max=284.0, halo=32
+)
+sub.num_interp_steps = 24  # small sub-domain -> sub-hourly: 6 h / 24 = 15 min output
+# set_domain already carries over the global replay as sub.px_model, so no reassignment is needed.
+
+# Each storm: a 6 h bracket over its Gulf rapid-intensification / landfall.
+storms = {
+    "Ida (2021)": np.datetime64("2021-08-29T12:00:00"),
+    "Michael (2018)": np.datetime64("2018-10-10T12:00:00"),
+    "Katrina (2005)": np.datetime64("2005-08-28T12:00:00"),
+}
+nmembers_tc = 16
+fig, axs = plt.subplots(1, 3, figsize=(18, 5), sharex=True)
+for ax, (name, storm_t0) in zip(axs, storms.items()):
+    io_tc = ensemble(
+        [storm_t0],
+        sub.num_interp_steps,
+        nmembers_tc,
+        sub,
+        data,
+        ZarrBackend(),
+        Zero(),
+        batch_size=4,
+        output_coords={"variable": np.array(["msl"])},
+        device=device,
+    )
+    central = (np.asarray(io_tc["msl"])[:, 0] / 100.0).min(
+        axis=(-2, -1)
+    )  # (nmembers, lead)
+    lead_h = np.asarray(io_tc.coords["lead_time"]) / np.timedelta64(
+        1, "h"
+    )  # 0, 1/4, ..., 6 h
+    out_lat, out_lon = np.asarray(io_tc.coords["lat"]), np.asarray(
+        io_tc.coords["lon"]
+    )  # bounding box
+    # ERA5 reference central pressure over the same patch. ERA5 is hourly, so the reference exists only at whole hours
+    # -- 0 h/6 h are pinned exactly, and the hourly points test the 15-min curve in between.
+    truth_h = np.arange(7)
+    truth_times = np.array([storm_t0 + np.timedelta64(int(h), "h") for h in truth_h])
+    truth_da = data(truth_times, ["msl"]).sel(
+        lat=out_lat, lon=out_lon, method="nearest"
+    )
+    truth_central = (np.asarray(truth_da.values)[:, 0] / 100.0).min(axis=(-2, -1))
+
+    for m in range(
+        nmembers_tc
+    ):  # each member: line + a fine x-marker at every 15-min sample
+        ax.plot(
+            lead_h, central[m], color="C0", lw=0.8, alpha=0.4, marker="x", ms=3, mew=0.6
+        )
+    ax.plot(
+        [],
+        [],
+        color="C0",
+        lw=0.8,
+        marker="x",
+        ms=3,
+        label=f"members (n={nmembers_tc}, 15-min)",
+    )
+    ax.plot(lead_h, central.mean(0), color="C1", lw=2.5, label="ensemble mean")
+    ax.plot(
+        truth_h, truth_central, "ko", ms=6, zorder=5, label="ERA5 reference (hourly)"
+    )
+    ax.set_title(name)
+    ax.set_xlabel("lead time [h]")
+    ax.grid(alpha=0.3)
+    ax.legend(fontsize=8)
+axs[0].set_ylabel("min MSLP over patch [hPa]")
+plt.tight_layout()
+plt.savefig("outputs/07_tc_central_pressure.png", dpi=150)
+
+# %%
+# Wrapping a Forecast Model (SFNO) Instead of a Replay
+# ----------------------------------------------------
+# The base model need not be a reanalysis replay -- any 0.25 deg prognostic model that supplies the required input variables and a coarse step divisible by ``num_interp_steps`` works.
+# Here we reuse the same interpolator and just swap in SFNO as the base to interpolate its 6 h forecast
+# to hourly. SFNO runs on its native 721-lat grid; the interpolator reconciles each SFNO frame onto its
+# own 720-lat grid (it drops the -90 pole row), so no manual regridding is needed.
+#
+# .. warning::
+#
+#    ``InterpCRPSDiT`` was trained on ERA5. The bracket endpoints are the verbatim base-model states
+#    (correct for any base); the learned interior is applied here on a forecast trajectory, so the
+#    inputs differ from the ERA5 training data.
+
+# %%
+sfno = SFNO.load_model(SFNO.load_default_package()).to(device).eval()
+model.px_model = (
+    sfno  # reuse the Part A interpolator; just swap the base model (no second DiT load)
+)
+
+io_sfno = ensemble(
+    [t0],
+    6,
+    nmembers,
+    model,
+    data,
+    ZarrBackend(),
+    Zero(),
+    batch_size=1,
+    output_coords={"variable": np.array(["tcwv"])},
+    device=device,
+)
+sfno_mid = np.asarray(io_sfno["tcwv"])[
+    :, 0, 3
+]  # 3 h midpoint tcwv, (nmembers, 720, 1440)
+vmin, vmax = float(sfno_mid.min()), float(sfno_mid.max())  # shared scale across panels
+fig, axs = plt.subplots(1, 3, figsize=(15, 4))
+for ax, (title, fld) in zip(
+    axs,
+    [
+        ("SFNO interp mean (3 h)", sfno_mid.mean(0)),
+        ("Member 0", sfno_mid[0]),
+        ("Member 1", sfno_mid[1]),
+    ],
+):
+    im = ax.imshow(
+        fld, cmap="turbo", vmin=vmin, vmax=vmax, aspect="auto", interpolation="none"
+    )
+    ax.set_title(title)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    fig.colorbar(im, ax=ax, fraction=0.025, label="tcwv [kg m$^{-2}$]")
+plt.tight_layout()
+plt.savefig("outputs/07_sfno_interp_ensemble.png", dpi=200)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,11 @@ graphcast = [
     "dm-tree>=0.1.9",
     "xarray<2026.4.0", # https://github.com/google-deepmind/graphcast/issues/213
 ]
+interp-crps-dit = [
+    # 2.2.0 is the first release with natten2d_rope + proj_reshape_2d_conv (PR #1731).
+    "natten ; python_version < '3.14'",
+    "nvidia-physicsnemo>=2.2.0",
+]
 interp-modafno = [
     "nvidia-physicsnemo>=2.0",
 ]
@@ -279,6 +284,9 @@ da-stormcast = [
     "cudf-cu13>=26.2.0",
 ]
 # All, must not have conflicts
+# NOTE: `interp-crps-dit` is intentionally excluded here. It needs nvidia-physicsnemo>=2.2.0, which
+# conflicts with the <=2.1.1 cap `da-healda` imposes on `all`. TODO(interp-crps-dit): add it back
+# once `da-healda` also moves to physicsnemo>=2.2.0 (or its cap is lifted).
 all = [
     "earth2studio[data,perturbation,statistics,utils,serve]",
     "earth2studio[atlas,aurora,dlesym,dlwp,fcn,fcn3,fengwu,gencast,interp-modafno,pangu,stormcast,sfno,stormscope,graphcast,ucast]",
@@ -289,6 +297,17 @@ all = [
 # ==== UV configuration ====
 [tool.uv]
 conflicts = [
+  [
+    # interp-crps-dit needs physicsnemo>=2.2.0; da-healda caps it at <=2.1.1 (and `all` pulls da-healda).
+    { extra = "interp-crps-dit" },
+    { extra = "da-healda" },
+  ],
+  [
+    # interp-crps-dit's physicsnemo>=2.2.0 also conflicts with `all`, which pulls in da-healda and its
+    # physicsnemo <=2.1.1 cap.
+    { extra = "interp-crps-dit" },
+    { extra = "all" },
+  ],
   [
     { extra = "ace2" },
     { extra = "atlas" },

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,6 +96,7 @@ _TEST_DEPENDENCIES: dict[str, list[str]] = {
     "test/models/px/test_fuxi.py": ["fuxi"],
     "test/models/px/test_gencast_mini.py": ["gencast"],
     "test/models/px/test_graphcast.py": ["graphcast"],
+    "test/models/px/test_interpcrpsdit.py": ["interp-crps-dit"],
     "test/models/px/test_interpmodafno.py": ["interp-modafno"],
     "test/models/px/test_pangu.py": ["pangu"],
     "test/models/px/test_sfno.py": ["sfno"],

--- a/test/models/px/test_datareplay.py
+++ b/test/models/px/test_datareplay.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from earth2studio.models.px.datareplay import DataReplay
+
+H, W = 8, 16
+LAT = np.linspace(90, -90, H, endpoint=False)
+LON = np.linspace(0, 360, W, endpoint=False)
+VARS = ["t2m", "u10m", "z500"]
+Y0 = np.datetime64("2020-01-01T00:00:00")
+
+
+class HourSource:
+    """Synthetic in-memory DataSource: each frame is a constant field equal to hours-since-Y0 (nlat rows)."""
+
+    def __init__(self, nlat=H, fill=None):
+        self.nlat = nlat
+        self.fill = (
+            fill  # if set, return this value (e.g. np.nan) to test the finite guard
+        )
+
+    def __call__(self, time, variable):
+        times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+        variable = [variable] if isinstance(variable, str) else list(variable)
+        arr = np.zeros((len(times), len(variable), self.nlat, W), dtype="float32")
+        for i, t in enumerate(times):
+            arr[i] = (
+                self.fill
+                if self.fill is not None
+                else float((t - Y0) / np.timedelta64(1, "h"))
+            )
+        return xr.DataArray(
+            arr,
+            dims=["time", "variable", "lat", "lon"],
+            coords=dict(
+                time=times,
+                variable=np.array(variable),
+                lat=np.linspace(90, -90, self.nlat, endpoint=False),
+                lon=LON,
+            ),
+        )
+
+
+def _ic(src, t0):
+    x = torch.from_numpy(src(np.array([t0]), VARS).values.astype("float32"))[
+        None, :, None
+    ]  # (1,1,1,V,H,W)
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARS),
+        lat=LAT,
+        lon=LON,
+    )
+    return x, coords
+
+
+def test_datareplay_call():
+    # __call__ advances one step: fetch the source at time + lead_time + step.
+    src = HourSource()
+    replay = DataReplay(src, VARS, OrderedDict(lat=LAT, lon=LON), step=6)
+    t0 = Y0 + np.timedelta64(48, "h")
+    x, coords = _ic(src, t0)
+    xf, cf = replay(x, coords)
+    assert xf.shape == (1, 1, 1, len(VARS), H, W)
+    assert int(cf["lead_time"][-1] / np.timedelta64(1, "h")) == 6  # advanced one step
+    # source at t0 + 6h == valid hour 54 (whole constant field)
+    assert torch.allclose(xf, torch.full_like(xf, 54.0), atol=1e-4)
+
+
+@pytest.mark.parametrize("step_h", [3, 6])
+def test_datareplay_iter(step_h):
+    src = HourSource()
+    replay = DataReplay(src, VARS, OrderedDict(lat=LAT, lon=LON), step=step_h)
+    t0 = Y0 + np.timedelta64(48, "h")
+    x, coords = _ic(src, t0)
+    leads = []
+    # islice to exactly 3 frames (IC + 2 steps) so no extra fourth frame is fetched.
+    for k, (xf, cf) in enumerate(
+        itertools.islice(replay.create_iterator(x, coords), 3)
+    ):
+        leads.append(int(cf["lead_time"][-1] / np.timedelta64(1, "m")))
+        assert xf.shape == (1, 1, 1, len(VARS), H, W)
+        assert torch.isfinite(xf).all()
+        # whole field is constant == valid hour (checks every cell, not just the mean)
+        expected = 48.0 + k * step_h
+        assert torch.allclose(xf, torch.full_like(xf, expected), atol=1e-4)
+    assert leads == [0, step_h * 60, step_h * 120]
+
+
+def test_datareplay_grid_mismatch_raises():
+    replay = DataReplay(
+        HourSource(nlat=H + 1), VARS, OrderedDict(lat=LAT, lon=LON), step=6
+    )
+    x, coords = _ic(HourSource(), Y0 + np.timedelta64(48, "h"))
+    iterator = replay.create_iterator(x, coords)
+    next(iterator)  # initial condition (from a valid source) must not raise
+    with pytest.raises(ValueError, match="does not match"):
+        next(iterator)  # first fetch hits the mismatched source grid
+
+
+def test_datareplay_nonfinite_raises():
+    replay = DataReplay(
+        HourSource(fill=np.nan), VARS, OrderedDict(lat=LAT, lon=LON), step=6
+    )
+    x, coords = _ic(HourSource(), Y0 + np.timedelta64(48, "h"))
+    iterator = replay.create_iterator(x, coords)
+    next(iterator)  # initial condition (finite) must not raise
+    with pytest.raises(ValueError, match="non-finite"):
+        next(iterator)  # first fetch returns the NaN-filled field
+
+
+@pytest.mark.parametrize(
+    "step, expected",
+    [
+        (6, np.timedelta64(6, "h")),  # int hours
+        (6.0, np.timedelta64(6, "h")),  # float hours
+        (np.float32(6.0), np.timedelta64(6, "h")),  # numpy float hours
+        (np.timedelta64(6, "h"), np.timedelta64(6, "h")),  # timedelta64 verbatim
+        (
+            np.timedelta64(90, "m"),
+            np.timedelta64(90, "m"),
+        ),  # sub-hour td64 kept (numeric-only check)
+    ],
+)
+def test_datareplay_valid_step(step, expected):
+    dom = OrderedDict(lat=LAT, lon=LON)
+    assert DataReplay(HourSource(), VARS, dom, step=step).step == expected
+
+
+@pytest.mark.parametrize(
+    "step, exc, match",
+    [
+        (6.5, ValueError, "whole hours"),  # fractional numeric hours
+        (0, ValueError, "positive"),  # positivity boundary
+        (-1, ValueError, "positive"),  # negative
+        ("6h", TypeError, "step must be"),  # wrong type
+        # NaT is the timedelta NaN: it passes the timedelta64 type check, and NaT <= 0h is False (all
+        # NaT comparisons are False), so it needs an explicit isnat() guard, not the positivity check.
+        (np.timedelta64("NaT"), ValueError, "NaT"),
+        (True, TypeError, "step must be"),  # bool subclasses int
+        (float("nan"), ValueError, "finite"),  # NaN
+        (float("inf"), ValueError, "finite"),  # inf
+    ],
+)
+def test_datareplay_exceptions(step, exc, match):
+    # invalid step values / types raise
+    with pytest.raises(exc, match=match):
+        DataReplay(HourSource(), VARS, OrderedDict(lat=LAT, lon=LON), step=step)
+
+
+def test_datareplay_front_hook_applied():
+    # front_hook transforms the provided input; the step-0 IC (derived from it) reflects the change,
+    # while later frames are fetched fresh from the source and are not front-hooked.
+    replay = DataReplay(HourSource(), VARS, OrderedDict(lat=LAT, lon=LON), step=6)
+    x, coords = _ic(HourSource(), Y0 + np.timedelta64(48, "h"))
+    replay.front_hook = lambda a, c: (a + 50.0, c)
+    it = replay.create_iterator(x, coords)
+    ic, _ = next(it)  # IC = input (hour 48) + 50 from front_hook
+    assert torch.allclose(ic, torch.full_like(ic, 48.0 + 50.0), atol=1e-4)
+    nxt, _ = next(it)  # fetched fresh from the source (hour 54), not front-hooked
+    assert torch.allclose(nxt, torch.full_like(nxt, 54.0), atol=1e-4)
+
+
+def test_datareplay_rear_hook_applied():
+    # rear_hook transforms every emitted frame (the IC and each fetched frame); exact values (IC at
+    # hour 48, fetched at 54/60) confirm the offset lands on every frame, not just some.
+    replay = DataReplay(HourSource(), VARS, OrderedDict(lat=LAT, lon=LON), step=6)
+    x, coords = _ic(HourSource(), Y0 + np.timedelta64(48, "h"))
+    replay.rear_hook = lambda a, c: (a + 100.0, c)
+    frames = [xf for xf, _ in itertools.islice(replay.create_iterator(x, coords), 3)]
+    for xf, hour in zip(frames, [48.0, 54.0, 60.0]):
+        assert torch.allclose(xf, torch.full_like(xf, hour + 100.0), atol=1e-4)
+
+
+def test_datareplay_iter_coord_mismatch_raises():
+    # The iterator path validates input coords (variable order) up front, like __call__ and
+    # Persistence -- not just at the runtime _fetch grid check.
+    replay = DataReplay(HourSource(), VARS, OrderedDict(lat=LAT, lon=LON), step=6)
+    x, coords = _ic(HourSource(), Y0 + np.timedelta64(48, "h"))
+    coords["variable"] = np.array(VARS[::-1])  # reversed order -> handshake mismatch
+    with pytest.raises(ValueError, match="not the same"):
+        next(replay.create_iterator(x, coords))

--- a/test/models/px/test_interpcrpsdit.py
+++ b/test/models/px/test_interpcrpsdit.py
@@ -1,0 +1,1238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import types
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+import earth2studio.models.px.interpcrpsdit as interp_mod
+from earth2studio.models.auto import Package
+from earth2studio.models.px.datareplay import DataReplay
+from earth2studio.models.px.interpcrpsdit import (
+    OPTIONAL_VARIABLES,
+    PHYS_EXTRA,
+    VARIABLES,
+    InterpCRPSDiT,
+)
+
+# Small grid to keep the suite fast on CPU without weights or network access.
+H, W = 16, 32
+LAT = np.linspace(90, -90, H, endpoint=False)
+LON = np.linspace(0, 360, W, endpoint=False)
+Y0 = np.datetime64("2020-01-01T00:00:00")
+
+
+class PhooDiT(torch.nn.Module):
+    """Dummy DiT matching the physicsnemo-DiT interface InterpCRPSDiT calls. Returns a zero residual,
+    so with center=0/scale=1 the interpolated field is exactly the linear base.
+    """
+
+    patch_size = (2, 2)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.detokenizer = (
+            types.SimpleNamespace()
+        )  # _dit_forward sets .h_patches/.w_patches on it
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        return x.new_zeros(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+class PhooSource:
+    """Synthetic in-memory DataSource: each frame is a constant field equal to hours-since-Y0, so linear
+    interpolation of two frames has a known closed form."""
+
+    def __call__(self, time, variable):
+        times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+        variable = [variable] if isinstance(variable, str) else list(variable)
+        arr = np.zeros((len(times), len(variable), H, W), dtype="float32")
+        for i, t in enumerate(times):
+            arr[i] = float((t - Y0) / np.timedelta64(1, "h"))
+        return xr.DataArray(
+            arr,
+            dims=["time", "variable", "lat", "lon"],
+            coords=dict(time=times, variable=np.array(variable), lat=LAT, lon=LON),
+        )
+
+
+class GridSource:
+    """Source on an exact subset of the base lat/lon grid (for sub-domain px_models); ``lat``/``lon``
+    must be members of ``all_lat``/``all_lon`` (np.where needs exact matches). spatially varying: each
+    cell = hours-since-Y0 + row-index + 0.01*col-index, keyed to absolute lat/lon, so a mis-offset
+    trim of the correct size yields different values than the exact bounding-box sub-block.
+    """
+
+    def __init__(self, lat, lon, all_lat, all_lon):
+        self.lat, self.lon = np.asarray(lat), np.asarray(lon)
+        self.all_lat, self.all_lon = np.asarray(all_lat), np.asarray(all_lon)
+
+    def __call__(self, time, variable):
+        times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+        variable = [variable] if isinstance(variable, str) else list(variable)
+        # global row/col index of each of this grid's cells (absolute coordinate -> unique value)
+        ri = np.array(
+            [int(np.where(self.all_lat == v)[0][0]) for v in self.lat], dtype="float32"
+        )
+        ci = np.array(
+            [int(np.where(self.all_lon == v)[0][0]) for v in self.lon], dtype="float32"
+        )
+        field = (
+            ri[:, None] + 0.01 * ci[None, :]
+        )  # (nlat, nlon), distinct per absolute cell
+        arr = np.zeros(
+            (len(times), len(variable), len(self.lat), len(self.lon)), dtype="float32"
+        )
+        for i, t in enumerate(times):
+            arr[i] = float((t - Y0) / np.timedelta64(1, "h")) + field[None]
+        return xr.DataArray(
+            arr,
+            dims=["time", "variable", "lat", "lon"],
+            coords=dict(
+                time=times, variable=np.array(variable), lat=self.lat, lon=self.lon
+            ),
+        )
+
+
+class NoiseDiT(PhooDiT):
+    """Residual = mean of the 6 trailing noise channels (so the drawn latent z reaches the
+    output). Used by the ensemble/seed test to observe member spread + seed reproducibility.
+    """
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        z = x[:, -6:].mean(
+            1, keepdim=True
+        )  # DiT input = [x0(73), xT(73), cond(87), z(6)]
+        return z.expand(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+class AutocastProbeDiT(PhooDiT):
+    """Records whether autocast is active during the forward, so the amp test can assert amp_dtype
+    toggles autocast on/off."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.saw_autocast: bool | None = None
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        self.saw_autocast = torch.is_autocast_enabled(x.device.type)
+        return x.new_zeros(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+class GapCaptureDiT(PhooDiT):
+    """Captures the gap-conditioning channel (index 13 of the 87-ch cond block) as built during
+    create_iterator, so the gap-value test exercises the gap->gap_val derivation.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gap_seen: float | None = None
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        self.gap_seen = float(
+            x[:, 73 + 73 + 13].mean()
+        )  # cond starts at 146; gap is cond[13]
+        return x.new_zeros(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+def _build(
+    gap_h=6,
+    num_interp_steps=6,
+    lon_pad=0,
+    drop_variables=None,
+    seed=None,
+    amp_dtype=None,
+    dit=None,
+    device="cpu",
+    t0=None,
+):
+    t0 = t0 if t0 is not None else Y0 + np.timedelta64(120, "h")
+    src = PhooSource()
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=dit if dit is not None else PhooDiT(),
+        center=torch.zeros(1, len(VARIABLES), 1, 1),
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=DataReplay(src, VARIABLES, OrderedDict(lat=LAT, lon=LON), step=gap_h),
+        num_interp_steps=num_interp_steps,
+        lon_pad=lon_pad,
+        seed=seed,
+        drop_variables=drop_variables,
+        amp_dtype=amp_dtype,
+    ).to(device)
+    x0 = torch.from_numpy(src(np.array([t0]), VARIABLES).values.astype("float32")).to(
+        device
+    )[None, :, None]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=LAT,
+        lon=LON,
+    )
+    return model, x0, coords, float((t0 - Y0) / np.timedelta64(1, "h"))
+
+
+@pytest.mark.parametrize(
+    "gap_h, num_interp_steps",
+    [
+        (6, 6),
+        (6, 36),
+        (3, 3),
+        (10, 10),
+    ],  # gaps 3/6/10h x resolutions 1h/10min (3,3) & (10,10) = range edges
+)
+def test_interpcrpsdit_gap_and_resolution(gap_h, num_interp_steps):
+    model, x0, coords, h0 = _build(gap_h=gap_h, num_interp_steps=num_interp_steps)
+    step_min = gap_h * 60 // num_interp_steps
+    leads, frames = [], []
+    # islice to IC + one full bracket + first frame of the next (no extra fetch past the seam).
+    for k, (xf, cf) in enumerate(
+        itertools.islice(model.create_iterator(x0, coords), num_interp_steps + 2)
+    ):
+        leads.append(int(cf["lead_time"][-1] / np.timedelta64(1, "m")))
+        frames.append(xf)
+        assert xf.shape == (1, 1, 1, len(VARIABLES), H, W)
+        assert torch.isfinite(xf).all()
+    # hourly/sub-hourly ladder, no drift; endpoint at gap; and the coarse endpoint is verbatim source
+    assert leads == [step_min * k for k in range(len(leads))]
+    # coarse endpoint == source frame at t0 + gap (whole constant field == hour)
+    endpoint = frames[num_interp_steps]
+    assert torch.allclose(endpoint, torch.full_like(endpoint, h0 + gap_h), atol=1e-4)
+
+
+def test_interpcrpsdit_pin_linear_interior():
+    # Phoo residual f=0 + center0/scale1 => interior frame == linear interp of the two coarse frames.
+    model, x0, coords, h0 = _build(gap_h=6, num_interp_steps=6)
+    it = model.create_iterator(x0, coords)
+    next(it)  # IC (tau handled as verbatim)
+    x1, c1 = next(it)  # first interior sub-step, tau = 1/6
+    tau = 1 / 6
+    assert c1["lead_time"][-1] == np.timedelta64(1, "h")  # 6h gap / 6 steps = 1h
+    # whole interior field == linear interp of the two constant coarse frames
+    assert torch.allclose(x1, torch.full_like(x1, h0 + tau * 6.0), atol=1e-4)
+
+
+def test_interpcrpsdit_gap_channel_value():
+    # gap-conditioning channel = (gap_h - 6)/3, derived from the coarse step (not passed in):
+    # capture the cond the DiT actually receives during create_iterator.
+    for gap_h, expect in [(3, -1.0), (6, 0.0), (9, 1.0)]:
+        dit = GapCaptureDiT()
+        model, x0, coords, _ = _build(gap_h=gap_h, num_interp_steps=3, dit=dit)
+        it = model.create_iterator(x0, coords)
+        next(it)  # IC (no DiT call)
+        next(it)  # first interior -- calls the DiT, populating gap_seen
+        assert dit.gap_seen == pytest.approx(expect, abs=1e-6)
+
+
+def test_interpcrpsdit_indivisible_cadence_raises():
+    # num_interp_steps must divide the coarse gap (min) -- hard error regardless of range.
+    model, x0, coords, _ = _build(gap_h=6, num_interp_steps=7)
+    with pytest.raises(ValueError, match="must divide"):
+        next(model.create_iterator(x0, coords))  # gap validated at the first (IC) step
+
+
+@pytest.mark.parametrize("gap_h", [12, 2])  # above and below the trained 3-10h range
+def test_interpcrpsdit_out_of_range_warns_but_runs(gap_h):
+    # Out-of-range gaps are off-distribution: warn, but still run (divisible cadence, so no raise).
+    model, x0, coords, _ = _build(gap_h=gap_h, num_interp_steps=6)
+    it = model.create_iterator(x0, coords)
+    with pytest.warns(UserWarning, match="outside the trained"):
+        x_ic, _ = next(it)  # IC -- gap validated here
+        x_interior, _ = next(it)  # first interior -- interpolation actually runs
+    assert torch.isfinite(x_ic).all()
+    assert torch.isfinite(x_interior).all()
+
+
+def test_interpcrpsdit_drop_variables():
+    # Dropped optional channels are declared unavailable: the base need not supply them and they are NOT
+    # emitted -- the model outputs VARIABLES minus the dropped set, with the kept channels exact.
+    model, x0, coords, _ = _build(drop_variables=["sp", "tcwv"])
+    assert list(model.drop_idx) == [VARIABLES.index("sp"), VARIABLES.index("tcwv")]
+    present = [v for v in VARIABLES if v not in ("sp", "tcwv")]
+    it = model.create_iterator(x0, coords)
+    ic_x, ic_c = next(
+        it
+    )  # IC endpoint: present variables only (variable axis = dim -3)
+    assert list(ic_c["variable"]) == present
+    assert ic_x.shape[-3] == len(present)  # sp, tcwv not emitted
+    x1, c1 = next(it)  # first interior
+    assert list(c1["variable"]) == present
+    assert x1.shape[-3] == len(present)
+    assert torch.isfinite(x1).all()
+    assert torch.all(
+        x1 != 0
+    )  # every emitted channel carries the linear interp (nothing zeroed in output)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"num_interp_steps": 0}, "num_interp_steps"),  # invalid value
+        ({"amp_dtype": torch.float64}, "amp_dtype must be"),  # invalid value
+        (
+            {"drop_variables": ["z500"]},
+            "trained-optional",
+        ),  # invalid variable (non-optional)
+    ],
+)
+def test_interpcrpsdit_exceptions(kwargs, match):
+    # invalid constructor values / variables raise ValueError
+    with pytest.raises(ValueError, match=match):
+        _build(**kwargs)
+
+
+def test_interpcrpsdit_ensemble_and_seed():
+    # NoiseDiT routes the drawn latent z into the output, so this test covers seeding + spread.
+    def one(seed: int) -> torch.Tensor:
+        model, x0, coords, _ = _build(num_interp_steps=6, seed=seed, dit=NoiseDiT())
+        x = x0.repeat(3, 1, 1, 1, 1, 1)  # 3 ensemble members
+        c = OrderedDict(coords)
+        c["batch"] = np.arange(3)
+        it = model.create_iterator(x, c)
+        next(it)
+        xi, _ = next(it)  # first interior sub-step
+        return xi
+
+    seed0_a, seed0_b, seed1 = one(seed=0), one(seed=0), one(seed=1)
+    assert torch.allclose(seed0_a, seed0_b)  # same seed -> reproducible
+    assert not torch.allclose(seed0_a[0], seed0_a[1])  # distinct members (z per member)
+    assert not torch.allclose(seed0_a, seed1)  # different seed -> different draw
+
+
+def _build_sub(halo=0, min_cells=4, gap_h=6, num_interp_steps=6):
+    # global 16x32 model -> regional sub-domain; attach a px_model on the sub's run grid.
+    model, _, _, _ = _build(gap_h=gap_h, num_interp_steps=num_interp_steps)
+    sub = model.set_domain(
+        lat_min=10, lat_max=70, lon_min=50, lon_max=200, halo=halo, min_cells=min_cells
+    )
+    rc = sub.run_coords()  # public API: the grid to build a regional px_model against
+    runlat, runlon = rc["lat"], rc["lon"]
+    src = GridSource(runlat, runlon, LAT, LON)
+    sub.px_model = DataReplay(
+        src, VARIABLES, OrderedDict(lat=runlat, lon=runlon), step=gap_h
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    x0 = torch.from_numpy(src(np.array([t0]), VARIABLES).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=runlat,
+        lon=runlon,
+    )
+    return sub, x0, coords
+
+
+@pytest.mark.parametrize("halo, exp_halo", [(0, (0, 0, 1, 0)), (2, (2, 2, 3, 2))])
+def test_interpcrpsdit_set_domain(halo, exp_halo):
+    sub, x0, coords = _build_sub(halo=halo)
+    frames = list(itertools.islice(sub.create_iterator(x0, coords), 3))
+    # the emitted output grid (public: from the frame coords) == the exact bounding box interior
+    outlat, outlon = frames[0][1]["lat"], frames[0][1]["lon"]
+    np.testing.assert_array_equal(outlat, LAT[2:8])  # lat 10..70 on the 16-row grid
+    np.testing.assert_array_equal(outlon, LON[5:18])  # lon 50..200 on the 32-col grid
+    nlat_o, nlon_o = len(outlat), len(outlon)
+    assert sub._halo == exp_halo  # asserts the per-side halo trim (internal _halo)
+    # run grid (what the DiT/px see) is >= output; with halo, larger overall (per-side pinned by _halo)
+    run = sub.run_coords()
+    if halo:
+        assert len(run["lat"]) > nlat_o and len(run["lon"]) > nlon_o
+    # frame 0 is the IC, emitted verbatim -> must equal the source's exact bounding box sub-block (spatially
+    # varying source, so a correct-size-but-wrong-offset trim would fail this).
+    h0 = float((coords["time"][0] - Y0) / np.timedelta64(1, "h"))
+    ri = np.arange(2, 8, dtype="float32")[:, None]
+    ci = np.arange(5, 18, dtype="float32")[None, :]
+    expected_ic = h0 + ri + 0.01 * ci  # (6, 13)
+    for k, (xf, cf) in enumerate(frames):
+        assert xf.shape[-2:] == (
+            nlat_o,
+            nlon_o,
+        )  # every emitted frame is the trimmed bounding box
+        np.testing.assert_array_equal(cf["lat"], outlat)
+        np.testing.assert_array_equal(cf["lon"], outlon)
+        assert torch.isfinite(xf).all()
+        if k == 0:
+            np.testing.assert_allclose(
+                xf[0, 0, 0, 0].cpu().numpy(), expected_ic, atol=1e-4
+            )
+
+
+def test_interpcrpsdit_crops_superset_base_grid():
+    # A base on a grid that contains the run grid (e.g. SFNO's 721 lat vs the model's 720) is
+    # reconciled onto the run grid via map_coords -- here a base with one extra southern row.
+    model, _, _, h0 = _build()
+    step = LAT[0] - LAT[1]
+    lat_big = np.concatenate(
+        [LAT, [LAT[-1] - step]]
+    )  # H+1 rows; LAT is the contiguous top slice
+    src = GridSource(lat_big, LON, lat_big, LON)
+    model.px_model = DataReplay(
+        src, VARIABLES, OrderedDict(lat=lat_big, lon=LON), step=6
+    )
+    x0 = torch.from_numpy(
+        src(np.array([Y0 + np.timedelta64(120, "h")]), VARIABLES).values.astype(
+            "float32"
+        )
+    )[None, :, None]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([Y0 + np.timedelta64(120, "h")]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=lat_big,
+        lon=LON,
+    )
+    xf, cf = next(
+        model.create_iterator(x0, coords)
+    )  # IC -- cropped to the run grid, retained values unmodified
+    assert xf.shape[-2:] == (H, W)  # cropped from H+1 -> H
+    # emitted on the run grid, not the base grid
+    np.testing.assert_array_equal(cf["lat"], LAT)
+    assert torch.isfinite(xf).all()
+    # IC equals the source's top-H rows (the extra southern row is dropped, not blended in)
+    expected = (
+        h0
+        + np.arange(H, dtype="float32")[:, None]
+        + 0.01 * np.arange(W, dtype="float32")[None, :]
+    )
+    np.testing.assert_allclose(xf[0, 0, 0, 0].cpu().numpy(), expected, atol=1e-4)
+    assert (
+        xf[0, 0, 0, 0].max().item() < h0 + H
+    )  # the extra row (values >= h0+H) was cropped, not averaged
+
+
+def test_interpcrpsdit_input_coords_reports_px_grid():
+    # input_coords reflects the wrapped px_model's grid (base is fed to px_model on its grid, then
+    # map_coords'd onto the run grid), matching InterpModAFNO; run_coords is the model's own run grid.
+    model, _, _, _ = _build()
+    step = LAT[0] - LAT[1]
+    lat_big = np.concatenate([LAT, [LAT[-1] - step]])
+    model.px_model = DataReplay(
+        GridSource(lat_big, LON, lat_big, LON),
+        VARIABLES,
+        OrderedDict(lat=lat_big, lon=LON),
+        step=6,
+    )
+    # input_coords reports the full px grid (H+1 rows), value-for-value
+    np.testing.assert_array_equal(model.input_coords()["lat"], lat_big)
+    np.testing.assert_array_equal(model.run_coords()["lat"], LAT)  # run grid (H)
+
+
+def test_interpcrpsdit_run_coords():
+    model, _, _, _ = _build()
+    # pre-set_domain: run grid == the full model grid
+    np.testing.assert_array_equal(model.run_coords()["lat"], LAT)
+    np.testing.assert_array_equal(model.run_coords()["lon"], LON)
+    sub = model.set_domain(
+        lat_min=10, lat_max=70, lon_min=50, lon_max=200, halo=2, min_cells=4
+    )
+    # post-set_domain: run grid == bounding box + halo, patch-snapped (rows 0..10, cols 2..20 for this bounding box)
+    np.testing.assert_array_equal(sub.run_coords()["lat"], LAT[0:10])
+    np.testing.assert_array_equal(sub.run_coords()["lon"], LON[2:20])
+    # run grid is strictly larger than the trimmed output (bounding box interior LAT[2:8]/LON[5:18])
+    assert len(sub.run_coords()["lat"]) > len(LAT[2:8])
+    assert len(sub.run_coords()["lon"]) > len(LON[5:18])
+    # run_coords reads the fixed grid directly, so detaching the px_model leaves it unchanged
+    before = sub.run_coords()
+    sub.px_model = None
+    after = sub.run_coords()
+    np.testing.assert_array_equal(after["lat"], before["lat"])
+    np.testing.assert_array_equal(after["lon"], before["lon"])
+
+
+def test_interpcrpsdit_set_domain_global_base():
+    # A global base (not a regional replay) drives a sub-domain: map_coords crops global -> bounding box+halo,
+    # exercising both map_coords legs plus interior interpolation on the cropped run grid.
+    model, _, _, _ = _build()
+    sub = model.set_domain(
+        lat_min=10, lat_max=70, lon_min=50, lon_max=200, halo=2, min_cells=4
+    )
+    src = GridSource(LAT, LON, LAT, LON)  # full global grid, not the sub run grid
+    sub.px_model = DataReplay(src, VARIABLES, OrderedDict(lat=LAT, lon=LON), step=6)
+    t0 = Y0 + np.timedelta64(120, "h")
+    x0 = torch.from_numpy(src(np.array([t0]), VARIABLES).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=LAT,
+        lon=LON,
+    )
+    frames = list(itertools.islice(sub.create_iterator(x0, coords), 3))
+    # emitted output grid == the bounding box interior, even though the base was global
+    outlat, outlon = frames[0][1]["lat"], frames[0][1]["lon"]
+    np.testing.assert_array_equal(outlat, LAT[2:8])
+    np.testing.assert_array_equal(outlon, LON[5:18])
+    nlat_o, nlon_o = len(outlat), len(outlon)
+    # Zero residual (PhooDiT) + 1h substeps => frame k == h0 + k + (bounding box sub-block). Checking every
+    # frame's exact values exercises both map_coords legs (correct crop offset, via the spatially
+    # varying block) and the interior linear interp (via the +k).
+    h0 = float((t0 - Y0) / np.timedelta64(1, "h"))
+    block = (
+        np.arange(2, 8, dtype="float32")[:, None]
+        + 0.01 * np.arange(5, 18, dtype="float32")[None, :]
+    )
+    for k, (xf, cf) in enumerate(frames):
+        assert xf.shape[-2:] == (
+            nlat_o,
+            nlon_o,
+        )  # cropped global -> bounding box interior
+        np.testing.assert_array_equal(cf["lat"], outlat)
+        np.testing.assert_array_equal(cf["lon"], outlon)
+        assert torch.isfinite(xf).all()
+        np.testing.assert_allclose(
+            xf[0, 0, 0, 0].cpu().numpy(), h0 + k + block, atol=1e-4
+        )
+
+
+def test_interpcrpsdit_set_domain_bbox_outside_raises():
+    model, _, _, _ = _build()
+    with pytest.raises(ValueError, match="outside the current grid"):
+        model.set_domain(
+            lat_min=-100, lat_max=70, lon_min=50, lon_max=200, min_cells=4
+        )  # lat below grid
+
+
+def test_interpcrpsdit_set_domain_too_small_raises():
+    model, _, _, _ = _build()
+    with pytest.raises(
+        ValueError, match="per-side minimum"
+    ):  # bounding box < min_cells per side
+        model.set_domain(
+            lat_min=10, lat_max=70, lon_min=50, lon_max=200, min_cells=1000
+        )
+
+
+@pytest.mark.parametrize(
+    "amp_dtype, expect_autocast", [(None, False), (torch.bfloat16, True)]
+)
+def test_interpcrpsdit_amp_dtype(amp_dtype, expect_autocast):
+    # amp_dtype toggles autocast around the DiT forward.
+    dit = AutocastProbeDiT()
+    model, x0, coords, _ = _build(amp_dtype=amp_dtype, dit=dit)
+    frames = [
+        xf for xf, _ in itertools.islice(model.create_iterator(x0, coords), 2)
+    ]  # IC + 1 interior
+    assert dit.saw_autocast is expect_autocast
+    assert torch.isfinite(frames[-1]).all()
+
+
+def test_interpcrpsdit_requires_px_model():
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=PhooDiT(),
+        center=torch.zeros(1, len(VARIABLES), 1, 1),
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=None,
+    )
+    # input_coords derives from px_model, so it raises when none is attached
+    with pytest.raises(ValueError, match="px_model, must be set"):
+        model.input_coords()
+    # the run path guards separately (a different raise site)
+    x = torch.zeros(1, 1, 1, len(VARIABLES), H, W)
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([Y0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=LAT,
+        lon=LON,
+    )
+    with pytest.raises(ValueError, match="px_model, must be set"):
+        next(model.create_iterator(x, coords))
+
+
+def test_interpcrpsdit_set_domain_negative_halo_raises():
+    model, _, _, _ = _build()
+    with pytest.raises(ValueError, match="halo must be non-negative"):
+        model.set_domain(lat_min=10, lat_max=70, lon_min=50, lon_max=200, halo=-1)
+
+
+def test_interpcrpsdit_set_domain_bad_min_cells_raises():
+    model, _, _, _ = _build()
+    with pytest.raises(ValueError, match="min_cells must be >= 1"):
+        model.set_domain(lat_min=10, lat_max=70, lon_min=50, lon_max=200, min_cells=0)
+
+
+def test_interpcrpsdit_lon_pad_periodic():
+    # lon_pad>0 exercises the circular longitude pad + periodic noise draw; with PhooDiT f=0 the
+    # pinned output is still the exact linear interp (the pad is added, then cropped back off).
+    model, x0, coords, h0 = _build(lon_pad=4)
+    it = model.create_iterator(x0, coords)
+    next(it)  # IC
+    x1, _ = next(it)  # first interior sub-step (tau=1/6)
+    assert x1.shape[-2:] == (
+        H,
+        W,
+    )  # circular pad added then cropped back to the run grid
+    assert torch.isfinite(x1).all()
+    assert torch.allclose(x1, torch.full_like(x1, h0 + (1.0 / 6.0) * 6.0), atol=1e-4)
+
+
+def test_interpcrpsdit_multi_time_independent_noise():
+    # Two init times in one call get independent per-member latents. Using a time-invariant source so
+    # the linear base is identical across times, any difference between the two outputs is purely noise.
+    class ConstSource:
+        def __call__(self, time, variable):
+            times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+            variable = [variable] if isinstance(variable, str) else list(variable)
+            arr = np.full((len(times), len(variable), H, W), 5.0, dtype="float32")
+            return xr.DataArray(
+                arr,
+                dims=["time", "variable", "lat", "lon"],
+                coords=dict(time=times, variable=np.array(variable), lat=LAT, lon=LON),
+            )
+
+    model, _, _, _ = _build(num_interp_steps=6, seed=0, dit=NoiseDiT())
+    model.px_model = DataReplay(
+        ConstSource(), VARIABLES, OrderedDict(lat=LAT, lon=LON), step=6
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    x = torch.full(
+        (1, 2, 1, len(VARIABLES), H, W), 5.0
+    )  # two init times, identical field
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0, t0 + np.timedelta64(12, "h")]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=LAT,
+        lon=LON,
+    )
+    it = model.create_iterator(x, coords)
+    next(it)  # IC
+    xi, _ = next(it)  # first interior sub-step; shape (1, 2, 1, 73, H, W)
+    assert xi.shape[1] == 2  # both init times emitted
+    # identical base across times => the two differ only via their independent per-time latents
+    assert not torch.allclose(xi[:, 0], xi[:, 1])
+
+
+def test_interpcrpsdit_load_model(tmp_path, monkeypatch):
+    # Exercise load_model with a mocked package: dummy .mdlus (from_checkpoint patched),
+    # real set_phys.nc invariant stack + normalization stats.
+    class _FakeMod:
+        @staticmethod
+        def from_checkpoint(path):
+            return PhooDiT()
+
+    monkeypatch.setattr(interp_mod, "PhysicsNemoModule", _FakeMod)
+    (tmp_path / "CRPSModel.mdlus").write_bytes(
+        b""
+    )  # presence only; from_checkpoint is mocked
+    (tmp_path / "config.json").write_text(
+        '{"name": "test"}'
+    )  # resolved for HF download tracking
+    np.save(
+        tmp_path / "global_means.npy", np.zeros((1, len(VARIABLES), 1, 1), "float32")
+    )
+    np.save(tmp_path / "global_stds.npy", np.ones((1, len(VARIABLES), 1, 1), "float32"))
+    hh, ww = 4, 8
+    lat = np.linspace(90, -90, hh, endpoint=False)  # descending, as load_model requires
+    lon = np.linspace(0, 360, ww, endpoint=False)
+    ramp = np.arange(hh * ww, dtype="float32").reshape(
+        hh, ww
+    )  # nonzero-variance invariant fields
+    invars = ["lsm", "z"] + PHYS_EXTRA
+    xr.Dataset(
+        {
+            v: (["latitude", "longitude"], (ramp + i).astype("float32"))
+            for i, v in enumerate(invars)
+        },
+        coords=dict(latitude=lat, longitude=lon),
+    ).to_netcdf(tmp_path / "set_phys.nc")
+
+    model = InterpCRPSDiT.load_model(Package(str(tmp_path)))
+    assert model.center.shape == (1, len(VARIABLES), 1, 1)
+    assert model.static_inv.shape == (12, hh, ww)  # 4 sin/cos + lsm + z + 6 phys
+    assert torch.isfinite(model.static_inv).all()
+    assert (
+        model._min_domain_cells == 64
+    )  # PhooDiT exposes no attn_kernel -> pre-load default kept
+
+
+@pytest.mark.parametrize("time_h", [120, 48])  # different init times
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda:0",
+            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="No GPU"),
+        ),
+    ],
+)
+def test_interpcrpsdit_call(device, time_h):
+    # __call__ (single-step forward) returns the initial condition (step 0) -- matching
+    # create_iterator's first yield (the InterpModAFNO px contract), not a future sub-step.
+    t0 = Y0 + np.timedelta64(time_h, "h")
+    model, x0, coords, h0 = _build(device=device, t0=t0)
+    x_call, c_call = model(x0, coords)
+    x_iter, c_iter = next(model.create_iterator(x0, coords))
+    assert torch.allclose(x_call, x_iter)  # __call__ == create_iterator step 0
+    assert x_call.shape[-2:] == (H, W)
+    assert torch.allclose(
+        x_call, torch.full_like(x_call, h0), atol=1e-4
+    )  # IC = source at t0
+    np.testing.assert_array_equal(np.asarray(c_call["lat"]), np.asarray(c_iter["lat"]))
+
+
+@pytest.mark.parametrize("ensemble", [1, 2])
+def test_interpcrpsdit_iter(ensemble):
+    # create_iterator yields the IC first, then advances lead_time; preserves the ensemble/batch dim.
+    model, x0, coords, h0 = _build()
+    x = x0.repeat(ensemble, 1, 1, 1, 1, 1)
+    c = OrderedDict(coords)
+    c["batch"] = np.arange(ensemble)
+    it = model.create_iterator(x, c)
+    ic_x, ic_c = next(it)  # step 0 = initial condition
+    assert ic_x.shape[0] == ensemble  # ensemble/batch dim preserved
+    assert int(ic_c["lead_time"][-1] / np.timedelta64(1, "m")) == 0  # IC at lead 0
+    assert torch.allclose(ic_x, torch.full_like(ic_x, h0), atol=1e-4)
+    s1_x, s1_c = next(it)  # first interior sub-step
+    assert s1_x.shape[0] == ensemble
+    assert s1_c["lead_time"][-1] > ic_c["lead_time"][-1]  # lead_time advanced
+    assert torch.isfinite(s1_x).all()
+
+
+@pytest.mark.package
+def test_interpcrpsdit_package():
+    # Real-weights smoke test (needs --package + a hosted default package + the interp-crps-dit extra;
+    # skipped otherwise). Loads the default package, builds a regional model, runs one real DiT forward.
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    package = InterpCRPSDiT.load_default_package()
+    model = InterpCRPSDiT.load_model(package).to(device).eval()
+    assert model.center.shape == (1, len(VARIABLES), 1, 1)
+    assert model.static_inv.shape[0] == 12
+    assert bool(torch.isfinite(model.static_inv).all())
+
+    sub = model.set_domain(
+        lat_min=10.0, lat_max=32.0, lon_min=100.0, lon_max=124.0, halo=0
+    )
+    rc = sub.run_coords()
+    rlat, rlon = rc["lat"], rc["lon"]
+    hs, ws = len(rlat), len(rlon)
+    mean = model.center.detach().cpu().numpy().reshape(len(VARIABLES), 1, 1)
+
+    class _MeanSrc:  # in-distribution constant field = per-variable mean
+        def __call__(self, time, variable):
+            times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+            var = [variable] if isinstance(variable, str) else list(variable)
+            arr = np.broadcast_to(mean, (len(times), len(VARIABLES), hs, ws)).astype(
+                "float32"
+            )
+            return xr.DataArray(
+                arr,
+                dims=["time", "variable", "lat", "lon"],
+                coords=dict(time=times, variable=np.array(var), lat=rlat, lon=rlon),
+            )
+
+    sub.px_model = DataReplay(
+        _MeanSrc(), VARIABLES, OrderedDict(lat=rlat, lon=rlon), step=6
+    )
+    x0 = torch.from_numpy(
+        np.broadcast_to(mean, (1, 1, 1, len(VARIABLES), hs, ws)).astype("float32")
+    ).to(device)
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([Y0 + np.timedelta64(120, "h")]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=rlat,
+        lon=rlon,
+    )
+    it = sub.create_iterator(x0, coords)
+    next(it)  # IC (verbatim)
+    xi, _ = next(it)  # first interior -- real natten2d_rope DiT forward
+    assert bool(torch.isfinite(xi).all())
+
+
+class ZCaptureDiT(PhooDiT):
+    """Records the trailing 6 latent channels the DiT sees each forward, to check the per-bracket
+    latent is drawn once and reused across all interior sub-steps."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.z_seen: list[torch.Tensor] = []
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        self.z_seen.append(x[:, -6:].clone())  # DiT input tail = z(6)
+        return x.new_zeros(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+class ShiftedSource:
+    """Source on a grid offset from the model grid (no exact members), to trigger the nearest-regrid
+    warning when it drives the interpolator."""
+
+    def __init__(self, lat, lon):
+        self.lat, self.lon = np.asarray(lat), np.asarray(lon)
+
+    def __call__(self, time, variable):
+        times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+        variable = [variable] if isinstance(variable, str) else list(variable)
+        arr = np.zeros(
+            (len(times), len(variable), len(self.lat), len(self.lon)), "float32"
+        )
+        for i, t in enumerate(times):
+            arr[i] = float((t - Y0) / np.timedelta64(1, "h"))
+        return xr.DataArray(
+            arr,
+            dims=["time", "variable", "lat", "lon"],
+            coords=dict(
+                time=times, variable=np.array(variable), lat=self.lat, lon=self.lon
+            ),
+        )
+
+
+def test_interpcrpsdit_bracket_latent_coherent():
+    # The per-member latent z is drawn once per bracket and reused across every interior sub-step
+    # (temporal coherence within a bracket), but re-drawn fresh for each new bracket (independent noise
+    # across brackets -- otherwise every bracket would share one realization).
+    dit = ZCaptureDiT()
+    model, x0, coords, _ = _build(gap_h=6, num_interp_steps=3, seed=0, dit=dit)
+    # IC + two full brackets: each bracket = 2 interior DiT calls, so z_seen = [b1, b1, b2, b2].
+    list(itertools.islice(model.create_iterator(x0, coords), 7))
+    assert len(dit.z_seen) == 4
+    assert (
+        float(dit.z_seen[0].abs().sum()) > 0.0
+    )  # latent actually flows (seeded, non-zero)
+    assert torch.equal(
+        dit.z_seen[0], dit.z_seen[1]
+    )  # bracket 1: same latent across sub-steps
+    assert torch.equal(
+        dit.z_seen[2], dit.z_seen[3]
+    )  # bracket 2: same latent across sub-steps
+    assert not torch.equal(
+        dit.z_seen[0], dit.z_seen[2]
+    )  # different latent between brackets
+
+
+def test_interpcrpsdit_front_hook_applied():
+    # front_hook transforms each incoming base frame; with a zero-residual DiT the +5 offset propagates
+    # through the linear base to every emitted frame (here checked on the IC = base at t0).
+    model, x0, coords, h0 = _build(gap_h=6, num_interp_steps=3)
+    calls = []
+
+    def front(a, c):
+        calls.append(True)
+        return a + 5.0, c
+
+    model.front_hook = front
+    frames = list(itertools.islice(model.create_iterator(x0, coords), 4))
+    assert calls  # invoked per base frame
+    ic = frames[0][0]
+    assert torch.allclose(ic, torch.full_like(ic, h0 + 5.0), atol=1e-4)
+
+
+def test_interpcrpsdit_rear_hook_output_not_reused_as_anchor():
+    # rear_hook (+100) transforms every emitted frame, but the interpolation anchor is the UN-hooked
+    # base frame -- so exact interior values stay the correct linear ramp + the constant offset, with
+    # no accumulation across brackets. If the hooked output were fed back as the next anchor, bracket 2
+    # would drift; asserting exact values across two brackets proves the rollout state is not corrupted.
+    model, x0, coords, h0 = _build(gap_h=6, num_interp_steps=3)
+    seen = []
+
+    def rear(a, c):
+        seen.append(int(c["lead_time"][-1] / np.timedelta64(1, "m")))
+        return a + 100.0, c
+
+    model.rear_hook = rear
+    frames = [xf for xf, _ in itertools.islice(model.create_iterator(x0, coords), 7)]
+    # IC(0), bracket1 interior(1,2)+endpoint(3), bracket2 interior(4,5)+endpoint(6); PhooDiT f=0 ->
+    # each interior is the linear interp of the un-hooked coarse endpoints (source hour = value).
+    expected = [h0, h0 + 2, h0 + 4, h0 + 6, h0 + 8, h0 + 10, h0 + 12]
+    assert len(seen) == len(frames)  # every emitted frame passed through rear_hook
+    for xf, e in zip(frames, expected):
+        assert torch.allclose(xf, torch.full_like(xf, e + 100.0), atol=1e-4)
+
+
+def test_interpcrpsdit_regrid_warns_off_grid_base():
+    # A base whose grid is not a subset of the model grid triggers the nearest-regrid warning
+    # (map_coords falls back to interpolation instead of an exact crop).
+    lat2 = LAT + 0.3  # offset -> not members of the model's LAT grid
+    src = ShiftedSource(lat2, LON)
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=PhooDiT(),
+        center=torch.zeros(1, len(VARIABLES), 1, 1),
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=DataReplay(src, VARIABLES, OrderedDict(lat=lat2, lon=LON), step=6),
+        num_interp_steps=6,
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    x0 = torch.from_numpy(src(np.array([t0]), VARIABLES).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=lat2,
+        lon=LON,
+    )
+    with pytest.warns(UserWarning, match="nearest-regridded"):
+        next(model.create_iterator(x0, coords))
+
+
+def test_interpcrpsdit_load_model_min_domain_cells(tmp_path, monkeypatch):
+    # load_model derives _min_domain_cells from the DiT's attn_kernel x patch_size (not the pre-load
+    # default of 64). Mocked package -- no real weights.
+    class AttnDiT(PhooDiT):
+        attn_kernel = 23  # exposed like the real natten2d_rope DiT
+
+    class _FakeMod:
+        @staticmethod
+        def from_checkpoint(path):
+            return AttnDiT()
+
+    monkeypatch.setattr(interp_mod, "PhysicsNemoModule", _FakeMod)
+    (tmp_path / "CRPSModel.mdlus").write_bytes(b"")
+    (tmp_path / "config.json").write_text(
+        '{"name": "test"}'
+    )  # resolved for HF download tracking
+    np.save(
+        tmp_path / "global_means.npy", np.zeros((1, len(VARIABLES), 1, 1), "float32")
+    )
+    np.save(tmp_path / "global_stds.npy", np.ones((1, len(VARIABLES), 1, 1), "float32"))
+    hh, ww = 4, 8
+    lat = np.linspace(90, -90, hh, endpoint=False)
+    lon = np.linspace(0, 360, ww, endpoint=False)
+    ramp = np.arange(hh * ww, dtype="float32").reshape(hh, ww)
+    invars = ["lsm", "z"] + PHYS_EXTRA
+    xr.Dataset(
+        {
+            v: (["latitude", "longitude"], (ramp + i).astype("float32"))
+            for i, v in enumerate(invars)
+        },
+        coords=dict(latitude=lat, longitude=lon),
+    ).to_netcdf(tmp_path / "set_phys.nc")
+    model = InterpCRPSDiT.load_model(Package(str(tmp_path)))
+    assert model._min_domain_cells == 23 * max(
+        AttnDiT.patch_size
+    )  # max kernel * max patch = 46
+
+
+def test_interpcrpsdit_lon_pad_exceeds_width():
+    # _cpad must stay genuinely periodic when lon_pad exceeds the grid width (indices wrap via modulo);
+    # a slice-based pad would clamp and _sample_tau's crop would collapse to zero width. With PhooDiT
+    # f=0 the round-trip must still yield the exact linear interp, not merely a finite field.
+    model, x0, coords, h0 = _build(
+        lon_pad=2 * W + 8
+    )  # pad wider than the grid (and > 2*W)
+    it = model.create_iterator(x0, coords)
+    next(it)  # IC
+    xi, _ = next(it)  # first interior sub-step (tau = 1/6)
+    assert xi.shape[-2:] == (H, W)  # cropped back to the grid, not collapsed
+    # exact linear interp of the two constant coarse frames (6 h gap / 6 steps -> tau = 1/6)
+    assert torch.allclose(xi, torch.full_like(xi, h0 + (1.0 / 6.0) * 6.0), atol=1e-4)
+
+
+class DropInputProbeDiT(PhooDiT):
+    """Captures, for dropped channels, the DiT-visible normalized input (first 73 = x0n) and the
+    presence-mask entry (last 73 of the 87-ch cond block), so a test can assert both are zero. DiT input
+    layout: [x0n(73), xTn(73), cond(87), z(6)]; cond = static(12) + cos_zenith + gap + mask(73).
+    """
+
+    def __init__(self, drop_idx) -> None:
+        super().__init__()
+        self.drop_idx = drop_idx
+        self.dropped_input: torch.Tensor | None = None
+        self.dropped_mask: torch.Tensor | None = None
+
+    def forward(self, x, t, condition=None, attn_kwargs=None):
+        self.dropped_input = x[:, self.drop_idx].clone()  # x0n at the dropped positions
+        mask0 = (
+            73 + 73 + 14
+        )  # presence mask starts at cond[14] (after static + cos_zenith + gap)
+        self.dropped_mask = x[:, [mask0 + i for i in self.drop_idx]].clone()
+        return x.new_zeros(x.shape[0], len(VARIABLES), x.shape[-2], x.shape[-1])
+
+
+def test_interpcrpsdit_missing_optional_base():
+    # A base that supplies only VARIABLES minus the optional four (like Pangu's 69) drives the
+    # interpolator when those four are dropped: output is the 69 present variables (endpoint-exact),
+    # and the absent channels are expanded to normalized zero internally (never emitted).
+    present = [v for v in VARIABLES if v not in OPTIONAL_VARIABLES]  # 69
+    drop_idx = [VARIABLES.index(v) for v in OPTIONAL_VARIABLES]
+    dit = DropInputProbeDiT(drop_idx)
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    src = (
+        PhooSource()
+    )  # returns exactly the requested variables as hour-constant fields
+    model = InterpCRPSDiT(
+        dit=dit,
+        center=torch.full(
+            (1, len(VARIABLES), 1, 1), 5.0
+        ),  # nonzero -> pad must use center, not 0
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=DataReplay(src, present, OrderedDict(lat=LAT, lon=LON), step=6),
+        num_interp_steps=6,
+        lon_pad=0,  # small synthetic grid
+        drop_variables=OPTIONAL_VARIABLES,
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    h0 = float((t0 - Y0) / np.timedelta64(1, "h"))
+    x0 = torch.from_numpy(src(np.array([t0]), present).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(present),
+        lat=LAT,
+        lon=LON,
+    )
+    it = model.create_iterator(x0, coords)
+    ic_x, ic_c = next(
+        it
+    )  # IC endpoint: only the 69 present variables, exact base values
+    assert list(ic_c["variable"]) == present
+    assert ic_x.shape[-3] == len(present)
+    assert torch.allclose(ic_x, torch.full_like(ic_x, h0), atol=1e-4)  # endpoint-exact
+    x1, c1 = next(it)  # first interior -- DiT forward runs
+    assert list(c1["variable"]) == present
+    assert torch.isfinite(x1).all()
+    # padded absent channels reach the DiT as normalized zero (center-filled, not physical zero)
+    assert dit.dropped_input is not None
+    assert torch.allclose(
+        dit.dropped_input, torch.zeros_like(dit.dropped_input), atol=1e-6
+    )
+    # and their presence-mask entries are zero (declared absent to the DiT)
+    assert dit.dropped_mask is not None
+    assert torch.all(dit.dropped_mask == 0)
+
+
+def test_interpcrpsdit_fractional_minute_gap_raises():
+    # A base whose coarse step is not a whole number of minutes must raise -- rounding it would
+    # silently shift every emitted lead time.
+    src = PhooSource()
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=PhooDiT(),
+        center=torch.zeros(1, len(VARIABLES), 1, 1),
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=DataReplay(
+            src, VARIABLES, OrderedDict(lat=LAT, lon=LON), step=np.timedelta64(90, "s")
+        ),  # 1.5 min
+        num_interp_steps=6,
+        lon_pad=0,
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    x0 = torch.from_numpy(src(np.array([t0]), VARIABLES).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(VARIABLES),
+        lat=LAT,
+        lon=LON,
+    )
+    with pytest.raises(ValueError, match="whole number of minutes"):
+        next(model.create_iterator(x0, coords))
+
+
+def _write_pkg(tmp_path, monkeypatch, means=None, stds=None, nlat=4, nlon=8, dit=None):
+    # Write a minimal mocked InterpCRPSDiT package (no real weights) and patch from_checkpoint.
+    class _FakeMod:
+        @staticmethod
+        def from_checkpoint(path):
+            return dit if dit is not None else PhooDiT()
+
+    monkeypatch.setattr(interp_mod, "PhysicsNemoModule", _FakeMod)
+    (tmp_path / "CRPSModel.mdlus").write_bytes(b"")
+    (tmp_path / "config.json").write_text('{"name": "test"}')
+    means = np.zeros((len(VARIABLES),), "float32") if means is None else means
+    stds = np.ones((len(VARIABLES),), "float32") if stds is None else stds
+    np.save(tmp_path / "global_means.npy", means)
+    np.save(tmp_path / "global_stds.npy", stds)
+    # 721 spans 90..-90 inclusive (a real 0.25 deg grid ending at the -90 pole); smaller grids match the
+    # module LAT (endpoint excluded).
+    lat = np.linspace(90, -90, nlat, endpoint=(nlat == 721))
+    lon = np.linspace(0, 360, nlon, endpoint=False)
+    ramp = np.arange(nlat * nlon, dtype="float32").reshape(nlat, nlon)
+    invars = ["lsm", "z"] + PHYS_EXTRA
+    xr.Dataset(
+        {
+            v: (["latitude", "longitude"], (ramp + i).astype("float32"))
+            for i, v in enumerate(invars)
+        },
+        coords=dict(latitude=lat, longitude=lon),
+    ).to_netcdf(tmp_path / "set_phys.nc")
+
+
+@pytest.mark.parametrize(
+    "kind, match",
+    [
+        ("zero_std", "strictly positive"),  # a zero scale -> would divide to inf
+        ("short_means", "must have"),  # wrong channel count
+        ("nonfinite_std", "non-finite"),  # NaN/inf normalization
+    ],
+)
+def test_interpcrpsdit_load_model_bad_normalization(tmp_path, monkeypatch, kind, match):
+    means = np.zeros((len(VARIABLES),), "float32")
+    stds = np.ones((len(VARIABLES),), "float32")
+    if kind == "zero_std":
+        stds[3] = 0.0
+    elif kind == "short_means":
+        means = means[:-1]  # 72 channels
+    elif kind == "nonfinite_std":
+        stds[5] = np.nan
+    _write_pkg(tmp_path, monkeypatch, means=means, stds=stds)
+    with pytest.raises(ValueError, match=match):
+        InterpCRPSDiT.load_model(Package(str(tmp_path)))
+
+
+def test_interpcrpsdit_load_model_crops_721_to_720(tmp_path, monkeypatch):
+    # A 721-lat set_phys.nc is cropped to the 720 training grid (the -90 pole row dropped).
+    _write_pkg(tmp_path, monkeypatch, nlat=721, nlon=8)
+    model = InterpCRPSDiT.load_model(Package(str(tmp_path)))
+    assert model.static_inv.shape == (12, 720, 8)  # pole row dropped
+    assert model.lat2d.shape == (720, 8)
+    # last retained row is -89.75 (the -90 pole was dropped from the 0.25 deg grid)
+    assert model.lat2d[-1, 0].item() == pytest.approx(-89.75)
+
+
+def test_interpcrpsdit_pad_fills_dropped_with_center():
+    # _pad_present_to_full fills dropped channels with their physical center (not zero); a per-channel
+    # distinct center makes a wrong fill detectable. Present channels are preserved verbatim.
+    center = (
+        torch.arange(len(VARIABLES), dtype=torch.float32).reshape(
+            1, len(VARIABLES), 1, 1
+        )
+        + 10.0
+    )
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=PhooDiT(),
+        center=center,
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=None,
+        num_interp_steps=6,
+        lon_pad=0,
+        drop_variables=OPTIONAL_VARIABLES,
+    )
+    x_present = torch.randn(1, 1, 1, len(model.present_idx), H, W)
+    full = model._pad_present_to_full(x_present)
+    assert full.shape[-3] == len(VARIABLES)
+    assert torch.equal(
+        full[..., model.present_idx, :, :], x_present
+    )  # present preserved
+    for i in model.drop_idx:  # dropped == that channel's physical center
+        assert torch.allclose(
+            full[..., i, :, :], torch.full((1, 1, 1, H, W), center[0, i, 0, 0].item())
+        )
+
+
+def test_interpcrpsdit_missing_optional_base_reorders_variables():
+    # The base may emit present variables in its own native order (Pangu's here); map_coords must
+    # reconcile them into VARIABLES order before padding, so every output channel carries its own values.
+    from earth2studio.models.px.pangu import (
+        VARIABLES as PANGU,
+    )  # 69 vars, Pangu's native order
+
+    present = [v for v in VARIABLES if v not in OPTIONAL_VARIABLES]
+    assert set(PANGU) == set(present)  # same set of variables
+    assert (
+        list(PANGU) != present
+    )  # but a different order -> genuinely exercises the reorder
+
+    class VarValueSource:  # variable v -> constant field == its index in VARIABLES (distinct per var)
+        def __call__(self, time, variable):
+            times = np.atleast_1d(np.asarray(time, dtype="datetime64[s]"))
+            var = [variable] if isinstance(variable, str) else list(variable)
+            arr = np.zeros((len(times), len(var), H, W), "float32")
+            for j, v in enumerate(var):
+                arr[:, j] = float(VARIABLES.index(v))
+            return xr.DataArray(
+                arr,
+                dims=["time", "variable", "lat", "lon"],
+                coords=dict(time=times, variable=np.array(var), lat=LAT, lon=LON),
+            )
+
+    src = VarValueSource()
+    lon2d, lat2d = np.meshgrid(LON, LAT)
+    model = InterpCRPSDiT(
+        dit=PhooDiT(),
+        center=torch.zeros(1, len(VARIABLES), 1, 1),
+        scale=torch.ones(1, len(VARIABLES), 1, 1),
+        static_inv=torch.zeros(12, H, W),
+        lat2d=torch.as_tensor(lat2d, dtype=torch.float32),
+        lon2d=torch.as_tensor(lon2d, dtype=torch.float32),
+        px_model=DataReplay(
+            src, list(PANGU), OrderedDict(lat=LAT, lon=LON), step=6
+        ),  # base in Pangu order
+        num_interp_steps=6,
+        lon_pad=0,
+        drop_variables=OPTIONAL_VARIABLES,
+    )
+    t0 = Y0 + np.timedelta64(120, "h")
+    x0 = torch.from_numpy(src(np.array([t0]), list(PANGU)).values.astype("float32"))[
+        None, :, None
+    ]
+    coords = OrderedDict(
+        batch=np.array([0]),
+        time=np.array([t0]),
+        lead_time=np.array([np.timedelta64(0, "h")]),
+        variable=np.array(PANGU),
+        lat=LAT,
+        lon=LON,
+    )
+    ic_x, ic_c = next(model.create_iterator(x0, coords))
+    assert (
+        list(ic_c["variable"]) == present
+    )  # emitted in VARIABLES order (minus dropped)
+    for j, v in enumerate(
+        present
+    ):  # each channel carries ITS variable's value -> correct reorder
+        assert torch.allclose(
+            ic_x[:, :, :, j],
+            torch.full_like(ic_x[:, :, :, j], float(VARIABLES.index(v))),
+            atol=1e-4,
+        )


### PR DESCRIPTION
## Description

Add `InterpCRPSDiT`, an endpoint-pinned CRPS temporal-interpolation model that refines a base model’s coarse trajectory to hourly and sub-hourly resolution. For a 6 h bracket, `num_interp_steps`=6, 24, and 36 produce 1 h, 15 min, and 10 min output, respectively. The requested cadence must be a whole number of minutes and evenly partition the coarse gap.

For each interior fraction `tau` the field is produced in a single forward as `out(tau) = (1−tau)·x0 + tau·xT + sin(pi·tau)·f(x0, xT, cond, z)` consisting of a linear base plus a DiT correction whose `sin(pi·tau)` envelope vanishes at both endpoints. The bracket endpoints are the base model's own frames and only the interior is learned. A regional sub-domain is available via `set_domain`. A base does not have to provide all 73 variables. If the only ones it lacks are the four optional channels (sp, u100m, v100m, tcwv), pass them to `drop_variables`. The model then no longer requires them from the base model but it fills them internally and omits them from the output.

Closes #986 

Blocked by:
- PR #985  which is used by the example and tests.
- `nvidia-physicsnemo` 2.2.0 on PyPI — needed to resolve `uv.lock` (2.2.0 is the first release with `natten2d_rope` + `proj_reshape_2d_conv`, PR #1731). Until then `uv lock` cannot resolve the extra, so this PR stays a draft.
- Model weights hosting — `load_default_package` currently returns a placeholder `hf://nvidia/earth2studio-interp-crps-dit`; needs the bundle hosted 

### Model details

| Property | Value |
|---|---|
| **Architecture** | PyTorch — DiT backbone with `natten2d_rope` neighborhood attention (physicsnemo `Module`) |
| **Time step** | Output = coarse gap / `num_interp_steps` (trained gaps 3–10 h; e.g. 6 h/6 = 1 h). Base gap auto-detected from the wrapped model. |
| **Input variables** | 73 (ERA5 0.25° set); the base need only supply `73 − drop_variables` |
| **Output variables** | 73 minus any `drop_variables` |
| **Spatial resolution** | 0.25° × 0.25° (720 × 1440); 721-lat bases are cropped to 720 |
| **Checkpoint source** | HuggingFace — `hf://nvidia/earth2studio-interp-crps-dit` (TODO: host + `@commit`) |
| **Checkpoint size** | ~382 MiB total (model `CRPSModel.mdlus` 376 MiB, grid `set_phys.nc` 5.6 MiB, plus norm `.npy` + `config.json`) |

### Dependencies added

The model has the `interp-crps-dit` optional-dependency extra.

| Package | Version | License | Reason |
|---|---|---|---|
| `natten` | (py < 3.14) | [MIT](https://github.com/SHI-Labs/NATTEN/blob/main/LICENSE) | Neighborhood attention kernels for the DiT `natten2d_rope` attention |
| `nvidia-physicsnemo` | `>=2.2.0` | Apache-2.0 | DiT `natten2d_rope` layer + `Module` checkpoint format (first in 2.2.0 / PR #1731) |


## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes (example, `models_px.rst`, `install.md`).
- [x] The `CHANGELOG.md` is up to date with these changes.
- [x] An issue is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot).
- [ ] PR 1 (`DataReplay`) merged — this PR is stacked on it (example + tests import `DataReplay`).
- [ ] Weights hosted on HuggingFace and `load_default_package` URL pinned with `@commit`.
- [ ] `nvidia-physicsnemo` 2.2.0 available on PyPI (unblocks `uv.lock`).