### PR TITLE
Add cycle-aware NCEP observation windows

### DIFF
--- a/.claude/skills-dev/developer-bump-version/SKILL.md
+++ b/.claude/skills-dev/developer-bump-version/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: developer-bump-version
+version: 0.16.0
+license: Apache-2.0
+metadata:
+  author: NVIDIA Earth-2 Team
+  tags:
+    - earth2studio
+    - earth2
+    - python
+    - release
+    - versioning
+    - changelog
+description: >
+  Bump the Earth2Studio version on main to start a new development cycle. This
+  unblocks commits on main after a release branch has been merged. Performs a
+  CHANGELOG update (new blank section) and a hatch version bump. Use when main
+  already has the release merge but still carries the old version string, or
+  when the developer-release-rebase skill detects the version was already bumped
+  during rebase and only the changelog/version housekeeping remains.
+---
+
+# Bump Version — Start New Development Cycle on Main
+
+Bump the Earth2Studio package version on `main` to the next minor alpha and
+insert a blank CHANGELOG section. This is the minimal set of changes needed to
+unblock further development commits on main after a release branch merge.
+
+Follow every step below **in order**. Each confirmation gate requires explicit
+user approval before proceeding.
+
+---
+
+## Step 1 — Determine the Next Version and Create Branch
+
+1. Read `earth2studio/__init__.py` to get the current `__version__` string.
+2. Compute the **next minor alpha**:
+   - If current is `X.Y.0` (release), next is `X.(Y+1).0a0`.
+   - If current is `X.Y.0rcN` or `X.Y.0aN`, next is `X.(Y+1).0a0`.
+   - If the version already ends in `a0` at the expected next minor, the bump
+     may already be done — note this and confirm with the user.
+3. Read `CHANGELOG.md` and check whether a section for the target version
+   already exists. If it does, the bump is already complete — inform the user
+   and stop.
+
+### **[CONFIRM — Version]**
+
+Print the current version, the target version, and ask the user to confirm
+before proceeding.
+
+### 1b — Create or verify the bump branch
+
+Check the current branch name:
+
+```bash
+git branch --show-current
+```
+
+If already on a branch named `version-bump-X.(Y+1).0a0`, skip branch creation.
+
+Otherwise, create a new branch from `main`:
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b version-bump-X.(Y+1).0a0
+```
+
+(Replace `X.(Y+1).0a0` with the actual computed target version.)
+
+---
+
+## Step 2 — Update CHANGELOG.md
+
+Read `CHANGELOG.md` and insert a new blank section **above** the most recent
+version entry. Use `xxxx-xx-xx` as the date placeholder — never fill in today's
+date for the new development version.
+
+The new section must look exactly like this (substituting the version number):
+
+```markdown
+## [X.(Y+1).0a0] - xxxx-xx-xx
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Dependencies
+
+```
+
+Also ensure the **released** version section (the one just below):
+
+1. Has unused (empty) subsections removed.
+2. Does **not** have the alpha/rc extension in its version (e.g., `[0.16.0]`
+   not `[0.16.0a0]`).
+3. Has a release date set in `YYYY-MM-DD` format.
+
+### **[CONFIRM — Release Date]**
+
+If the use doesn't know, just keep it as is, make sure to tell user this is an option.
+If the released section does not already have a date set, ask the user what
+date to use before proceeding.
+
+---
+
+## Step 3 — Bump the Package Version
+
+Run these two commands in sequence:
+
+```bash
+uv run hatch version minor
+uv run hatch version alpha
+```
+
+After running, read `earth2studio/__init__.py` and confirm it now contains the
+expected `X.(Y+1).0a0` version string.
+
+If a pre-commit hook (`pyupgrade` or similar) fails due to a Python version
+incompatibility, it is safe to skip with `SKIP=pyupgrade` on the subsequent
+commit step — note this to the user.
+
+---
+
+## Step 4 — Commit and Push
+
+Stage only the expected files and commit:
+
+```bash
+git add CHANGELOG.md earth2studio/__init__.py
+git commit -m "Bump version to X.(Y+1).0a0"
+```
+
+Push the branch (or the current branch if already on a feature branch):
+
+```bash
+git push origin HEAD
+```
+
+### **[REMIND — PR or Direct Push]**
+
+After pushing, remind the user:
+
+> If main is protected, open a PR titled **"Bump version to X.(Y+1).0a0"**
+> targeting `main`. Otherwise the direct push is sufficient.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `cycle_aware` option to UFS, GDAS, and NNJA observation sources to control
+  whether future cycle files are included for tolerance-window reads.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0a0] - 2026-07-xx
+## [0.18.0a0] - xxxx-xx-xx
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Dependencies
+
+## [0.17.0] - 2026-07-xx
 
 ### Added
 
@@ -59,10 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `NomadsGDASObsConv` `max_workers` parameter to `async_workers` for
   consistency with other observation data sources
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Fixed `PrecipitationAFNOv2` and `WindgustAFNO` passing latitude and longitude in
@@ -86,8 +98,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ACE2ERA5 forcing data retrieval for static variables requested across
   multiple times.
 - Added CF-convention scale/offset when retrieving JPSS data.
-
-### Security
 
 ### Dependencies
 

--- a/earth2studio/__init__.py
+++ b/earth2studio/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17.0a0"
+__version__ = "0.18.0a0"
 
 # Deprecation warnings
 # import sys

--- a/earth2studio/data/gdas.py
+++ b/earth2studio/data/gdas.py
@@ -87,6 +87,8 @@ class NomadsGDASObsConv:
         Time tolerance window for filtering observations. Accepts a single value
         (symmetric +/- window) or a tuple (lower, upper) for asymmetric windows,
         by default np.timedelta64(10, "m").
+    cycle_aware : bool, optional
+        Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache downloaded observation files locally, by default True.
     verbose : bool, optional
@@ -132,6 +134,7 @@ class NomadsGDASObsConv:
     def __init__(
         self,
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
+        cycle_aware: bool = True,
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
@@ -146,6 +149,7 @@ class NomadsGDASObsConv:
         self._tolerance_lower = pd.to_timedelta(self._tolerance_lower).to_pytimedelta()
         self._tolerance_upper = pd.to_timedelta(self._tolerance_upper).to_pytimedelta()
         self._cache = cache
+        self._cycle_aware = cycle_aware
         self._verbose = verbose
         self.async_timeout = async_timeout
         self._async_workers = async_workers
@@ -267,7 +271,12 @@ class NomadsGDASObsConv:
     ) -> list[NCEPObsTask]:
         """Build download tasks for required 6h PrepBUFR cycles."""
         return plan_conv_tasks(
-            cycle_windows(times, self._tolerance_lower, self._tolerance_upper),
+            cycle_windows(
+                times,
+                self._tolerance_lower,
+                self._tolerance_upper,
+                cycle_aware=self._cycle_aware,
+            ),
             variables,
             GDASObsConvLexicon,
             self._build_uri,

--- a/earth2studio/data/nnja.py
+++ b/earth2studio/data/nnja.py
@@ -140,6 +140,8 @@ class NNJAObsConv:
         Time tolerance window for filtering observations. Accepts a single
         value (symmetric ± window) or a tuple ``(lower, upper)`` for
         asymmetric windows, by default ``np.timedelta64(0, 'm')``.
+    cycle_aware : bool, optional
+        Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache downloaded files in the local filesystem cache, by default True.
     verbose : bool, optional
@@ -187,6 +189,7 @@ class NNJAObsConv:
         self,
         source: str = "prepbufr",
         time_tolerance: TimeTolerance = np.timedelta64(0, "m"),
+        cycle_aware: bool = True,
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
@@ -213,6 +216,7 @@ class NNJAObsConv:
         self._map_acft_profile_report_types = True
         self._verbose = verbose
         self._cache = cache
+        self._cycle_aware = cycle_aware
         self._async_workers = async_workers
         self._decode_workers = max(1, decode_workers)
         self._retries = retries
@@ -330,7 +334,12 @@ class NNJAObsConv:
         self, time_list: list[datetime], variable: list[str]
     ) -> list[NCEPObsTask]:
         return plan_conv_tasks(
-            cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper),
+            cycle_windows(
+                time_list,
+                self._tolerance_lower,
+                self._tolerance_upper,
+                cycle_aware=self._cycle_aware,
+            ),
             variable,
             self.LEXICON,
             self._build_uri,
@@ -463,6 +472,8 @@ class NNJAObsSat:
     satellites : list[str] | None, optional
         Satellite platforms to include. ``None`` includes every platform in
         the requested aggregate files.
+    cycle_aware : bool, optional
+        Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache downloaded files in the local filesystem cache, by default True.
     verbose : bool, optional
@@ -515,6 +526,7 @@ class NNJAObsSat:
         self,
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         satellites: list[str] | None = None,
+        cycle_aware: bool = True,
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
@@ -535,6 +547,7 @@ class NNJAObsSat:
 
         self._verbose = verbose
         self._cache = cache
+        self._cycle_aware = cycle_aware
         self._async_workers = async_workers
         self._decode_workers = max(1, decode_workers)
         self._retries = retries
@@ -688,7 +701,12 @@ class NNJAObsSat:
                 raise ValueError(f"Invalid NNJA satellite lexicon key: {source_key}")
             variables_by_sensor.setdefault(sensor, {})[variable_name] = source_field
 
-        windows = cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper)
+        windows = cycle_windows(
+            time_list,
+            self._tolerance_lower,
+            self._tolerance_upper,
+            cycle_aware=self._cycle_aware,
+        )
         tasks: list[_NNJASatTask] = []
         for sensor, var_plan in variables_by_sensor.items():
             product = _NNJA_SAT_PRODUCTS[sensor]

--- a/earth2studio/data/ufs.py
+++ b/earth2studio/data/ufs.py
@@ -73,11 +73,11 @@ class _UFSObsBase:
     def __init__(
         self,
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
-        max_workers: int = 24,
         cycle_aware: bool = True,
         cache: bool = True,
-        async_timeout: int = 600,
         verbose: bool = True,
+        async_timeout: int = 600,
+        max_workers: int = 24,
     ) -> None:
         self.obs_type = "ges"
         self._verbose = verbose
@@ -443,17 +443,17 @@ class UFSObsConv(_UFSObsBase):
         Time tolerance window for filtering observations. Accepts a single value
         (symmetric ± window) or a tuple (lower, upper) for asymmetric windows,
         by default, np.timedelta64(10, 'm').
-    max_workers : int, optional
-        Max workers in async IO thread pool for concurrent downloads, by default 24.
     cycle_aware : bool, optional
         Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache data source in local filesystem cache, by default True.
+    verbose : bool, optional
+        Log basic progress information, by default True.
     async_timeout : int, optional
         Time in seconds after which the async fetch will be cancelled if not finished,
         by default 600.
-    verbose : bool, optional
-        Log basic progress information, by default True.
+    max_workers : int, optional
+        Max workers in async IO thread pool for concurrent downloads, by default 24.
 
     Warning
     -------
@@ -593,17 +593,17 @@ class UFSObsSat(_UFSObsBase):
         by default, np.timedelta64(10, 'm').
     satellites : list[str], optional
         List of satellite platforms to include, by default includes all platforms.
-    max_workers : int, optional
-        Max workers in async IO thread pool for concurrent downloads, by default 24.
     cycle_aware : bool, optional
         Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache data source in local filesystem cache, by default True.
+    verbose : bool, optional
+        Log basic progress information, by default True.
     async_timeout : int, optional
         Time in seconds after which the async fetch will be cancelled if not finished,
         by default 600.
-    verbose : bool, optional
-        Log basic progress information, by default True.
+    max_workers : int, optional
+        Max workers in async IO thread pool for concurrent downloads, by default 24.
 
     Warning
     -------
@@ -706,11 +706,11 @@ class UFSObsSat(_UFSObsBase):
         self,
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         satellites: list[str] | None = None,
-        max_workers: int = 24,
         cycle_aware: bool = True,
         cache: bool = True,
-        async_timeout: int = 600,
         verbose: bool = True,
+        async_timeout: int = 600,
+        max_workers: int = 24,
     ) -> None:
         if satellites is None:
             satellites = list(self.VALID_SATELLITES)
@@ -724,11 +724,11 @@ class UFSObsSat(_UFSObsBase):
         self.satellites = satellites
         super().__init__(
             time_tolerance=time_tolerance,
-            max_workers=max_workers,
             cycle_aware=cycle_aware,
             cache=cache,
-            async_timeout=async_timeout,
             verbose=verbose,
+            async_timeout=async_timeout,
+            max_workers=max_workers,
         )
 
     def _create_tasks(

--- a/earth2studio/data/ufs.py
+++ b/earth2studio/data/ufs.py
@@ -30,11 +30,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 from loguru import logger
-from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     _sync_async,
     datasource_cache_root,
+    gather_with_concurrency,
     obstore_fetch_to_cache,
     obstore_store_from_url,
     prep_data_inputs,
@@ -77,19 +77,19 @@ class _UFSObsBase:
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
-        max_workers: int = 24,
+        async_workers: int = 24,
     ) -> None:
         self.obs_type = "ges"
         self._verbose = verbose
         self._cache = cache
         self._cycle_aware = cycle_aware
-        self._max_workers = max_workers
+        self._async_workers = async_workers
         self.async_timeout = async_timeout
         self._tmp_cache_hash: str | None = None
         # Anonymous obstore S3 store for the public NOAA UFS replay bucket.
         self._store = obstore_store_from_url(
             f"s3://{self.UFS_BUCKET}",
-            max_pool_connections=self._max_workers,
+            max_pool_connections=self._async_workers,
             region=self._region,
         )
 
@@ -142,8 +142,11 @@ class _UFSObsBase:
         async_tasks = self._create_tasks(time_list, variable_list)
         file_key_set = {task.gsi_obs_key for task in async_tasks}
         fetch_jobs = [self._fetch_remote_file(key) for key in file_key_set]
-        await tqdm.gather(
-            *fetch_jobs, desc="Fetching GSI files", disable=(not self._verbose)
+        await gather_with_concurrency(
+            fetch_jobs,
+            max_workers=self._async_workers,
+            desc="Fetching GSI files",
+            verbose=(not self._verbose),
         )
 
         df = self._compile_dataframe(async_tasks, variable_list, schema)
@@ -452,8 +455,8 @@ class UFSObsConv(_UFSObsBase):
     async_timeout : int, optional
         Time in seconds after which the async fetch will be cancelled if not finished,
         by default 600.
-    max_workers : int, optional
-        Max workers in async IO thread pool for concurrent downloads, by default 24.
+    async_workers : int, optional
+        Number of concurrent async download workers, by default 24.
 
     Warning
     -------
@@ -602,8 +605,8 @@ class UFSObsSat(_UFSObsBase):
     async_timeout : int, optional
         Time in seconds after which the async fetch will be cancelled if not finished,
         by default 600.
-    max_workers : int, optional
-        Max workers in async IO thread pool for concurrent downloads, by default 24.
+    async_workers : int, optional
+        Number of concurrent async download workers, by default 24.
 
     Warning
     -------
@@ -710,7 +713,7 @@ class UFSObsSat(_UFSObsBase):
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
-        max_workers: int = 24,
+        async_workers: int = 24,
     ) -> None:
         if satellites is None:
             satellites = list(self.VALID_SATELLITES)
@@ -728,7 +731,7 @@ class UFSObsSat(_UFSObsBase):
             cache=cache,
             verbose=verbose,
             async_timeout=async_timeout,
-            max_workers=max_workers,
+            async_workers=async_workers,
         )
 
     def _create_tasks(

--- a/earth2studio/data/ufs.py
+++ b/earth2studio/data/ufs.py
@@ -23,7 +23,7 @@ import shutil
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import h5netcdf
 import numpy as np
@@ -39,6 +39,7 @@ from earth2studio.data.utils import (
     obstore_store_from_url,
     prep_data_inputs,
 )
+from earth2studio.data.utils_ncep import cycle_windows
 from earth2studio.lexicon import GSIConventionalLexicon, GSISatelliteLexicon
 from earth2studio.utils.time import normalize_time_tolerance
 from earth2studio.utils.type import TimeArray, TimeTolerance, VariableArray
@@ -515,6 +516,7 @@ class UFSObsConv(_UFSObsBase):
         self, time_list: list[datetime], variable: list[str]
     ) -> list[_GSIAsyncTask]:
         tasks: list[_GSIAsyncTask] = []
+        windows = cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper)
         for v in variable:
             try:
                 gsi_name, modifier = GSIConventionalLexicon[v]  # type: ignore
@@ -528,28 +530,22 @@ class UFSObsConv(_UFSObsBase):
                 logger.error(f"Variable id {v} not found in GSI lexicon")
                 raise
 
-            for t in time_list:
-                tmin = t + self._tolerance_lower
-                tmax = t + self._tolerance_upper
-                day = tmin.replace(minute=0, second=0, microsecond=0)
-                day = day.replace(hour=(day.hour // 6) * 6)
-                while day <= tmax:
-                    year_key = day.strftime("%Y")
-                    month_key = day.strftime("%m")
-                    datetime_key = day.strftime("%Y%m%d%H")
-                    obs_key = f"{year_key}/{month_key}/{datetime_key}/gsi/diag_{gsi_platform}_{gsi_sensor}_{gsi_product}.{datetime_key}_control.nc4"
-                    tasks.append(
-                        _GSIAsyncTask(
-                            datetime_file=day,
-                            datetime_min=tmin,
-                            datetime_max=tmax,
-                            gsi_obs_key=obs_key,
-                            gsi_modifier=modifier,
-                            gsi_obs_name=gsi_name,
-                            e2s_obs_name=v,
-                        )
+            for day, (tmin, tmax) in windows.items():
+                year_key = day.strftime("%Y")
+                month_key = day.strftime("%m")
+                datetime_key = day.strftime("%Y%m%d%H")
+                obs_key = f"{year_key}/{month_key}/{datetime_key}/gsi/diag_{gsi_platform}_{gsi_sensor}_{gsi_product}.{datetime_key}_control.nc4"
+                tasks.append(
+                    _GSIAsyncTask(
+                        datetime_file=day,
+                        datetime_min=tmin,
+                        datetime_max=tmax,
+                        gsi_obs_key=obs_key,
+                        gsi_modifier=modifier,
+                        gsi_obs_name=gsi_name,
+                        e2s_obs_name=v,
                     )
-                    day = day + timedelta(hours=6)
+                )
         return tasks
 
     def _transform_column(
@@ -726,6 +722,7 @@ class UFSObsSat(_UFSObsBase):
         self, time_list: list[datetime], variable: list[str]
     ) -> list[_GSIAsyncTask]:
         tasks: list[_GSIAsyncTask] = []
+        windows = cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper)
         for v in variable:
             try:
                 gsi_name, modifier = GSISatelliteLexicon[v]  # type: ignore
@@ -743,29 +740,23 @@ class UFSObsSat(_UFSObsBase):
                 raise
 
             for gsi_platform in gsi_platforms:
-                for t in time_list:
-                    tmin = t + self._tolerance_lower
-                    tmax = t + self._tolerance_upper
-                    day = tmin.replace(minute=0, second=0, microsecond=0)
-                    day = day.replace(hour=(day.hour // 6) * 6)
-                    while day <= tmax:
-                        year_key = day.strftime("%Y")
-                        month_key = day.strftime("%m")
-                        datetime_key = day.strftime("%Y%m%d%H")
-                        obs_key = f"{year_key}/{month_key}/{datetime_key}/gsi/diag_{gsi_sensor}_{gsi_platform}_{gsi_product}.{datetime_key}_control.nc4"
-                        tasks.append(
-                            _GSIAsyncTask(
-                                datetime_file=day,
-                                datetime_min=tmin,
-                                datetime_max=tmax,
-                                gsi_obs_key=obs_key,
-                                gsi_modifier=modifier,
-                                gsi_obs_name=gsi_name,
-                                e2s_obs_name=v,
-                                satellite=gsi_platform,
-                            )
+                for day, (tmin, tmax) in windows.items():
+                    year_key = day.strftime("%Y")
+                    month_key = day.strftime("%m")
+                    datetime_key = day.strftime("%Y%m%d%H")
+                    obs_key = f"{year_key}/{month_key}/{datetime_key}/gsi/diag_{gsi_sensor}_{gsi_platform}_{gsi_product}.{datetime_key}_control.nc4"
+                    tasks.append(
+                        _GSIAsyncTask(
+                            datetime_file=day,
+                            datetime_min=tmin,
+                            datetime_max=tmax,
+                            gsi_obs_key=obs_key,
+                            gsi_modifier=modifier,
+                            gsi_obs_name=gsi_name,
+                            e2s_obs_name=v,
+                            satellite=gsi_platform,
                         )
-                        day = day + timedelta(hours=6)
+                    )
         return tasks
 
     def _build_column_map(self, schema: pa.Schema) -> dict[str, str]:

--- a/earth2studio/data/ufs.py
+++ b/earth2studio/data/ufs.py
@@ -74,6 +74,7 @@ class _UFSObsBase:
         self,
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         max_workers: int = 24,
+        cycle_aware: bool = True,
         cache: bool = True,
         async_timeout: int = 600,
         verbose: bool = True,
@@ -81,6 +82,7 @@ class _UFSObsBase:
         self.obs_type = "ges"
         self._verbose = verbose
         self._cache = cache
+        self._cycle_aware = cycle_aware
         self._max_workers = max_workers
         self.async_timeout = async_timeout
         self._tmp_cache_hash: str | None = None
@@ -443,6 +445,8 @@ class UFSObsConv(_UFSObsBase):
         by default, np.timedelta64(10, 'm').
     max_workers : int, optional
         Max workers in async IO thread pool for concurrent downloads, by default 24.
+    cycle_aware : bool, optional
+        Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache data source in local filesystem cache, by default True.
     async_timeout : int, optional
@@ -516,7 +520,12 @@ class UFSObsConv(_UFSObsBase):
         self, time_list: list[datetime], variable: list[str]
     ) -> list[_GSIAsyncTask]:
         tasks: list[_GSIAsyncTask] = []
-        windows = cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper)
+        windows = cycle_windows(
+            time_list,
+            self._tolerance_lower,
+            self._tolerance_upper,
+            cycle_aware=self._cycle_aware,
+        )
         for v in variable:
             try:
                 gsi_name, modifier = GSIConventionalLexicon[v]  # type: ignore
@@ -586,6 +595,8 @@ class UFSObsSat(_UFSObsBase):
         List of satellite platforms to include, by default includes all platforms.
     max_workers : int, optional
         Max workers in async IO thread pool for concurrent downloads, by default 24.
+    cycle_aware : bool, optional
+        Exclude future cycle files relative to the upper tolerance bound, by default True.
     cache : bool, optional
         Cache data source in local filesystem cache, by default True.
     async_timeout : int, optional
@@ -696,6 +707,7 @@ class UFSObsSat(_UFSObsBase):
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         satellites: list[str] | None = None,
         max_workers: int = 24,
+        cycle_aware: bool = True,
         cache: bool = True,
         async_timeout: int = 600,
         verbose: bool = True,
@@ -713,6 +725,7 @@ class UFSObsSat(_UFSObsBase):
         super().__init__(
             time_tolerance=time_tolerance,
             max_workers=max_workers,
+            cycle_aware=cycle_aware,
             cache=cache,
             async_timeout=async_timeout,
             verbose=verbose,
@@ -722,7 +735,12 @@ class UFSObsSat(_UFSObsBase):
         self, time_list: list[datetime], variable: list[str]
     ) -> list[_GSIAsyncTask]:
         tasks: list[_GSIAsyncTask] = []
-        windows = cycle_windows(time_list, self._tolerance_lower, self._tolerance_upper)
+        windows = cycle_windows(
+            time_list,
+            self._tolerance_lower,
+            self._tolerance_upper,
+            cycle_aware=self._cycle_aware,
+        )
         for v in variable:
             try:
                 gsi_name, modifier = GSISatelliteLexicon[v]  # type: ignore

--- a/earth2studio/data/utils_ncep.py
+++ b/earth2studio/data/utils_ncep.py
@@ -890,8 +890,7 @@ def decode_prepbufr(
                 )
             )
     logger.debug(
-        f"Decoded {len(rows):,} PrepBUFR rows in "
-        f"{time.perf_counter() - started:.1f}s"
+        f"Decoded {len(rows):,} PrepBUFR rows in {time.perf_counter() - started:.1f}s"
     )
     return _finalize_rows(
         rows,
@@ -1046,13 +1045,15 @@ def observation_cycle_times(
     tolerance_lower: timedelta,
     tolerance_upper: timedelta,
     cadence: timedelta = timedelta(hours=6),
+    cycle_aware: bool = True,
 ) -> list[datetime]:
-    """Return cadence file times whose observation windows overlap a request.
+    """Return cadence file times needed for a requested observation window.
 
-    Each file timestamp is treated as the end of its observation window, so a
-    file at ``T`` may contain observations from ``(T - cadence, T]``. This means
-    requests often need the next cycle file as well as the cycle at or before
-    the requested time.
+    When ``cycle_aware`` is ``True``, only files with cycle timestamps at or
+    before the request's upper tolerance bound are returned. When
+    ``cycle_aware`` is ``False``, the first cycle after the upper tolerance bound
+    is also returned so retrospective reads can include observations stored in a
+    later cycle file.
 
     Parameters
     ----------
@@ -1064,12 +1065,14 @@ def observation_cycle_times(
         Upper tolerance bound relative to ``time``.
     cadence : timedelta, optional
         Cadence between published files, by default ``timedelta(hours=6)``.
+    cycle_aware : bool, optional
+        Whether to exclude future cycle files relative to the request's upper
+        tolerance bound, by default ``True``.
 
     Returns
     -------
     list[datetime]
-        Cadence-aligned file timestamps whose backward-looking observation
-        windows overlap ``[time + tolerance_lower, time + tolerance_upper]``.
+        Cadence-aligned file timestamps for the requested observation window.
 
     Raises
     ------
@@ -1083,13 +1086,18 @@ def observation_cycle_times(
     tmax = time + tolerance_upper
     day_start = tmin.replace(hour=0, minute=0, second=0, microsecond=0)
     cycle = day_start + ((tmin - day_start) // cadence) * cadence
-    if cycle < tmin:
+    if not cycle_aware and tolerance_lower >= timedelta(0) and cycle < tmin:
         cycle += cadence
 
     cycles: list[datetime] = []
-    while cycle < tmax + cadence:
-        cycles.append(cycle)
-        cycle += cadence
+    if cycle_aware:
+        while cycle <= tmax:
+            cycles.append(cycle)
+            cycle += cadence
+    else:
+        while cycle < tmax + cadence:
+            cycles.append(cycle)
+            cycle += cadence
     return cycles
 
 
@@ -1098,6 +1106,7 @@ def cycle_windows(
     tolerance_lower: timedelta,
     tolerance_upper: timedelta,
     cadence: timedelta = timedelta(hours=6),
+    cycle_aware: bool = True,
 ) -> dict[datetime, tuple[datetime, datetime]]:
     """Map cadence file times to merged requested observation windows.
 
@@ -1111,6 +1120,9 @@ def cycle_windows(
         Upper tolerance bound relative to each requested timestamp.
     cadence : timedelta, optional
         Cadence between published files, by default ``timedelta(hours=6)``.
+    cycle_aware : bool, optional
+        Whether to exclude future cycle files relative to each request's upper
+        tolerance bound, by default ``True``.
 
     Returns
     -------
@@ -1123,7 +1135,7 @@ def cycle_windows(
         tmin = t + tolerance_lower
         tmax = t + tolerance_upper
         for cycle in observation_cycle_times(
-            t, tolerance_lower, tolerance_upper, cadence
+            t, tolerance_lower, tolerance_upper, cadence, cycle_aware=cycle_aware
         ):
             existing = windows.get(cycle)
             windows[cycle] = (
@@ -1163,8 +1175,7 @@ def resolve_output_schema(
     for name in fields:
         if name not in schema.names:
             raise KeyError(
-                f"Field '{name}' not in {class_name} SCHEMA. "
-                f"Available: {schema.names}"
+                f"Field '{name}' not in {class_name} SCHEMA. Available: {schema.names}"
             )
         selected.append(schema.field(name))
     return pa.schema(selected)

--- a/earth2studio/data/utils_ncep.py
+++ b/earth2studio/data/utils_ncep.py
@@ -667,6 +667,7 @@ def _extract_gpsro_subset(
 def empty_dataframe(
     schema: pa.Schema = NCEP_CONVENTIONAL_PUBLIC_SCHEMA,
 ) -> pd.DataFrame:
+    """Return a typed empty DataFrame for a PyArrow schema."""
     # Build typed empty columns (not object-dtype ``None``) so ``pd.concat`` does
     # not emit "all-NA columns" FutureWarnings when frames from different
     # sub-archives are concatenated.
@@ -1049,11 +1050,11 @@ def observation_cycle_times(
 ) -> list[datetime]:
     """Return cadence file times needed for a requested observation window.
 
-    When ``cycle_aware`` is ``True``, only files with cycle timestamps at or
-    before the request's upper tolerance bound are returned. When
-    ``cycle_aware`` is ``False``, the first cycle after the upper tolerance bound
-    is also returned so retrospective reads can include observations stored in a
-    later cycle file.
+    File selection starts at the cadence floor of the request's lower tolerance
+    bound. When ``cycle_aware`` is ``True``, only files with cycle timestamps at
+    or before the upper tolerance bound are returned. When ``cycle_aware`` is
+    ``False``, the first cycle after the upper tolerance bound is also returned
+    so retrospective reads can include observations stored in a later cycle file.
 
     Parameters
     ----------
@@ -1086,18 +1087,12 @@ def observation_cycle_times(
     tmax = time + tolerance_upper
     day_start = tmin.replace(hour=0, minute=0, second=0, microsecond=0)
     cycle = day_start + ((tmin - day_start) // cadence) * cadence
-    if not cycle_aware and tolerance_lower >= timedelta(0) and cycle < tmin:
-        cycle += cadence
 
+    cycle_end = tmax if cycle_aware else tmax + cadence
     cycles: list[datetime] = []
-    if cycle_aware:
-        while cycle <= tmax:
-            cycles.append(cycle)
-            cycle += cadence
-    else:
-        while cycle < tmax + cadence:
-            cycles.append(cycle)
-            cycle += cadence
+    while cycle <= cycle_end:
+        cycles.append(cycle)
+        cycle += cadence
     return cycles
 
 

--- a/test/data/test_gdas.py
+++ b/test/data/test_gdas.py
@@ -176,12 +176,12 @@ def test_nomads_gdas_available():
 def test_nomads_gdas_url_builder():
     ds = NomadsGDASObsConv(cache=False, verbose=False)
     uri = ds._build_uri("prepbufr", datetime(2026, 4, 5, 12))
-    expected = "pub/data/nccf/com/obsproc/prod/" "gdas.20260405/gdas.t12z.prepbufr.nr"
+    expected = "pub/data/nccf/com/obsproc/prod/gdas.20260405/gdas.t12z.prepbufr.nr"
     assert uri == expected
 
     gpsro_uri = ds._build_uri("gpsro", datetime(2026, 4, 5, 12))
     assert gpsro_uri == (
-        "pub/data/nccf/com/obsproc/prod/" "gdas.20260405/gdas.t12z.gpsro.tm00.bufr_d.nr"
+        "pub/data/nccf/com/obsproc/prod/gdas.20260405/gdas.t12z.gpsro.tm00.bufr_d.nr"
     )
 
 
@@ -341,6 +341,27 @@ def test_nomads_gdas_create_tasks():
     assert gpsro_task.uri.endswith(".gpsro.tm00.bufr_d.nr")
     assert "t" in prepbufr_task.var_plan
     assert "gps" in gpsro_task.var_plan
+
+    cycle = datetime(2026, 4, 4, 0)
+    aware_ds = NomadsGDASObsConv(
+        time_tolerance=(timedelta(hours=-3), timedelta(hours=3)),
+        cycle_aware=True,
+    )
+    unaware_ds = NomadsGDASObsConv(
+        time_tolerance=(timedelta(hours=-3), timedelta(hours=3)),
+        cycle_aware=False,
+    )
+    assert [task.datetime_file for task in aware_ds._create_tasks([cycle], ["t"])] == [
+        datetime(2026, 4, 3, 18),
+        cycle,
+    ]
+    assert [
+        task.datetime_file for task in unaware_ds._create_tasks([cycle], ["t"])
+    ] == [
+        datetime(2026, 4, 3, 18),
+        cycle,
+        datetime(2026, 4, 4, 6),
+    ]
 
     windowed_ds = NomadsGDASObsConv(time_tolerance=timedelta(minutes=20))
     windowed_tasks = windowed_ds._create_tasks(

--- a/test/data/test_nnja.py
+++ b/test/data/test_nnja.py
@@ -174,6 +174,30 @@ def test_nnja_obs_conv_tolerance_conversion():
     assert ds_asym._tolerance_upper == timedelta(hours=1)
 
 
+def test_nnja_obs_conv_cycle_aware_task_selection():
+    requested = datetime(2024, 1, 1)
+    tolerance = (timedelta(hours=-3), timedelta(hours=3))
+
+    aware = NNJAObsConv(
+        time_tolerance=tolerance, cycle_aware=True, cache=False, verbose=False
+    )
+    unaware = NNJAObsConv(
+        time_tolerance=tolerance, cycle_aware=False, cache=False, verbose=False
+    )
+
+    assert [task.datetime_file for task in aware._create_tasks([requested], ["t"])] == [
+        datetime(2023, 12, 31, 18),
+        requested,
+    ]
+    assert [
+        task.datetime_file for task in unaware._create_tasks([requested], ["t"])
+    ] == [
+        datetime(2023, 12, 31, 18),
+        requested,
+        datetime(2024, 1, 1, 6),
+    ]
+
+
 def test_nnja_obs_conv_resolve_fields():
     schema_full = NNJAObsConv.resolve_fields(None)
     assert schema_full.names == NNJAObsConv.SCHEMA.names
@@ -1186,8 +1210,8 @@ def test_nnja_obs_sat_cycle_windows_follow_nnja_cycle_selection():
     requested = datetime(2024, 1, 1)
     tasks = source._create_tasks([requested, requested], ["atms"])
     assert [task.datetime_file for task in tasks] == [
+        datetime(2023, 12, 31, 18),
         requested,
-        requested + timedelta(hours=6),
     ]
 
     source = NNJAObsSat(
@@ -1198,6 +1222,23 @@ def test_nnja_obs_sat_cycle_windows_follow_nnja_cycle_selection():
     )
     tasks = source._create_tasks([requested], ["atms"])
     assert [task.datetime_file for task in tasks] == [
+        datetime(2023, 12, 31, 0),
+        datetime(2023, 12, 31, 6),
+        datetime(2023, 12, 31, 12),
+        datetime(2023, 12, 31, 18),
+        requested,
+    ]
+
+    source = NNJAObsSat(
+        time_tolerance=(timedelta(hours=-21), timedelta(hours=3)),
+        cycle_aware=False,
+        cache=False,
+        verbose=False,
+        decode_workers=1,
+    )
+    tasks = source._create_tasks([requested], ["atms"])
+    assert [task.datetime_file for task in tasks] == [
+        datetime(2023, 12, 31, 0),
         datetime(2023, 12, 31, 6),
         datetime(2023, 12, 31, 12),
         datetime(2023, 12, 31, 18),

--- a/test/data/test_ufs.py
+++ b/test/data/test_ufs.py
@@ -176,6 +176,32 @@ def test_ufsobsconv_tolerance_conversion():
     assert ds_asym._tolerance_upper == timedelta(hours=1)
 
 
+def test_ufsobs_create_tasks_use_cycle_windows():
+    time = datetime(2024, 1, 1, 0)
+    tolerance = (np.timedelta64(0, "h"), np.timedelta64(4, "h"))
+    expected_cycles = [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)]
+    expected_max = datetime(2024, 1, 1, 4)
+
+    sources = [
+        (UFSObsConv(time_tolerance=tolerance, cache=False, verbose=False), "t"),
+        (
+            UFSObsSat(
+                time_tolerance=tolerance,
+                satellites=["npp"],
+                cache=False,
+                verbose=False,
+            ),
+            "atms",
+        ),
+    ]
+
+    for ds, variable in sources:
+        tasks = ds._create_tasks([time], [variable])
+        assert [task.datetime_file for task in tasks] == expected_cycles
+        assert {task.datetime_min for task in tasks} == {time}
+        assert {task.datetime_max for task in tasks} == {expected_max}
+
+
 @pytest.mark.parametrize("cls", [UFSObsConv, UFSObsSat])
 def test_ufsobs_missing_file_warns_not_raises(cls, caplog):
     """A missing diag file warns and returns rather than aborting the fetch.

--- a/test/data/test_ufs.py
+++ b/test/data/test_ufs.py
@@ -176,18 +176,33 @@ def test_ufsobsconv_tolerance_conversion():
     assert ds_asym._tolerance_upper == timedelta(hours=1)
 
 
-def test_ufsobs_create_tasks_use_cycle_windows():
+@pytest.mark.parametrize(
+    "cycle_aware, expected_cycles",
+    [
+        (True, [datetime(2024, 1, 1, 0)]),
+        (False, [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)]),
+    ],
+)
+def test_ufsobs_create_tasks_use_cycle_windows(cycle_aware, expected_cycles):
     time = datetime(2024, 1, 1, 0)
     tolerance = (np.timedelta64(0, "h"), np.timedelta64(4, "h"))
-    expected_cycles = [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)]
     expected_max = datetime(2024, 1, 1, 4)
 
     sources = [
-        (UFSObsConv(time_tolerance=tolerance, cache=False, verbose=False), "t"),
+        (
+            UFSObsConv(
+                time_tolerance=tolerance,
+                cycle_aware=cycle_aware,
+                cache=False,
+                verbose=False,
+            ),
+            "t",
+        ),
         (
             UFSObsSat(
                 time_tolerance=tolerance,
                 satellites=["npp"],
+                cycle_aware=cycle_aware,
                 cache=False,
                 verbose=False,
             ),

--- a/test/data/test_utils_ncep.py
+++ b/test/data/test_utils_ncep.py
@@ -111,7 +111,7 @@ def test_observation_cycle_times_respect_cycle_awareness():
             timedelta(0),
             timedelta(hours=6),
             False,
-            [datetime(2024, 1, 1, 0)],
+            [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)],
         ),
         (
             datetime(2024, 1, 1, 3),
@@ -127,7 +127,7 @@ def test_observation_cycle_times_respect_cycle_awareness():
             timedelta(0),
             timedelta(hours=6),
             False,
-            [datetime(2024, 1, 1, 6)],
+            [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)],
         ),
         (
             datetime(2024, 1, 1, 5),
@@ -135,7 +135,11 @@ def test_observation_cycle_times_respect_cycle_awareness():
             timedelta(hours=3),
             timedelta(hours=6),
             False,
-            [datetime(2024, 1, 1, 6), datetime(2024, 1, 1, 12)],
+            [
+                datetime(2024, 1, 1, 0),
+                datetime(2024, 1, 1, 6),
+                datetime(2024, 1, 1, 12),
+            ],
         ),
         (
             datetime(2024, 1, 1, 1),
@@ -143,7 +147,7 @@ def test_observation_cycle_times_respect_cycle_awareness():
             timedelta(0),
             timedelta(hours=3),
             False,
-            [datetime(2024, 1, 1, 3)],
+            [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 3)],
         ),
     ]
 

--- a/test/data/test_utils_ncep.py
+++ b/test/data/test_utils_ncep.py
@@ -67,20 +67,50 @@ def _modifiers(lexicon: type, *variables: str) -> dict:
     return {variable: lexicon.get_item(variable)[1] for variable in variables}
 
 
-def test_observation_cycle_times_select_covering_files():
+def test_observation_cycle_times_respect_cycle_awareness():
     cases = [
         (
             datetime(2024, 1, 1, 0),
             timedelta(0),
             timedelta(hours=4),
             timedelta(hours=6),
+            True,
+            [datetime(2024, 1, 1, 0)],
+        ),
+        (
+            datetime(2024, 1, 1, 0),
+            timedelta(0),
+            timedelta(hours=4),
+            timedelta(hours=6),
+            False,
             [datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)],
+        ),
+        (
+            datetime(2024, 1, 1, 0),
+            timedelta(hours=-3),
+            timedelta(hours=3),
+            timedelta(hours=6),
+            True,
+            [datetime(2023, 12, 31, 18), datetime(2024, 1, 1, 0)],
+        ),
+        (
+            datetime(2024, 1, 1, 0),
+            timedelta(hours=-3),
+            timedelta(hours=3),
+            timedelta(hours=6),
+            False,
+            [
+                datetime(2023, 12, 31, 18),
+                datetime(2024, 1, 1, 0),
+                datetime(2024, 1, 1, 6),
+            ],
         ),
         (
             datetime(2024, 1, 1, 0),
             timedelta(0),
             timedelta(0),
             timedelta(hours=6),
+            False,
             [datetime(2024, 1, 1, 0)],
         ),
         (
@@ -88,6 +118,15 @@ def test_observation_cycle_times_select_covering_files():
             timedelta(0),
             timedelta(0),
             timedelta(hours=6),
+            True,
+            [datetime(2024, 1, 1, 0)],
+        ),
+        (
+            datetime(2024, 1, 1, 3),
+            timedelta(0),
+            timedelta(0),
+            timedelta(hours=6),
+            False,
             [datetime(2024, 1, 1, 6)],
         ),
         (
@@ -95,6 +134,7 @@ def test_observation_cycle_times_select_covering_files():
             timedelta(0),
             timedelta(hours=3),
             timedelta(hours=6),
+            False,
             [datetime(2024, 1, 1, 6), datetime(2024, 1, 1, 12)],
         ),
         (
@@ -102,13 +142,17 @@ def test_observation_cycle_times_select_covering_files():
             timedelta(0),
             timedelta(0),
             timedelta(hours=3),
+            False,
             [datetime(2024, 1, 1, 3)],
         ),
     ]
 
-    for time, lower, upper, cadence, expected in cases:
+    for time, lower, upper, cadence, cycle_aware, expected in cases:
         assert (
-            utils_ncep.observation_cycle_times(time, lower, upper, cadence) == expected
+            utils_ncep.observation_cycle_times(
+                time, lower, upper, cadence, cycle_aware=cycle_aware
+            )
+            == expected
         )
 
 


### PR DESCRIPTION
## Summary

Stacked on: https://github.com/NVIDIA/earth2studio/pull/1011

- Route UFS observation task planning through the shared NCEP cycle-window utility.
- Add a `cycle_aware` option to UFS, GDAS, NNJA conventional, and NNJA satellite observation sources.
- Default `cycle_aware=True` excludes future cycle files relative to the request upper tolerance bound; `cycle_aware=False` retains retrospective reads that include the next cycle file when needed.
- Add task-planning tests for cycle-aware and cycle-unaware behavior.

Closes: https://github.com/NVIDIA/earth2studio/issues/967

## Validation

- `uv run ruff check earth2studio/data/utils_ncep.py earth2studio/data/ufs.py earth2studio/data/gdas.py earth2studio/data/nnja.py test/data/test_utils_ncep.py test/data/test_ufs.py test/data/test_gdas.py test/data/test_nnja.py`
- `uv run mypy --ignore-missing-imports earth2studio/data/utils_ncep.py earth2studio/data/ufs.py earth2studio/data/gdas.py earth2studio/data/nnja.py`
- `uv run pytest test/data/test_ufs.py -q -m 'not slow'`
- Direct `observation_cycle_times` assertions for cycle-aware and cycle-unaware windows

Note: local GDAS/NNJA test files are dependency-gated in this environment (`data`/`pybufrkit`) and were skipped by pytest.
