### PR TITLE
Correct PrecipitationAFNOv2 precipitation accumulation window in docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the `PrecipitationAFNOv2` docstring: the model predicts precipitation
+  accumulated over the following six hours `[t, t+6h]`, not the prior six hours.
 - Fixed `DerivedRH` mixed-phase saturation blend clipping the liquid-water fraction
   ratio to 1.2 instead of 1.0 before squaring, which let the effective weight reach
   1.44 and inflated relative humidity above freezing.

--- a/earth2studio/models/dx/precipitation_afno_v2.py
+++ b/earth2studio/models/dx/precipitation_afno_v2.py
@@ -71,7 +71,7 @@ VARIABLES = [
 @check_optional_dependencies()
 class PrecipitationAFNOv2(torch.nn.Module, AutoModelMixin):
     """Improved Precipitation AFNO diagnostic model. Predicts the total precipitation
-    for the past 6 hours [t-6h, t] with the units m. This model uses an 20 atmospheric
+    for the next 6 hours [t, t+6h] with the units m. This model uses 20 atmospheric
     inputs and outputs one on a 0.25 degree lat-lon grid (south-pole excluding)
     [720 x 1440].
 


### PR DESCRIPTION
## Description

Corrects the `PrecipitationAFNOv2` docstring, which stated the model predicts precipitation for the prior six hours `[t-6h, t]`. The model predicts total precipitation accumulated over the six hours **following** the input validity time `[t, t+6h]`. 

Related to #932 (which reports the same window discrepancy). This does not resolve the separate skill concern raised there, so #932 should remain open.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An issue is linked to this pull request.
- [x] Assess and address Greptile feedback.

## Dependencies

None.