### PR TITLE
Convert dynamical.org pressure-level temperatures Celsius to Kelvin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed dynamical.org pressure-level temperatures (`t850`, `t925`) not being converted
+  from Celsius to Kelvin, so they were returned ~273 K too low.
 - Fixed `DerivedRH` mixed-phase saturation blend clipping the liquid-water fraction
   ratio to 1.2 instead of 1.0 before squaring, which let the effective weight reach
   1.44 and inflated relative humidity above freezing.

--- a/earth2studio/lexicon/dynamical.py
+++ b/earth2studio/lexicon/dynamical.py
@@ -79,7 +79,8 @@ class DynamicalLexicon(metaclass=LexiconType):
 
         Conversions to the Earth2Studio convention:
 
-        - ``temperature_2m``, ``dew_point_temperature_2m``: Celsius -> Kelvin
+        - ``temperature_2m``, ``dew_point_temperature_2m``, ``temperature_*hpa``:
+          Celsius -> Kelvin
         - ``geopotential_height_*``: metres -> geopotential (m2 s-2)
         - ``total_cloud_cover_atmosphere``: percent -> fraction
 
@@ -95,8 +96,8 @@ class DynamicalLexicon(metaclass=LexiconType):
         """
         dynamical_name = cls.VOCAB[val]
 
-        if val in ("t2m", "d2m"):
-            # Celsius -> Kelvin
+        if val in ("t2m", "d2m") or (val.startswith("t") and val[1:].isdigit()):
+            # Celsius -> Kelvin (2 m, dew point, and pressure-level temperatures)
             def mod(x: np.ndarray) -> np.ndarray:
                 """Convert Celsius to Kelvin."""
                 return np.asarray(x) + 273.15

--- a/test/data/test_dynamical.py
+++ b/test/data/test_dynamical.py
@@ -30,6 +30,7 @@ from earth2studio.data import (
     DynamicalIFSENS_FX,
 )
 from earth2studio.data.dynamical import _DynamicalBase
+from earth2studio.lexicon.dynamical import DynamicalLexicon
 
 # Un-normalized synthetic grid: ascending latitude and -180..180 longitude,
 # mirroring how dynamical.org serves coordinates.
@@ -37,7 +38,7 @@ _LAT = np.linspace(-90.0, 90.0, 7)
 _LON = np.linspace(-180.0, 135.0, 8)
 
 # Variable -> (unit, raw value) used to build the synthetic store and to verify
-# STAC-unit-driven conversion to the Earth2Studio convention.
+# lexicon-defined conversion to the Earth2Studio convention.
 _VARS = {
     "temperature_2m": ("degree_Celsius", 20.0),
     "wind_u_10m": ("m s-1", 3.0),
@@ -113,6 +114,16 @@ def _patch(monkeypatch, klass, collection_id, dims, dataset):
     )
 
 
+# dynamical.org serves pressure-level temperatures in Celsius; the lexicon must
+# convert them to Kelvin. t500 is mapped but not currently served by any
+# collection; t850/t925 are the active cases.
+@pytest.mark.parametrize("variable", ["t500", "t850", "t925"])
+def test_dynamical_pressure_temperature_celsius_to_kelvin(variable):
+    _, modifier = DynamicalLexicon.get_item(variable)
+    # Probe two points so the check pins both the offset and the (unit) slope.
+    np.testing.assert_allclose(modifier(np.array([0.0, 20.0])), [273.15, 293.15])
+
+
 @pytest.mark.timeout(30)
 def test_dynamical_call_mock(monkeypatch):
     times = np.array(["2024-01-01T00:00", "2024-01-01T06:00"], dtype="datetime64[ns]")
@@ -134,7 +145,7 @@ def test_dynamical_call_mock(monkeypatch):
     assert data.coords["lat"].values[-1] == pytest.approx(-90.0)
     assert (data.coords["lon"].values >= 0).all()
     assert (np.diff(data.coords["lon"].values) > 0).all()
-    # STAC-unit-driven conversions
+    # Lexicon-defined conversions to the Earth2Studio convention
     np.testing.assert_allclose(data.sel(variable="t2m").values, 20.0 + 273.15)
     np.testing.assert_allclose(data.sel(variable="u10m").values, 3.0)
     np.testing.assert_allclose(data.sel(variable="tcc").values, 0.5)


### PR DESCRIPTION
## Description

`DynamicalLexicon.get_item` only converted `t2m`/`d2m` from Celsius to Kelvin, so pressure-level temperatures (`t850`, `t925`), which dynamical.org also serves in Celsius, were returned ~273 K too low. Extends the existing id-driven conversion branch to cover `t<level>` ids, following the lexicon's existing conversion pattern. Adds a parametrized lexicon test and a CHANGELOG entry.

closes #1005

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

None.