### PR TITLE
Fix uv sync command in Developer Guide

### DIFF
--- a/docs/userguide/developer/overview.md
+++ b/docs/userguide/developer/overview.md
@@ -35,7 +35,7 @@ To create a local development environment with a git repo and uv:
 2. To install the base, developer, documentation dependencies, use:
 
     ```bash
-    uv sync --group={docs}
+    uv sync --group docs
     ```
 
 :::{note}


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Fix the `uv sync` command in the Developer Guide by removing invalid braces around the `docs` dependency group.

The previous command, `uv sync --group={docs}`, is invalid; the correct syntax is `uv sync --group docs`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
