### PR TITLE
Fix StormCastCONUS cropping bug

### DIFF
--- a/earth2studio/models/px/stormcastconus.py
+++ b/earth2studio/models/px/stormcastconus.py
@@ -988,8 +988,8 @@ class _SplitModelWrapper(torch.nn.Module):
         Parameters
         ----------
         bbox : tuple[tuple[int, int], tuple[int, int]]
-            ``((lat_start, lat_end), (lon_start, lon_end))`` indices on the full
-            HRRR grid. Bounds must align with the patch size of ``model_high``.
+            ``((lat_start, lat_end), (lon_start, lon_end))`` indices on the model
+            grid (not the full HRRR grid). Bounds must align with the DiT patch size.
         """
         self.grid_shape = (bbox[0][1] - bbox[0][0], bbox[1][1] - bbox[1][0])
         p = self.model_high.model.model.patch_size

--- a/earth2studio/models/px/stormcastconus.py
+++ b/earth2studio/models/px/stormcastconus.py
@@ -223,7 +223,19 @@ class StormCastCONUS(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                 )
 
             p = self.diffusion_model.model_high.model.model.patch_size
-            if (hrrr_lat_lim[0] - FULL_MODEL_HRRR_BBOX[0][0]) % p[0]:
+
+            crop_bbox = (
+                (
+                    hrrr_lat_lim[0] - FULL_MODEL_HRRR_BBOX[0][0],
+                    hrrr_lat_lim[1] - FULL_MODEL_HRRR_BBOX[0][0],
+                ),
+                (
+                    hrrr_lon_lim[0] - FULL_MODEL_HRRR_BBOX[1][0],
+                    hrrr_lon_lim[1] - FULL_MODEL_HRRR_BBOX[1][0],
+                ),
+            )
+
+            if crop_bbox[0][0] % p[0]:
                 raise ValueError(
                     f"hrrr_lat_lim[0] - {FULL_MODEL_HRRR_BBOX[0]} must be divisible by {p[0]}"
                 )
@@ -231,7 +243,7 @@ class StormCastCONUS(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                 raise ValueError(
                     f"hrrr_lat_lim[1] - hrrr_lat_lim[0] must be divisible by {p[0]}"
                 )
-            if (hrrr_lon_lim[0] - FULL_MODEL_HRRR_BBOX[1][0]) % p[1]:
+            if crop_bbox[1][0] % p[1]:
                 raise ValueError(
                     f"hrrr_lon_lim[0] - {FULL_MODEL_HRRR_BBOX[1]} must be divisible by {p[1]}"
                 )
@@ -240,7 +252,7 @@ class StormCastCONUS(torch.nn.Module, AutoModelMixin, PrognosticMixin):
                     f"hrrr_lon_lim[1] - hrrr_lon_lim[0] must be divisible by {p[1]}"
                 )
 
-            self.diffusion_model.crop_model((hrrr_lat_lim, hrrr_lon_lim))
+            self.diffusion_model.crop_model(crop_bbox)
 
         hrrr_lat, hrrr_lon = HRRR.grid()
         self.lat = hrrr_lat[

--- a/test/models/px/test_stormcastconus.py
+++ b/test/models/px/test_stormcastconus.py
@@ -37,17 +37,48 @@ NVAR = 4  # must include "refc" – it is always indexed in __init__
 NVAR_COND = 5
 
 
+class _Tokenizer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pos_embed = torch.nn.Parameter(
+            torch.arange(16, dtype=torch.float32).reshape(16, 1)
+        )
+        self.input_size = (32, 32)
+        self.h_patches = 4
+        self.w_patches = 4
+
+
+class _Detokenizer:
+    def __init__(self):
+        self.input_size = (32, 32)
+        self.h_patches = 4
+        self.w_patches = 4
+
+
 class _PatchConfig:
-    patch_size = (8, 8)
+    def __init__(self):
+        self.patch_size = (8, 8)
+        self.input_size = (32, 32)
+        self.tokenizer = _Tokenizer()
+        self.detokenizer = _Detokenizer()
+
+
+class _InnerModel:
+    def __init__(self):
+        self.model = _PatchConfig()
+
+
+class _DiffusionSubmodel:
+    def __init__(self):
+        self.model = _InnerModel()
 
 
 class PhooStormCastCONUSDiffusionModel(_SplitModelWrapper):
     """Minimal diffusion model stub for StormCastCONUS unit tests.
 
     Subclasses :class:`_SplitModelWrapper` so that it passes the ``isinstance``
-    check in ``StormCastCONUS.__init__``.  Skips the real ``__init__`` and
-    exposes ``model_high.model.model.patch_size`` as required by the crop_model
-    path.  ``crop_model`` is a no-op.
+    check in ``StormCastCONUS.__init__``. Skips the real ``__init__`` but
+    provides the model structure used by ``_SplitModelWrapper.crop_model``.
     The forward pass returns the (unchanged) noisy input so the diffusion
     sampler converges trivially.
     """
@@ -56,12 +87,22 @@ class PhooStormCastCONUSDiffusionModel(_SplitModelWrapper):
         # Skip _SplitModelWrapper.__init__; only call torch.nn.Module.__init__
         torch.nn.Module.__init__(self)
         self._nvar = nvar
-        dit = _PatchConfig()
-        inner = type("_Inner", (), {"model": dit})()
-        self.model_high = type("_High", (), {"model": inner})()
-
-    def crop_model(self, bbox: tuple) -> None:
-        pass
+        self.model_high = _DiffusionSubmodel()
+        self.model_pz_low = _DiffusionSubmodel()
+        self.model_tq_low = _DiffusionSubmodel()
+        self.model_uv_low = _DiffusionSubmodel()
+        self.models = {
+            "high": self.model_high,
+            "pz_low": self.model_pz_low,
+            "tq_low": self.model_tq_low,
+            "uv_low": self.model_uv_low,
+        }
+        self.full_grid_shape = (32, 32)
+        self.grid_shape = self.full_grid_shape
+        self.pos_embed_full = {
+            key: model.model.model.tokenizer.pos_embed
+            for key, model in self.models.items()
+        }
 
     def forward(
         self, x: torch.Tensor, t: torch.Tensor, condition=None, **kwargs
@@ -111,6 +152,25 @@ def _build_model(
         use_amp=use_amp,
         clamp_values=clamp_values,
     ).to(device)
+
+
+def test_stormcastconus_crop_uses_model_region_coordinates():
+    model = _build_model()
+    diffusion_model = model.diffusion_model
+
+    assert isinstance(diffusion_model, PhooStormCastCONUSDiffusionModel)
+    expected_pos_embed = torch.tensor([[0.0], [1.0], [4.0], [5.0]])
+    assert diffusion_model.grid_shape == (16, 16)
+    for submodel in diffusion_model.models.values():
+        dit = submodel.model.model
+        assert dit.input_size == (16, 16)
+        assert dit.tokenizer.input_size == (16, 16)
+        assert dit.tokenizer.h_patches == 2
+        assert dit.tokenizer.w_patches == 2
+        assert torch.equal(dit.tokenizer.pos_embed, expected_pos_embed)
+        assert dit.detokenizer.input_size == (16, 16)
+        assert dit.detokenizer.h_patches == 2
+        assert dit.detokenizer.w_patches == 2
 
 
 @pytest.mark.parametrize(

--- a/test/models/px/test_stormcastconus.py
+++ b/test/models/px/test_stormcastconus.py
@@ -114,6 +114,8 @@ def _build_model(
     device: str = "cpu",
     use_amp: bool = False,
     clamp_values: bool = False,
+    hrrr_lat_lim: tuple[int, int] = (LAT_START, LAT_END),
+    hrrr_lon_lim: tuple[int, int] = (LON_START, LON_END),
 ) -> StormCastCONUS:
     """Construct a minimal StormCastCONUS for unit testing."""
     diffusion = PhooStormCastCONUSDiffusionModel(NVAR)
@@ -143,8 +145,8 @@ def _build_model(
         invariants,
         conditioning_means,
         conditioning_stds,
-        hrrr_lat_lim=(LAT_START, LAT_END),
-        hrrr_lon_lim=(LON_START, LON_END),
+        hrrr_lat_lim=hrrr_lat_lim,
+        hrrr_lon_lim=hrrr_lon_lim,
         variables=variables,
         conditioning_variables=conditioning_variables,
         conditioning_data_source=r_condition,
@@ -171,6 +173,24 @@ def test_stormcastconus_crop_uses_model_region_coordinates():
         assert dit.detokenizer.input_size == (16, 16)
         assert dit.detokenizer.h_patches == 2
         assert dit.detokenizer.w_patches == 2
+
+
+@pytest.mark.parametrize(
+    "hrrr_lat_lim, hrrr_lon_lim, match",
+    [
+        ((18, 34), (3, 19), r"hrrr_lat_lim\[0\].*must be divisible"),
+        ((17, 34), (3, 19), r"hrrr_lat_lim\[1\].*must be divisible"),
+        ((17, 33), (4, 20), r"hrrr_lon_lim\[0\].*must be divisible"),
+        ((17, 33), (3, 20), r"hrrr_lon_lim\[1\].*must be divisible"),
+    ],
+)
+def test_stormcastconus_crop_requires_patch_aligned_limits(
+    hrrr_lat_lim: tuple[int, int],
+    hrrr_lon_lim: tuple[int, int],
+    match: str,
+):
+    with pytest.raises(ValueError, match=match):
+        _build_model(hrrr_lat_lim=hrrr_lat_lim, hrrr_lon_lim=hrrr_lon_lim)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixes a bug in `earth2studio.models.px.stormcastconus.StormCastCONUS`, where the wrong coordinates were being passed to the positional embedding cropping when running with a subdomain.

Changes:
1. Correctly subtract `hrrr_lat_lim[0]` and `hrrr_lon_lim[0]` from the crop coordinates.
2. Add unit tests for cropping, improving test coverage.

Thanks @gertln for spotting the problem!

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
