### PR TITLE
docs: fix GraphCast pip install command

### DIFF
--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -394,13 +394,16 @@ uv add earth2studio --extra fuxi
 ::::
 :::::
 :::::{tab-item} GraphCast
-Notes: The GraphCast models (operational and small) require additional dependencies for JAX and Haiku.
+Notes: The GraphCast models (operational and small) require additional dependencies
+for JAX and Haiku. The GraphCast package must be installed from the Google DeepMind
+repository.
 
 ::::{tab-set}
 :::{tab-item} pip
 
 ```bash
-pip install earth2studio[graphcast]
+pip install "earth2studio[graphcast]" \
+  "graphcast @ git+https://github.com/google-deepmind/graphcast.git@7077d40a36db6541e3ed72ccaed1c0d202fa6014"
 ```
 
 :::

--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -402,8 +402,8 @@ repository.
 :::{tab-item} pip
 
 ```bash
-pip install "earth2studio[graphcast]" \
-  "graphcast @ git+https://github.com/google-deepmind/graphcast.git@7077d40a36db6541e3ed72ccaed1c0d202fa6014"
+pip install "graphcast @ git+https://github.com/google-deepmind/graphcast.git@7077d40a36db6541e3ed72ccaed1c0d202fa6014"
+pip install "earth2studio[graphcast]"
 ```
 
 :::


### PR DESCRIPTION
## Description

Fixes the GraphCast optional dependency install instructions for pip users.

The existing pip install earth2studio[graphcast] command can resolve the unrelated PyPI graphcast package instead of the Google DeepMind GraphCast package used by Earth2Studio. This updates the install guide to explicitly install GraphCast from the pinned Google DeepMind git commit.

https://github.com/NVIDIA/earth2studio/blob/main/pyproject.toml#L369

Closes #996

## Validation

- uv run pre-commit run markdownlint --files docs/userguide/about/install.md
