### PR TITLE
Fix CorrDiffCosmoEra5 package cache collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (~30% faster)
 - Migrated GOES GLM data source from s3fs to obstore; listings of complete
   hours are memoized per instance while the current hour is always re-listed
-- Pinned the default `CorrDiffCosmoEra5` Hugging Face package to a specific revision.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (~30% faster)
 - Migrated GOES GLM data source from s3fs to obstore; listings of complete
   hours are memoized per instance while the current hour is always re-listed
+- Pinned the default `CorrDiffCosmoEra5` Hugging Face package to a specific revision.
 
 ### Deprecated
 
@@ -31,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `CorrDiffCosmoEra5` loading files from the wrong resolution when cache names
+  collided. Cache names now include the resolution.
 - Fixed `OPERA` data source returning negative precipitation values (`-99.0 mm/h`
   for `tprate`, `-0.099 m` for `tp01`) for pixels where the radar detected no rain.
   Undetect pixels for RATE and ACRR quantities are now filled with `0.0` instead

--- a/earth2studio/models/dx/corrdiff_cosmo_era5.py
+++ b/earth2studio/models/dx/corrdiff_cosmo_era5.py
@@ -53,6 +53,7 @@ from typing import Literal
 import numpy as np
 import torch
 import xarray as xr
+from fsspec.implementations.cache_mapper import BasenameCacheMapper
 from loguru import logger
 
 from earth2studio.lexicon import CosmoLexicon
@@ -111,7 +112,9 @@ SUPPORTED_VARIANTS = ("rea6", "rea2")
 # ``load_default_package`` / ``from_pretrained``. The package nests rea6/ and
 # rea2/ subfolders; ``load_model(..., resolution=)`` selects the subfolder, so
 # one URI serves all four models.
-DEFAULT_PACKAGE_URI: str = "hf://nvidia/corrdiff-cosmo-era5"
+DEFAULT_PACKAGE_URI: str = (
+    "hf://nvidia/corrdiff-cosmo-era5@44064f304158f863f6ae02948b1b8e08d523458e"
+)
 
 
 def _points_in_grid_footprint(
@@ -1609,7 +1612,10 @@ class CorrDiffCosmoEra5(torch.nn.Module, AutoModelMixin):
             DEFAULT_PACKAGE_URI,
             cache_options={
                 "cache_storage": Package.default_cache("corrdiff_cosmo_era5"),
-                "same_names": True,
+                # Include the resolution directory to distinguish files with
+                # matching basenames, such as rea2/metadata.json and
+                # rea6/metadata.json.
+                "cache_mapper": BasenameCacheMapper(directory_levels=1),
             },
         )
 

--- a/test/models/dx/test_corrdiff_cosmo_era5.py
+++ b/test/models/dx/test_corrdiff_cosmo_era5.py
@@ -24,6 +24,7 @@ preserves the full per-resolution/per-mode config.
 
 import json
 import os
+import re
 import types
 import warnings
 from collections import OrderedDict
@@ -32,6 +33,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import fsspec
 import numpy as np
 import pytest
 import torch
@@ -1014,3 +1016,32 @@ def test_corrdiff_cosmo_era5_package(mode, resolution):
             assert sl.min().item() >= b["min"] - 1e-4, f"{ch} below min in {mode}"
         if b.get("max") is not None:
             assert sl.max().item() <= b["max"] + 1e-4, f"{ch} above max in {mode}"
+
+
+def test_default_package_cache_serves_each_resolution_its_own_file(
+    tmp_path: Path,
+) -> None:
+    mem = fsspec.filesystem("memory")
+    mem.pipe_file("/corrdiff-pkg/rea2/metadata.json", b'{"resolution": "rea2"}')
+    mem.pipe_file("/corrdiff-pkg/rea6/metadata.json", b'{"resolution": "rea6"}')
+
+    # Use the model's actual cache options (redirect only the cache dir), so a
+    # regression to same_names would run here and fail rather than be bypassed.
+    options = dict(CorrDiffCosmoEra5.load_default_package().cache_options)
+    options["cache_storage"] = str(tmp_path)
+    package = Package("memory://corrdiff-pkg", cache_options=options)
+
+    # Cache both (shared basename) before reading -- the collision the fix prevents.
+    path2 = package.resolve("rea2/metadata.json")
+    path6 = package.resolve("rea6/metadata.json")
+    assert path2 != path6
+    assert json.loads(Path(path2).read_text())["resolution"] == "rea2"
+    assert json.loads(Path(path6).read_text())["resolution"] == "rea6"
+
+
+def test_default_package_uri_pins_commit_hash() -> None:
+    uri = CorrDiffCosmoEra5.load_default_package().root
+    assert re.fullmatch(
+        r"hf://nvidia/corrdiff-cosmo-era5@[0-9a-f]{40}",
+        uri,
+    )

--- a/test/models/dx/test_corrdiff_cosmo_era5.py
+++ b/test/models/dx/test_corrdiff_cosmo_era5.py
@@ -24,7 +24,6 @@ preserves the full per-resolution/per-mode config.
 
 import json
 import os
-import re
 import types
 import warnings
 from collections import OrderedDict

--- a/test/models/dx/test_corrdiff_cosmo_era5.py
+++ b/test/models/dx/test_corrdiff_cosmo_era5.py
@@ -1018,7 +1018,7 @@ def test_corrdiff_cosmo_era5_package(mode, resolution):
             assert sl.max().item() <= b["max"] + 1e-4, f"{ch} above max in {mode}"
 
 
-def test_default_package_cache_serves_each_resolution_its_own_file(
+def test_default_package_cache_serves(
     tmp_path: Path,
 ) -> None:
     mem = fsspec.filesystem("memory")
@@ -1037,11 +1037,3 @@ def test_default_package_cache_serves_each_resolution_its_own_file(
     assert path2 != path6
     assert json.loads(Path(path2).read_text())["resolution"] == "rea2"
     assert json.loads(Path(path6).read_text())["resolution"] == "rea6"
-
-
-def test_default_package_uri_pins_commit_hash() -> None:
-    uri = CorrDiffCosmoEra5.load_default_package().root
-    assert re.fullmatch(
-        r"hf://nvidia/corrdiff-cosmo-era5@[0-9a-f]{40}",
-        uri,
-    )


### PR DESCRIPTION
## Description

`CorrDiffCosmoEra5.load_default_package()` used `same_names=True`, causing
same-named files under `rea2/` and `rea6/` to share one cache path. Consequently,
loading a resolution could read metadata cached for the other resolution and fail
with errors such as `KeyError: 'rea6_diffusion'`.

Changes:

- Use `BasenameCacheMapper(directory_levels=1)` to include the resolution in cache
  names while preserving filename extensions.
- Pin the default Hugging Face package to an immutable revision.
- Add a hermetic end-to-end regression test that caches and reads same-named REA2
  and REA6 files using the model’s actual cache configuration.