### PR TITLE
async_zarr backend for eval recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added IEM parsed ASOS/AWOS station observation data source (`IEM_ASOS`)
 - Added Zarr v3 sharding support to `AsyncZarrBackend`
+- Added a working `add_array` plus `__contains__`, `__getitem__`, `__iter__`,
+  `__len__`, `store` and `coords` to `AsyncZarrBackend`, matching `ZarrBackend`, and
+  `output.io_backend` to the eval recipe to select between them (`async_zarr` is the
+  new default)
 
 ### Changed
 

--- a/earth2studio/io/async_zarr.py
+++ b/earth2studio/io/async_zarr.py
@@ -19,7 +19,8 @@ import concurrent
 import concurrent.futures
 import datetime
 import threading
-from collections.abc import Callable
+from collections import OrderedDict
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 
 # import threading
@@ -1136,12 +1137,145 @@ class AsyncZarrBackend:
                 io_future.result()
             self.io_futures = [f for f in self.io_futures if f in not_done]
 
+    def __contains__(self, item: str) -> bool:
+        """Checks if item in Zarr Group.
+
+        Parameters
+        ----------
+        item : str
+        """
+        return bool(fsspec.asyn.sync(self.loop, self.root.contains, item))
+
+    def __getitem__(self, item: str) -> Any:
+        """Gets item in Zarr Group, flushing pending writes first.
+
+        `self.root` is an AsyncGroup whose arrays cannot be indexed from
+        synchronous code, so a separate synchronous handle is opened. Without the
+        flush that handle would not see writes still in flight on a pool thread,
+        nor chunks still buffered in an incomplete shard. Note flushing writes out
+        incomplete shards, so later writes into those shards fall back to a read
+        modify write. Intended for inspection, not for reads in a hot write loop.
+
+        Parameters
+        ----------
+        item : str
+        """
+        if self.io_futures or self._shard_buffers:
+            self.flush()
+        return self._sync_root()[item]
+
+    def __len__(self) -> int:
+        """Gets length of Zarr Group."""
+        return len(self._sync_root())
+
+    def __iter__(self) -> Iterator:
+        """Return an iterator over Zarr Group member names."""
+        return iter(self._sync_root())
+
+    def _sync_root(self) -> Any:
+        """Synchronous handle on the same store, backing the read side of the API"""
+        return zarr.open(store=self.root.store, mode="r", use_consolidated=False)
+
+    @property
+    def store(self) -> Any:
+        """Underlying Zarr store, e.g. for `zarr.consolidate_metadata(io.store)`"""
+        return self.root.store
+
+    @property
+    def coords(self) -> CoordSystem:
+        """Coordinate arrays of the store, read back from it.
+
+        `ZarrBackend` accumulates this as arrays are added; here the store is the
+        single source of truth, which also keeps it correct when the store was
+        created by another process.
+        """
+        return fsspec.asyn.sync(self.loop, self._read_coords)
+
+    async def _read_coords(self) -> CoordSystem:
+        arrays = {name: array async for name, array in self.root.arrays()}
+        dims_of = {
+            name: list(array.metadata.dimension_names or [])
+            for name, array in sorted(arrays.items())
+        }
+        # Data arrays carry the dimension order, a self named coordinate array
+        # carries none. Those seed nothing and are appended after, otherwise a
+        # store holding only coordinate arrays would report no coordinates at all.
+        dim_order: list[str] = []
+        for name, dims in dims_of.items():
+            if dims == [name]:
+                continue
+            for dim in dims:
+                if dim not in dim_order:
+                    dim_order.append(dim)
+        for name, dims in dims_of.items():
+            if dims == [name] and name not in dim_order:
+                dim_order.append(name)
+
+        coords: CoordSystem = OrderedDict()
+        for dim in dim_order:
+            if dim in arrays:
+                coords[dim] = await arrays[dim].getitem(slice(None))
+        return coords
+
     def add_array(
-        self, coords: CoordSystem, array_name: str | list[str], **kwargs: dict[str, Any]
+        self,
+        coords: CoordSystem,
+        array_name: str | list[str],
+        dtype: Any = np.float32,
+        **kwargs: Any,
     ) -> None:
-        """Pass through, arrays are initialized lazily in this io object"""
-        # TODO: Warning?
-        pass
+        """Create arrays and their coordinate arrays in the store
+
+        Arrays are otherwise created lazily on first write, which is per process:
+        several processes writing the same array for the first time all see it as
+        absent and race on creation. Creating the schema up front, from one process,
+        avoids that race. It also allows arrays with different dimension sets, which
+        no single first write could imply.
+
+        Parameters
+        ----------
+        coords : CoordSystem
+            Coordinate system of the array(s).
+        array_name : str | list[str]
+            Name(s) of the array(s) to create.
+        dtype : np.dtype, optional
+            Data type of the array(s), by default np.float32 (matching
+            `ZarrBackend.add_array` without data). Arrays created lazily by
+            `write` instead use the written tensor's dtype.
+        kwargs : Any
+            Accepted for `IOBackend` compatibility (e.g. `ZarrBackend`'s `data=`)
+            but not supported here, array content comes from `write` and creation
+            options from the constructor. Ignored with a warning.
+        """
+        if kwargs:
+            logger.warning(
+                f"AsyncZarrBackend.add_array ignoring unsupported kwargs: "
+                f"{sorted(kwargs)}"
+            )
+        if isinstance(array_name, str):
+            array_name = [array_name]
+        names = [str(name) for name in array_name]
+        dtypes = [np.dtype(dtype)] * len(names)
+        coords = self._scrub_coordinates(coords.copy())
+        fsspec.asyn.sync(self.loop, self._add_array, coords, names, dtypes)
+
+    async def _add_array(
+        self, coords: CoordSystem, names: list[str], dtypes: list[np.dtype]
+    ) -> None:
+        # An existing coordinate array must match the values passed, otherwise data
+        # arrays sized from these coords disagree with the stored coordinate and the
+        # store cannot be opened by xarray
+        for key, value in coords.items():
+            if key in self.parallel_coords or not await self.root.contains(key):
+                continue
+            existing = await (await self.root.get(key)).getitem(slice(None))
+            if existing.shape != value.shape or not np.array_equal(existing, value):
+                raise ValueError(
+                    f"Coordinate array '{key}' already exists in the store with "
+                    "different values, use a different dimension name"
+                )
+        await self._initialize_arrays(coords, names, dtypes)
+        await self._register_shard_specs(names)
 
     def write(
         self,

--- a/earth2studio/io/async_zarr.py
+++ b/earth2studio/io/async_zarr.py
@@ -202,6 +202,14 @@ class _ShardBuffer:
 class AsyncZarrBackend:
     """Async Zarr v3 IO Backend
 
+    An asynchronous Zarr backend for inference pipelines that produce
+    data faster than a store can absorb it synchronously. Iteratively generated dimensions
+    (time, lead_time, ensemble) go into `parallel_coords` with their complete value sets,
+    each inference step writes one slice along them, and `close()` is called at the end
+    to drain pending writes and write out any incomplete shard. Remote stores are supported
+    through `fs_factory`, and Zarr v3 sharding via `shard_coords` keeps the file count of
+    large campaigns low.
+
     Warning
     -------
     This IO backend presently does not support overwritting existing Zarr stores. Only
@@ -289,6 +297,21 @@ class AsyncZarrBackend:
 
     Notes
     -----
+    Relation to ZarrBackend
+
+    Exposes the same surface as :class:`ZarrBackend` and can be used as a drop-in
+    replacement, with a few behavioral differences:
+
+    - `add_array` takes a `dtype` instead of a template `data` tensor and is
+      idempotent, so it is safe to call from every rank of a distributed job.
+    - In non-blocking mode a failed write raises at a later `write`, `flush` or
+      `close` rather than at the failing call, and inputs are copied so callers
+      may freely reuse their buffers.
+    - `coords` is read back from the store, and `__getitem__` flushes pending
+      writes first; intended for inspection, not reads in a write loop.
+    - Consolidated metadata is not maintained; consolidate at the end of a
+      pipeline if desired, e.g. ``zarr.consolidate_metadata(io.store)``.
+
     Sharding
 
     Because every coordinate in `parallel_coords` is chunked with a size of 1, a large
@@ -314,6 +337,34 @@ class AsyncZarrBackend:
     Sharding composes with `zarr_codecs`, which compresses the inner chunks within a
     shard, and with `chunked_coords`, which sets the chunk size of coordinates outside
     `parallel_coords`.
+
+    Examples
+    --------
+    Write a forecast one lead time at a time, hiding the IO behind the model steps:
+
+    >>> times = np.array([np.datetime64("2024-01-01")])
+    >>> lead_times = np.array([np.timedelta64(6 * i, "h") for i in range(4)])
+    >>> io = AsyncZarrBackend(
+    ...     "forecast.zarr",
+    ...     parallel_coords={"time": times, "lead_time": lead_times},
+    ...     blocking=False,
+    ...     shard_coords={"lead_time": 4},  # optional: 4 chunks per storage object
+    ... )
+    >>> total_coords = OrderedDict(
+    ...     {
+    ...         "time": times,
+    ...         "lead_time": lead_times,
+    ...         "lat": np.linspace(-90, 90, 721),
+    ...         "lon": np.linspace(0, 360, 1440, endpoint=False),
+    ...     }
+    ... )
+    >>> io.add_array(total_coords, ["t2m", "z500"])
+    >>> for i in range(len(lead_times)):
+    ...     x = torch.randn(1, 1, 721, 1440)  # model output for this step
+    ...     step_coords = total_coords.copy()
+    ...     step_coords["lead_time"] = lead_times[i : i + 1]
+    ...     io.write([x, x], step_coords, ["t2m", "z500"])
+    >>> io.close()  # drain pending writes, write out any incomplete shard
     """
 
     def __init__(

--- a/recipes/eval/README.md
+++ b/recipes/eval/README.md
@@ -535,6 +535,19 @@ Note that larger *chunks* are not the alternative: `time`, `lead_time` and
 would let concurrent writes read-modify-write the same object and lose one of
 them.  `OutputManager` rejects a chunk size other than 1 on those axes.
 
+Only `lead_time` is safe to shard on a multi-rank run.  `time` and `ensemble`
+are the distributed axes, and shard buffering is per-process, so a shard
+spanning two ranks is written in full by both and the later write silently
+discards the other's data.  `OutputManager` rejects sharding those axes
+whenever the world size is greater than one.  Sharding also interacts with
+resume: `flush()` runs after every work item there, writing out any incomplete
+shard, and re-entering that shard later falls back to a read-modify-write of
+the whole object.  Sharding on `lead_time` only avoids this.  Predownload
+stores hold a single `lead_time` and are always written unsharded.
+
+Reading a sharded store requires zarr ≥ 3 (and a correspondingly recent
+xarray); readers on zarr 2.x fail with a codec error.
+
 ## Configuration
 
 All configuration lives under `cfg/` and uses [Hydra](https://hydra.cc/docs/intro/).

--- a/recipes/eval/README.md
+++ b/recipes/eval/README.md
@@ -516,6 +516,25 @@ When `resume=true`, the `output.overwrite` setting is ignored — existing
 data is never deleted.  When all items are complete, subsequent runs exit
 immediately with a success message.
 
+## IO backend and sharding
+
+By default the recipe writes through `AsyncZarrBackend`, which runs
+`output.thread_writers` writer threads of its own and supports Zarr v3
+sharding.  Setting `output.io_backend: zarr` falls back to `ZarrBackend`,
+which writes synchronously (`thread_writers` is ignored there).
+
+```yaml
+output:
+    io_backend: async_zarr
+    shard_coords: {lead_time: 8}
+    max_inflight_shards: 4
+```
+
+Note that larger *chunks* are not the alternative: `time`, `lead_time` and
+`ensemble` are written one slice at a time, so a chunk spanning several of them
+would let concurrent writes read-modify-write the same object and lose one of
+them.  `OutputManager` rejects a chunk size other than 1 on those axes.
+
 ## Configuration
 
 All configuration lives under `cfg/` and uses [Hydra](https://hydra.cc/docs/intro/).

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -124,9 +124,24 @@ output:
         - z500
     overwrite: true
     thread_writers: 4   # 0 = synchronous writes
+    # time/lead_time/ensemble must keep chunk size 1 with async_zarr: they are
+    # written one slice per step, and a larger chunk would let concurrent writes
+    # read-modify-write the same object. Use shard_coords to cut file count.
     chunks:
         time: 1
         lead_time: 1
+
+    # --- IO backend ---------------------------------------------------------
+    # async_zarr : AsyncZarrBackend (default), owns its writer threads and
+    #              supports Zarr v3 sharding.
+    # zarr       : ZarrBackend, fully synchronous. 
+    io_backend: async_zarr
+
+    # --- sharding (async_zarr only) -----------------------------------------
+    # Sharding packs many chunks into one storage object, cutting file count
+    # without changing the chunk layout readers see.
+    shard_coords: {}          # e.g. {lead_time: 8}
+    max_inflight_shards: 4
 
 # ---------------------------------------------------------------------------
 # Pre-download settings (used by predownload.py, consulted by score.py)

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -140,7 +140,11 @@ output:
     # --- sharding (async_zarr only) -----------------------------------------
     # Sharding packs many chunks into one storage object, cutting file count
     # without changing the chunk layout readers see.
+    # Only lead_time is safe to shard on a multi-rank run
     shard_coords: {}          # e.g. {lead_time: 8}
+    # Host memory per rank is roughly
+    #   max_inflight_shards * 4 * prod(shard_shape) * itemsize
+    # plus thread_writers in-flight copies of one write each
     max_inflight_shards: 4
 
 # ---------------------------------------------------------------------------

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -134,7 +134,7 @@ output:
     # --- IO backend ---------------------------------------------------------
     # async_zarr : AsyncZarrBackend (default), owns its writer threads and
     #              supports Zarr v3 sharding.
-    # zarr       : ZarrBackend, fully synchronous. 
+    # zarr       : ZarrBackend, fully synchronous.
     io_backend: async_zarr
 
     # --- sharding (async_zarr only) -----------------------------------------

--- a/recipes/eval/predownload.py
+++ b/recipes/eval/predownload.py
@@ -117,6 +117,9 @@ def _download_store(
         store_name=f"{store.name}.zarr",
         overwrite=overwrite,
         resume=not overwrite,
+        # A single lead_time per store, so sharding buys nothing and each
+        # per-timestep flush would write an incomplete shard
+        shard_coords={},
     ) as mgr:
         mgr.validate_output_store(store_coords, store.variables)
         _download_to_store(store=store, output_mgr=mgr, cfg=cfg, dist=dist)

--- a/recipes/eval/src/output.py
+++ b/recipes/eval/src/output.py
@@ -512,7 +512,7 @@ class OutputManager:
 
     def write(self, x: torch.Tensor, coords: CoordSystem) -> None:
         """Write a chunk of forecast data.
-        
+
         Parameters
         ----------
         x : torch.Tensor

--- a/recipes/eval/src/output.py
+++ b/recipes/eval/src/output.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import os
 import shutil
 from collections import OrderedDict
-from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -31,7 +30,7 @@ from loguru import logger
 from omegaconf import DictConfig
 from physicsnemo.distributed import DistributedManager
 
-from earth2studio.io import ZarrBackend
+from earth2studio.io import AsyncZarrBackend, ZarrBackend
 from earth2studio.models.dx import DiagnosticModel
 from earth2studio.models.px import PrognosticModel
 from earth2studio.utils.coords import CoordSystem, handshake_coords, split_coords
@@ -39,6 +38,10 @@ from earth2studio.utils.coords import CoordSystem, handshake_coords, split_coord
 from .distributed import run_on_rank0_first
 
 _NON_SPATIAL_DIMS = frozenset({"batch", "time", "lead_time", "variable", "ensemble"})
+
+# Axes the pipelines write one slice at a time (per work item / rollout step).
+# AsyncZarrBackend requires these to be chunk-1 parallel coordinates.
+_ITERATION_DIMS = ("time", "lead_time", "ensemble")
 
 
 def _spatial_dims(coords: CoordSystem) -> list[str]:
@@ -371,19 +374,60 @@ class OutputManager:
             output_cfg.get("chunks", {"time": 1, "lead_time": 1})
         )
 
+        self._backend = str(output_cfg.get("io_backend", "async_zarr"))
+        if self._backend not in ("zarr", "async_zarr"):
+            raise ValueError(
+                f"output.io_backend must be 'zarr' or 'async_zarr', "
+                f"got {self._backend!r}"
+            )
+        self._shard_coords: dict[str, int] = dict(
+            output_cfg.get("shard_coords", {}) or {}
+        )
+        self._max_inflight_shards = int(output_cfg.get("max_inflight_shards", 4))
+
+        if self._is_async:
+            bad_chunks = sorted(
+                dim
+                for dim, size in self._chunks.items()
+                if dim in _ITERATION_DIMS and size != 1
+            )
+            if bad_chunks:
+                raise ValueError(
+                    f"output.chunks must use chunk size 1 for {bad_chunks} with "
+                    "io_backend=async_zarr: these axes are written one slice per "
+                    "step. Use output.shard_coords to reduce file count instead."
+                )
+        elif self._thread_io > 0:
+            logger.warning(
+                "output.thread_writers is ignored with io_backend=zarr, "
+                "writes are synchronous"
+            )
+
+        bad_axes = sorted(set(self._shard_coords) - {"lead_time"})
+        if bad_axes and self._dist.world_size > 1:
+            raise ValueError(
+                f"output.shard_coords may only shard 'lead_time', got {bad_axes}. "
+                "time/ensemble are the axes work is distributed over, so a shard "
+                "spanning two ranks is silently truncated to one rank's data."
+            )
+        if self._shard_coords and not self._is_async:
+            raise ValueError(
+                "output.shard_coords requires output.io_backend=async_zarr"
+            )
+
         self._total_coords: CoordSystem | None = None
         self._variables: list[str] | None = None
-        self._io: ZarrBackend | None = None
-        self._executor: ThreadPoolExecutor | None = None
-        self._futures: list[Future[Any]] = []
+        self._io: ZarrBackend | AsyncZarrBackend | None = None
+
+    @property
+    def _is_async(self) -> bool:
+        return self._backend == "async_zarr"
 
     # ------------------------------------------------------------------
     # Context manager protocol
     # ------------------------------------------------------------------
 
     def __enter__(self) -> OutputManager:
-        if self._thread_io > 0:
-            self._executor = ThreadPoolExecutor(max_workers=self._thread_io)
         return self
 
     def __exit__(
@@ -393,22 +437,18 @@ class OutputManager:
         exc_tb: TracebackType | None,
     ) -> None:
         write_error: BaseException | None = None
-        if self._executor is not None:
-            for f in self._futures:
-                try:
-                    f.result()
-                except Exception as e:
-                    if write_error is None:
-                        write_error = e
-                        logger.error(f"Threaded write failed: {e}")
-            self._executor.shutdown(wait=True)
-            self._futures.clear()
+        if self._is_async and self._io is not None:
+            # Drains the backend's pool and writes out any incomplete shard
+            try:
+                self._io.close()
+            except Exception as e:  # noqa: BLE001
+                write_error = e
+                logger.error(f"Async write failed: {e}")
 
         has_error = exc_type is not None or write_error is not None
         if self._dist.distributed:
             err_flag = torch.tensor(
-                [1.0 if has_error else 0.0],
-                device="cuda" if torch.cuda.is_available() else "cpu",
+                [1.0 if has_error else 0.0], device=self._dist.device
             )
             torch.distributed.all_reduce(err_flag, op=torch.distributed.ReduceOp.MAX)
             any_error = err_flag.item() > 0
@@ -461,7 +501,7 @@ class OutputManager:
         self._io = run_on_rank0_first(self._open_store)
 
     @property
-    def io(self) -> ZarrBackend:
+    def io(self) -> ZarrBackend | AsyncZarrBackend:
         """The underlying IO backend (available after :meth:`validate_output_store`)."""
         if self._io is None:
             raise RuntimeError(
@@ -471,8 +511,8 @@ class OutputManager:
         return self._io
 
     def write(self, x: torch.Tensor, coords: CoordSystem) -> None:
-        """Write a chunk of forecast data, optionally using a thread pool.
-
+        """Write a chunk of forecast data.
+        
         Parameters
         ----------
         x : torch.Tensor
@@ -481,29 +521,22 @@ class OutputManager:
             Coordinates corresponding to *x*.
         """
         arrays, coord_sets, var_names = split_coords(x, coords)
-        if self._executor is not None:
-            future = self._executor.submit(self.io.write, arrays, coord_sets, var_names)
-            self._futures.append(future)
-        else:
-            self.io.write(arrays, coord_sets, var_names)
+        self.io.write(arrays, coord_sets, var_names)
 
     def flush(self) -> None:
-        """Wait for all pending threaded writes to complete.
+        """Wait for pending writes to land.
 
-        Called between work items during resume runs to guarantee that all
-        zarr writes have landed before a completion marker is written.
-        Raises immediately if any pending write failed.
+        Called between work items during resume runs, so a completion marker is
+        never written before the data it refers to. Raises if a write failed.
         """
-        if self._executor is not None:
-            for f in self._futures:
-                f.result()
-            self._futures.clear()
+        if self._is_async:
+            self.io.flush()
 
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _open_store(self) -> ZarrBackend:
+    def _open_store(self) -> ZarrBackend | AsyncZarrBackend:
         """Create or open the zarr store (called inside rank-ordered context)."""
         if self._total_coords is None or self._variables is None:
             raise ValueError(
@@ -533,11 +566,36 @@ class OutputManager:
         if "ensemble" not in chunks and "ensemble" in self._total_coords:
             chunks["ensemble"] = 1
 
-        io = ZarrBackend(
-            file_name=self._path,
-            chunks=chunks,
-            backend_kwargs={"overwrite": False},
-        )
+        io: ZarrBackend | AsyncZarrBackend
+        if self._is_async:
+            # Iteration axes are parallel coordinates, which the backend chunks at
+            # 1 and allows to be written one slice at a time (guarded in __init__).
+            # Every other dim keeps its requested chunk size and is written whole.
+            parallel: CoordSystem = OrderedDict(
+                (dim, np.asarray(values))
+                for dim, values in self._total_coords.items()
+                if dim in _ITERATION_DIMS
+            )
+            chunked = {
+                dim: int(size)
+                for dim, size in chunks.items()
+                if dim not in _ITERATION_DIMS and dim in self._total_coords
+            }
+            io = AsyncZarrBackend(
+                self._path,
+                parallel_coords=parallel,
+                blocking=self._thread_io <= 0,
+                pool_size=max(self._thread_io, 1),
+                chunked_coords=chunked,
+                shard_coords=self._shard_coords,
+                max_inflight_shards=self._max_inflight_shards,
+            )
+        else:
+            io = ZarrBackend(
+                file_name=self._path,
+                chunks=chunks,
+                backend_kwargs={"overwrite": False},
+            )
 
         if is_rank0 and not store_exists:
             write_coords = self._total_coords.copy()

--- a/recipes/eval/src/output.py
+++ b/recipes/eval/src/output.py
@@ -622,8 +622,8 @@ class OutputManager:
                     )
             for dim in self._total_coords:
                 handshake_coords(io.coords, self._total_coords, required_dim=dim)
-            if self._dist.world_size > 1:
-                self._validate_store_shards(io)
+            if self._is_async or self._dist.world_size > 1:
+                self._validate_store_geometry(io)
             if is_rank0:
                 logger.info(f"Validated existing store for resume: {self._path}")
             else:
@@ -631,24 +631,37 @@ class OutputManager:
 
         return io
 
-    def _validate_store_shards(self, io: ZarrBackend | AsyncZarrBackend) -> None:
-        """Reject resuming multi-rank into a store sharded on a distributed axis.
+    def _validate_store_geometry(self, io: ZarrBackend | AsyncZarrBackend) -> None:
+        """Reject resuming into a store whose on-disk layout the writers would race on.
 
-        The ``shard_coords`` guard in ``__init__`` only sees the config: a store
-        created by an earlier single-process run may already be sharded on
-        ``time`` or ``ensemble``, and multi-rank writes into such shards would
-        silently keep only the last rank's data.
+        The ``__init__`` guards only see the config; the store carries the geometry
+        it was created with.  Two layouts would silently lose data: chunks > 1 on an
+        iteration axis, which async slice-at-a-time writes race on (checked on any
+        async resume), and shards on a distributed axis, which two ranks would each
+        write in full (checked when ``world_size > 1``).
         """
         if self._variables is None:
             return
         for v in self._variables:
             array = io[v]
-            if array.shards is None:
-                continue
             dims = list(array.metadata.dimension_names or [])
             for axis, dim in enumerate(dims):
-                if dim in ("time", "ensemble") and (
-                    array.shards[axis] > array.chunks[axis]
+                if dim not in _ITERATION_DIMS:
+                    continue
+                if self._is_async and array.chunks[axis] != 1:
+                    raise ValueError(
+                        f"Existing array '{v}' has chunk size "
+                        f"{array.chunks[axis]} on '{dim}', likely created with "
+                        "io_backend=zarr. async_zarr writes one slice at a time, "
+                        "so concurrent writes into a shared chunk would silently "
+                        "lose data. Resume with output.io_backend=zarr or "
+                        "recreate the store."
+                    )
+                if (
+                    self._dist.world_size > 1
+                    and dim in ("time", "ensemble")
+                    and array.shards is not None
+                    and array.shards[axis] > array.chunks[axis]
                 ):
                     raise ValueError(
                         f"Existing array '{v}' is sharded on '{dim}' (shard size "

--- a/recipes/eval/src/output.py
+++ b/recipes/eval/src/output.py
@@ -352,6 +352,10 @@ class OutputManager:
         If provided, overrides ``output.overwrite`` from config.
     resume : bool | None
         If provided, overrides the top-level ``resume`` from config.
+    shard_coords : dict[str, int] | None
+        If provided, overrides ``output.shard_coords`` from config.  Pass an
+        empty dict for stores that sharding cannot help, such as the
+        single-``lead_time`` predownload stores.
     """
 
     def __init__(
@@ -360,6 +364,7 @@ class OutputManager:
         store_name: str = "forecast.zarr",
         overwrite: bool | None = None,
         resume: bool | None = None,
+        shard_coords: dict[str, int] | None = None,
     ) -> None:
         output_cfg = cfg.output
         self._dist = DistributedManager()
@@ -381,7 +386,9 @@ class OutputManager:
                 f"got {self._backend!r}"
             )
         self._shard_coords: dict[str, int] = dict(
-            output_cfg.get("shard_coords", {}) or {}
+            shard_coords
+            if shard_coords is not None
+            else output_cfg.get("shard_coords", {}) or {}
         )
         self._max_inflight_shards = int(output_cfg.get("max_inflight_shards", 4))
 
@@ -400,7 +407,8 @@ class OutputManager:
         elif self._thread_io > 0:
             logger.warning(
                 "output.thread_writers is ignored with io_backend=zarr, "
-                "writes are synchronous"
+                "writes are synchronous. Use io_backend=async_zarr for "
+                "threaded writes."
             )
 
         bad_axes = sorted(set(self._shard_coords) - {"lead_time"})
@@ -438,7 +446,10 @@ class OutputManager:
     ) -> None:
         write_error: BaseException | None = None
         if isinstance(self._io, AsyncZarrBackend):
-            # Drains the backend's pool and writes out any incomplete shard
+            # Drains the backend's pool and writes out any incomplete shard.
+            # Logged first so that if a rank hangs here, its last log line
+            # names the culprit rather than the collective timeout downstream.
+            logger.debug(f"Rank {self._dist.rank}: draining async writes")
             try:
                 self._io.close()
             except Exception as e:  # noqa: BLE001
@@ -611,9 +622,39 @@ class OutputManager:
                     )
             for dim in self._total_coords:
                 handshake_coords(io.coords, self._total_coords, required_dim=dim)
+            if self._dist.world_size > 1:
+                self._validate_store_shards(io)
             if is_rank0:
                 logger.info(f"Validated existing store for resume: {self._path}")
             else:
                 logger.debug(f"Rank {self._dist.rank} validated store: {self._path}")
 
         return io
+
+    def _validate_store_shards(self, io: ZarrBackend | AsyncZarrBackend) -> None:
+        """Reject resuming multi-rank into a store sharded on a distributed axis.
+
+        The ``shard_coords`` guard in ``__init__`` only sees the config: a store
+        created by an earlier single-process run may already be sharded on
+        ``time`` or ``ensemble``, and multi-rank writes into such shards would
+        silently keep only the last rank's data.
+        """
+        if self._variables is None:
+            return
+        for v in self._variables:
+            array = io[v]
+            if array.shards is None:
+                continue
+            dims = list(array.metadata.dimension_names or [])
+            for axis, dim in enumerate(dims):
+                if dim in ("time", "ensemble") and (
+                    array.shards[axis] > array.chunks[axis]
+                ):
+                    raise ValueError(
+                        f"Existing array '{v}' is sharded on '{dim}' (shard size "
+                        f"{array.shards[axis]}, chunk size {array.chunks[axis]}), "
+                        "likely by an earlier single-process run. Work is "
+                        "distributed over time/ensemble, so resuming with "
+                        "multiple ranks would silently lose data. Resume "
+                        "single-process or recreate the store."
+                    )

--- a/recipes/eval/src/output.py
+++ b/recipes/eval/src/output.py
@@ -437,7 +437,7 @@ class OutputManager:
         exc_tb: TracebackType | None,
     ) -> None:
         write_error: BaseException | None = None
-        if self._is_async and self._io is not None:
+        if isinstance(self._io, AsyncZarrBackend):
             # Drains the backend's pool and writes out any incomplete shard
             try:
                 self._io.close()
@@ -529,7 +529,7 @@ class OutputManager:
         Called between work items during resume runs, so a completion marker is
         never written before the data it refers to. Raises if a write failed.
         """
-        if self._is_async:
+        if isinstance(self.io, AsyncZarrBackend):
             self.io.flush()
 
     # ------------------------------------------------------------------

--- a/recipes/eval/test/test_output.py
+++ b/recipes/eval/test/test_output.py
@@ -444,3 +444,60 @@ class TestIOBackendSelection:
                 stored = zarr.open(mgr._path)["t2m"][:]
         for step in range(len(total_coords["lead_time"])):
             assert np.all(stored[0, step] == float(step))
+
+    def _create_store(self, tmp_path, total_coords, **overrides):
+        cfg = self._cfg(tmp_path, **overrides)
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                with OutputManager(cfg) as mgr:
+                    mgr.validate_output_store(total_coords, VARIABLES)
+        return cfg
+
+    def test_resume_multirank_rejects_store_sharded_on_distributed_axis(
+        self, tmp_path, total_coords
+    ):
+        """The config guard can be sidestepped by an earlier single-process run;
+        the store's actual shard geometry must be re-checked on resume."""
+        self._create_store(tmp_path, total_coords, shard_coords={"time": 4})
+        dist = _make_dist_mock(world_size=2, distributed=True)
+        with patch(_DIST_PATH, return_value=dist):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                mgr = OutputManager(
+                    self._cfg(tmp_path, overwrite=False, shard_coords={}),
+                    resume=True,
+                )
+                with pytest.raises(ValueError, match="sharded on 'time'"):
+                    mgr.validate_output_store(total_coords, VARIABLES)
+
+    def test_resume_multirank_allows_lead_time_sharded_store(
+        self, tmp_path, total_coords
+    ):
+        self._create_store(tmp_path, total_coords, shard_coords={"lead_time": 2})
+        dist = _make_dist_mock(world_size=2, distributed=True)
+        with patch(_DIST_PATH, return_value=dist):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                mgr = OutputManager(
+                    self._cfg(tmp_path, overwrite=False, shard_coords={"lead_time": 2}),
+                    resume=True,
+                )
+                mgr.validate_output_store(total_coords, VARIABLES)
+                assert "t2m" in mgr.io
+
+    def test_resume_multirank_allows_unsharded_store(self, tmp_path, total_coords):
+        self._create_store(tmp_path, total_coords)
+        dist = _make_dist_mock(world_size=2, distributed=True)
+        with patch(_DIST_PATH, return_value=dist):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                mgr = OutputManager(self._cfg(tmp_path, overwrite=False), resume=True)
+                mgr.validate_output_store(total_coords, VARIABLES)
+                assert "t2m" in mgr.io
+
+    def test_shard_coords_parameter_overrides_config(self, tmp_path):
+        """Predownload passes shard_coords={} so its stores are never sharded,
+        even when the campaign config shards the forecast store."""
+        dist = _make_dist_mock(world_size=2, distributed=True)
+        with patch(_DIST_PATH, return_value=dist):
+            mgr = OutputManager(
+                self._cfg(tmp_path, shard_coords={"time": 4}), shard_coords={}
+            )
+            assert mgr._shard_coords == {}

--- a/recipes/eval/test/test_output.py
+++ b/recipes/eval/test/test_output.py
@@ -453,6 +453,37 @@ class TestIOBackendSelection:
                     mgr.validate_output_store(total_coords, VARIABLES)
         return cfg
 
+    def test_resume_async_rejects_store_with_chunked_iteration_axis(
+        self, tmp_path, total_coords
+    ):
+        """A store created under io_backend=zarr may have chunks > 1 on an
+        iteration axis; async slice-at-a-time writes into a shared chunk are
+        last-writer-wins, so resuming it with async_zarr must be rejected."""
+        self._create_store(
+            tmp_path,
+            total_coords,
+            io_backend="zarr",
+            chunks={"time": 1, "lead_time": 3},
+        )
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                mgr = OutputManager(self._cfg(tmp_path, overwrite=False), resume=True)
+                with pytest.raises(ValueError, match="chunk size"):
+                    mgr.validate_output_store(total_coords, VARIABLES)
+
+    def test_resume_zarr_allows_store_with_chunked_iteration_axis(
+        self, tmp_path, total_coords
+    ):
+        create_cfg = dict(io_backend="zarr", chunks={"time": 1, "lead_time": 3})
+        self._create_store(tmp_path, total_coords, **create_cfg)
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                mgr = OutputManager(
+                    self._cfg(tmp_path, overwrite=False, **create_cfg), resume=True
+                )
+                mgr.validate_output_store(total_coords, VARIABLES)
+                assert "t2m" in mgr.io
+
     def test_resume_multirank_rejects_store_sharded_on_distributed_axis(
         self, tmp_path, total_coords
     ):

--- a/recipes/eval/test/test_output.py
+++ b/recipes/eval/test/test_output.py
@@ -162,9 +162,6 @@ class TestOutputManager:
             with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
                 with OutputManager(threaded_cfg) as mgr:
                     mgr.validate_output_store(total_coords, VARIABLES)
-                    assert mgr._executor is not None
-                    assert mgr._executor._max_workers == 2
-
                     n_var = len(VARIABLES)
                     n_lat = len(total_coords["lat"])
                     n_lon = len(total_coords["lon"])
@@ -322,3 +319,128 @@ class TestOutputManagerStoreName:
         with patch(_DIST_PATH, return_value=_make_dist_mock()):
             mgr = OutputManager(cfg, resume=True)
             assert mgr._resume is True
+
+
+class TestIOBackendSelection:
+    """`output.io_backend` must be a drop-in switch, with guarded config."""
+
+    @pytest.fixture()
+    def total_coords(self, prognostic):
+        times = np.array([np.datetime64("2024-01-01")])
+        return build_forecast_coords(prognostic, times, nsteps=2)
+
+    def _cfg(self, tmp_path, **overrides):
+        output = {
+            "path": str(tmp_path / "out"),
+            "overwrite": True,
+            "thread_writers": 0,
+            "chunks": {"time": 1, "lead_time": 1},
+            "io_backend": "async_zarr",
+        }
+        output.update(overrides)
+        return OmegaConf.create({"output": output})
+
+    @pytest.mark.parametrize("thread_writers", [0, 4])
+    def test_both_backends_write_the_same_data(
+        self, tmp_path, total_coords, prognostic, thread_writers
+    ):
+        import zarr
+
+        n_var = len(VARIABLES)
+        n_lat = len(total_coords["lat"])
+        n_lon = len(total_coords["lon"])
+
+        def run(backend):
+            cfg = self._cfg(
+                tmp_path / backend,
+                io_backend=backend,
+                thread_writers=thread_writers,
+            )
+            cfg.output.path = str(tmp_path / backend)
+            with patch(_DIST_PATH, return_value=_make_dist_mock()):
+                with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                    with OutputManager(cfg) as mgr:
+                        mgr.validate_output_store(total_coords, VARIABLES)
+                        for step, lead in enumerate(total_coords["lead_time"]):
+                            coords = OrderedDict(
+                                {
+                                    "time": total_coords["time"],
+                                    "lead_time": np.array([lead]),
+                                    "variable": np.array(VARIABLES),
+                                    "lat": total_coords["lat"],
+                                    "lon": total_coords["lon"],
+                                }
+                            )
+                            mgr.write(
+                                torch.full((1, 1, n_var, n_lat, n_lon), float(step)),
+                                coords,
+                            )
+                        mgr.flush()
+                    return zarr.open(mgr._path)
+
+        a, b = run("zarr"), run("async_zarr")
+        for v in VARIABLES:
+            np.testing.assert_array_equal(np.asarray(a[v][:]), np.asarray(b[v][:]))
+
+    def test_rejects_unknown_backend(self, tmp_path):
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with pytest.raises(ValueError, match="io_backend"):
+                OutputManager(self._cfg(tmp_path, io_backend="parquet"))
+
+    @pytest.mark.parametrize("axis", ["time", "lead_time", "ensemble"])
+    def test_rejects_non_unit_chunk_on_iteration_axis(self, tmp_path, axis):
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with pytest.raises(ValueError, match="chunk size 1"):
+                OutputManager(self._cfg(tmp_path, chunks={"time": 1, axis: 2}))
+
+    def test_allows_chunking_a_spatial_axis(self, tmp_path):
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            OutputManager(self._cfg(tmp_path, chunks={"time": 1, "lat": 4}))
+
+    @pytest.mark.parametrize("axis", ["time", "ensemble"])
+    def test_rejects_sharding_a_distributed_axis(self, tmp_path, axis):
+        dist = _make_dist_mock(world_size=2, distributed=True)
+        with patch(_DIST_PATH, return_value=dist):
+            with pytest.raises(ValueError, match="lead_time"):
+                OutputManager(self._cfg(tmp_path, shard_coords={axis: 4}))
+
+    def test_allows_sharding_any_axis_single_process(self, tmp_path):
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            OutputManager(self._cfg(tmp_path, shard_coords={"time": 4}))
+
+    def test_rejects_sharding_with_zarr_backend(self, tmp_path):
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with pytest.raises(ValueError, match="async_zarr"):
+                OutputManager(
+                    self._cfg(
+                        tmp_path, io_backend="zarr", shard_coords={"lead_time": 4}
+                    )
+                )
+
+    def test_sharded_write_roundtrips(self, tmp_path, total_coords):
+        import zarr
+
+        n_var = len(VARIABLES)
+        n_lat = len(total_coords["lat"])
+        n_lon = len(total_coords["lon"])
+        cfg = self._cfg(tmp_path, thread_writers=2, shard_coords={"lead_time": 2})
+        with patch(_DIST_PATH, return_value=_make_dist_mock()):
+            with patch(_RANK0_PATH, side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+                with OutputManager(cfg) as mgr:
+                    mgr.validate_output_store(total_coords, VARIABLES)
+                    for step, lead in enumerate(total_coords["lead_time"]):
+                        coords = OrderedDict(
+                            {
+                                "time": total_coords["time"],
+                                "lead_time": np.array([lead]),
+                                "variable": np.array(VARIABLES),
+                                "lat": total_coords["lat"],
+                                "lon": total_coords["lon"],
+                            }
+                        )
+                        mgr.write(
+                            torch.full((1, 1, n_var, n_lat, n_lon), float(step)), coords
+                        )
+                stored = zarr.open(mgr._path)["t2m"][:]
+        for step in range(len(total_coords["lead_time"])):
+            assert np.all(stored[0, step] == float(step))

--- a/recipes/eval/test/test_resume.py
+++ b/recipes/eval/test/test_resume.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+import zarr
 from omegaconf import OmegaConf
 from src.output import OutputManager, build_forecast_coords
 from src.pipelines import ForecastPipeline
@@ -243,10 +244,22 @@ class TestOutputManagerResume:
                     )
                     data = torch.randn(1, 1, n_var, n_lat, n_lon)
                     mgr.write(data, write_coords)
-                    assert len(mgr._futures) == 1
 
+                    # Pending writes live in the backend now, not in a future
+                    # list owned here, so assert what flush() is FOR: once it
+                    # returns the data is in the store, so a resume marker
+                    # written next cannot outrun its own data. Read through an
+                    # independent handle, since mgr.io[...] flushes on its own.
                     mgr.flush()
-                    assert len(mgr._futures) == 0
+                    store = zarr.open(mgr._path, mode="r")
+                    for i, var in enumerate(VARIABLES):
+                        np.testing.assert_allclose(
+                            np.asarray(store[var][0, 0]),
+                            data[0, 0, i].numpy(),
+                            rtol=0,
+                            atol=0,
+                            err_msg=f"{var} not durable after flush()",
+                        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/io/test_async_zarr.py
+++ b/test/io/test_async_zarr.py
@@ -1275,3 +1275,126 @@ def test_async_zarr_shard_with_chunked_spatial_coord(tmp_path: str) -> None:
     stored = zarr.open(f"{tmp_path}/shard_chunk.zarr")["fields"][:]
     for i in range(len(lead_time)):
         assert np.all(stored[i] == float(i))
+
+
+def test_async_zarr_add_array_eager_and_idempotent(tmp_path: str) -> None:
+    lead_time = np.array([np.timedelta64(0, "h"), np.timedelta64(6, "h")])
+    total_coords = OrderedDict(
+        {
+            "lead_time": lead_time,
+            "lat": np.linspace(-90, 90, 8),
+            "lon": np.linspace(0, 360, 16, endpoint=False),
+        }
+    )
+    z = AsyncZarrBackend(
+        f"{tmp_path}/add_array.zarr",
+        parallel_coords=OrderedDict({"lead_time": lead_time}),
+        fs_factory=LocalFileSystem,
+        blocking=True,
+    )
+    z.add_array(total_coords, ["fields_1", "fields_2"])
+    assert "fields_1" in z and "fields_2" in z
+    assert "never_added" not in z
+    assert z["fields_1"].shape == (2, 8, 16)
+
+    # Re-adding an existing array must not raise or destroy data
+    step = total_coords.copy()
+    step["lead_time"] = lead_time[0:1]
+    z.write(torch.ones(1, 8, 16), step, "fields_1")
+    z.add_array(total_coords, ["fields_1", "fields_2"])
+    assert np.all(z["fields_1"][0] == 1.0)
+
+    # An ndarray of names is accepted, as the eval recipe's scoring passes
+    z.add_array(total_coords, np.array(["fields_3", "fields_4"]))
+    assert "fields_3" in z and "fields_4" in z
+    z.close()
+
+
+def test_async_zarr_add_array_heterogeneous_dims(tmp_path: str) -> None:
+    lead_time = np.array([np.timedelta64(0, "h"), np.timedelta64(6, "h")])
+    z = AsyncZarrBackend(
+        f"{tmp_path}/hetero.zarr",
+        parallel_coords=OrderedDict({"lead_time": lead_time}),
+        fs_factory=LocalFileSystem,
+        blocking=True,
+    )
+    z.add_array(
+        OrderedDict({"lead_time": lead_time, "lat": np.linspace(-90, 90, 4)}),
+        "with_lat",
+    )
+    z.add_array(
+        OrderedDict({"lead_time": lead_time, "member": np.arange(3)}), "with_member"
+    )
+    z.close()
+    assert z["with_lat"].shape == (2, 4)
+    assert z["with_member"].shape == (2, 3)
+
+
+def test_async_zarr_add_array_coord_mismatch_raises(tmp_path: str) -> None:
+    z = AsyncZarrBackend(
+        f"{tmp_path}/mismatch.zarr",
+        parallel_coords={},
+        fs_factory=LocalFileSystem,
+        blocking=True,
+    )
+    z.add_array(OrderedDict({"quantile": np.array([0.1, 0.5, 0.9])}), "a")
+    with pytest.raises(ValueError, match="different values"):
+        z.add_array(OrderedDict({"quantile": np.array([0.25, 0.75])}), "b")
+
+
+def test_async_zarr_matches_zarr_backend_surface(tmp_path: str) -> None:
+    from earth2studio.io import ZarrBackend
+
+    lead_time = np.array([np.timedelta64(0, "h"), np.timedelta64(6, "h")])
+    total_coords = OrderedDict(
+        {
+            "lead_time": lead_time,
+            "lat": np.linspace(-90, 90, 8),
+            "lon": np.linspace(0, 360, 16, endpoint=False),
+        }
+    )
+    sync_io = ZarrBackend(f"{tmp_path}/sync.zarr")
+    sync_io.add_array(total_coords, "fields")
+
+    async_io = AsyncZarrBackend(
+        f"{tmp_path}/async.zarr",
+        parallel_coords=OrderedDict({"lead_time": lead_time}),
+        fs_factory=LocalFileSystem,
+        blocking=True,
+    )
+    async_io.add_array(total_coords, "fields")
+
+    assert ("fields" in sync_io) == ("fields" in async_io) is True
+    assert ("absent" in sync_io) == ("absent" in async_io) is False
+    assert set(sync_io) == set(async_io)
+    assert len(sync_io) == len(async_io)
+    assert sync_io["fields"].shape == async_io["fields"].shape
+
+    # Same coordinate names, values and dimension order
+    assert list(async_io.coords) == list(sync_io.coords)
+    for dim, values in total_coords.items():
+        np.testing.assert_array_equal(np.asarray(async_io.coords[dim]), values)
+
+    zarr.consolidate_metadata(async_io.store)
+    async_io.close()
+
+
+def test_async_zarr_coords_of_coord_only_store(tmp_path: str) -> None:
+    """A store with no data arrays yet must still report its coordinates.
+
+    The eval recipe's score store looks exactly like this between its creation
+    and its data arrays being added, and every rank validates against it.
+    """
+    lead_time = np.array([np.timedelta64(0, "h"), np.timedelta64(6, "h")])
+    total_coords = OrderedDict({"lead_time": lead_time, "lat": np.linspace(-90, 90, 4)})
+    z = AsyncZarrBackend(
+        f"{tmp_path}/coords_only.zarr",
+        parallel_coords=OrderedDict({"lead_time": lead_time}),
+        fs_factory=LocalFileSystem,
+        blocking=True,
+    )
+    z.add_array(total_coords, [])
+    z.close()
+
+    assert set(z.coords) == {"lead_time", "lat"}
+    np.testing.assert_array_equal(np.asarray(z.coords["lat"]), total_coords["lat"])


### PR DESCRIPTION
## Description

- Makes `AsyncZarrBackend` interchangeable with `ZarrBackend`, then lets the eval recipe pick between them via `output.io_backend `(defaulting to `async_zarr`).
- The backend gains a working `add_array` plus `__contains__`, `__getitem__`, `__iter__`, `__len__`, `store` and `coords`, matching` ZarrBackend`.
- Updated `output.py` to use `AsyncZarrBackend`
- Added tests for the above changes

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).
