### PR TITLE
Optimize and migrate ISD, IBTrACS, CFS reforecast, and OPERA data sources on obstore

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: zizmor.sarif
           category: zizmor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hours are memoized per instance while the current hour is always re-listed
 - Migrated Himawari AHI data source from s3fs to obstore with memoized
   minute-directory listings (scans older than an hour)
+- Migrated ISD, IBTrACS, CFS reforecast, and OPERA data sources from
+  fsspec/s3fs to obstore
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   minute-directory listings (scans older than an hour)
 - Migrated ISD, IBTrACS, CFS reforecast, and OPERA data sources from
   fsspec/s3fs to obstore
+- CFS reforecast grib decoding now resolves all requested variables in a
+  single pass over the file's messages instead of one `pygrib.select` scan
+  per variable (~20x faster for full-lexicon requests)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `CFS_Reforecast_FX` and `CFS_Reforecast_FX_Flux` pointing at the retired
+  NCEI archive path; the reforecast archive moved to
+  `https://www.ncei.noaa.gov/oa/prod-cfs-reforecast` with renamed product subdirs
 - Fixed `CorrDiffCosmoEra5` loading files from the wrong resolution when cache names
   collided. Cache names now include the resolution.
 - Fixed `OPERA` data source returning negative precipitation values (`-99.0 mm/h`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CFS reforecast grib decoding now resolves all requested variables in a
   single pass over the file's messages instead of one `pygrib.select` scan
   per variable (~20x faster for full-lexicon requests)
+- Consolidated the four identical per-source grib decode helpers
+  (`_decode_gfs_grib`, `_decode_hrrr_grib`, `_decode_gefs_grib`,
+  `_decode_cfs_grib`) into a shared `decode_grib_message` helper in
+  `earth2studio.data.utils`
 
 ### Deprecated
 

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -807,4 +807,3 @@ class CFS_FX_Flux(CFS_FX):
     CFS_LON = np.linspace(0, 360 - 360 / 384, 384)
 
     LEXICON: Any = CFSFluxLexicon
-

--- a/earth2studio/data/cfs.py
+++ b/earth2studio/data/cfs.py
@@ -26,7 +26,6 @@ from typing import Any
 
 import numpy as np
 import obstore as obs
-import pygrib
 import xarray as xr
 from loguru import logger
 from obstore.store import ObjectStore
@@ -37,6 +36,7 @@ from earth2studio.data.utils import (
     async_retry,
     cancellable_to_thread,
     datasource_cache_root,
+    decode_grib_message,
     gather_with_concurrency,
     obstore_fetch_to_cache,
     obstore_store_from_url,
@@ -469,7 +469,7 @@ class CFS_FX:
         # pygrib is sync-only.  Use cancellable_to_thread so a hung decode can
         # be abandoned without holding the event loop.
         values = await cancellable_to_thread(
-            _decode_cfs_grib,
+            decode_grib_message,
             grib_file,
             task.cfs_submsg_index,
             timeout=30.0,
@@ -808,37 +808,3 @@ class CFS_FX_Flux(CFS_FX):
 
     LEXICON: Any = CFSFluxLexicon
 
-
-def _decode_cfs_grib(grib_file: str, submsg_index: int) -> np.ndarray:
-    """Decode a single CFS grib submessage from a cached byte-range file.
-
-    Parameters
-    ----------
-    grib_file : str
-        Path to the cached grib file on local disk. The file may contain a
-        single message or, for vector wind packing, multiple submessages.
-    submsg_index : int
-        1-based pygrib message index to extract. For scalar records this is
-        always 1; for vector records (e.g. `UGRD`/`VGRD` siblings) it selects
-        the requested wind component.
-
-    Returns
-    -------
-    np.ndarray
-        Decoded 2-D field as a NumPy array.
-    """
-    try:
-        grbs = pygrib.open(grib_file)
-    except Exception as e:
-        logger.error(f"Failed to open grib file {grib_file}")
-        raise e
-    try:
-        # pygrib.open() uses 1-based message indexing.
-        return np.asarray(grbs[submsg_index].values)
-    except Exception as e:
-        logger.error(
-            f"Failed to read grib file {grib_file} at submessage {submsg_index}"
-        )
-        raise e
-    finally:
-        grbs.close()

--- a/earth2studio/data/cfs_reforecast.py
+++ b/earth2studio/data/cfs_reforecast.py
@@ -200,8 +200,7 @@ class CFS_Reforecast_FX:
     Additional information on the data repository:
 
     - https://www.ncei.noaa.gov/products/weather-climate-models/climate-forecast-system
-    - https://www.ncei.noaa.gov/data/climate-forecast-system/access/reforecast/6-hourly-by-pressure-level-9-month-runs/
-    - https://www.ncei.noaa.gov/data/climate-forecast-system/access/reforecast/6-hourly-flux-9-month-runs/
+    - https://www.ncei.noaa.gov/oa/prod-cfs-reforecast/index.html
 
     Badges
     ------
@@ -209,15 +208,15 @@ class CFS_Reforecast_FX:
     """
 
     # NCEI HTTPS base path; both pgbf and flxf live under the same parent
-    # but differ in the product subdir.
-    CFS_NCEI_BASE = (
-        "https://www.ncei.noaa.gov/data/climate-forecast-system/access/reforecast"
-    )
+    # but differ in the product subdir. The archive moved from
+    # /data/climate-forecast-system/access/reforecast to this S3-style
+    # endpoint (the old path now only serves a readme with the new URL).
+    CFS_NCEI_BASE = "https://www.ncei.noaa.gov/oa/prod-cfs-reforecast"
 
     # File prefix and product subdirectory for this product.  Overridden in
     # :class:`CFS_Reforecast_FX_Flux`.
     CFS_PRODUCT = "pgbf"
-    CFS_NCEI_SUBDIR = "6-hourly-by-pressure-level-9-month-runs"
+    CFS_NCEI_SUBDIR = "6-hourly_9mon_pgbf"
 
     # 1 degree regular lat-lon grid, identical to the operational pgbf.
     CFS_LAT = CFS_FX.CFS_LAT
@@ -620,7 +619,7 @@ class CFS_Reforecast_FX_Flux(CFS_Reforecast_FX):
     Additional information on the data repository:
 
     - https://www.ncei.noaa.gov/products/weather-climate-models/climate-forecast-system
-    - https://www.ncei.noaa.gov/data/climate-forecast-system/access/reforecast/6-hourly-flux-9-month-runs/
+    - https://www.ncei.noaa.gov/oa/prod-cfs-reforecast/index.html
 
     Badges
     ------
@@ -628,7 +627,7 @@ class CFS_Reforecast_FX_Flux(CFS_Reforecast_FX):
     """
 
     CFS_PRODUCT = "flxf"
-    CFS_NCEI_SUBDIR = "6-hourly-flux-9-month-runs"
+    CFS_NCEI_SUBDIR = "cfs_reforecast_6-hourly_9mon_flxf"
 
     # T126 Gaussian grid, identical to the operational flxf.
     CFS_LAT = CFS_FX_Flux.CFS_LAT

--- a/earth2studio/data/cfs_reforecast.py
+++ b/earth2studio/data/cfs_reforecast.py
@@ -28,8 +28,8 @@ from typing import Any
 import numpy as np
 import pygrib
 import xarray as xr
-from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.cfs import CFS_FX, CFS_FX_Flux
@@ -39,6 +39,8 @@ from earth2studio.data.utils import (
     cancellable_to_thread,
     datasource_cache_root,
     gather_with_concurrency,
+    obstore_fetch_to_cache,
+    obstore_store_from_url,
     prep_forecast_inputs,
 )
 from earth2studio.lexicon import CFSFluxLexicon, CFSLexicon
@@ -239,16 +241,11 @@ class CFS_Reforecast_FX:
         self.async_timeout = async_timeout
 
         # Filesystem is lazily initialised inside the event loop.
-        self.fs: HTTPFileSystem | None = None
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialisation of the HTTPS fsspec backend.
-
-        Note
-        ----
-        Async fsspec expects initialisation inside the execution loop.
-        """
-        self.fs = HTTPFileSystem(asynchronous=True)
+        """Async initialization of the obstore HTTP store"""
+        self.store = obstore_store_from_url(self.CFS_NCEI_BASE)
 
     def __call__(
         self,
@@ -304,7 +301,7 @@ class CFS_Reforecast_FX:
         xr.DataArray
             CFS reforecast data array.
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
@@ -514,25 +511,23 @@ class CFS_Reforecast_FX:
         str
             Path to the cached file on local disk.
         """
-        if self.fs is None:
-            raise ValueError("File system is not initialised")
+        if self.store is None:
+            raise ValueError("Object store is not initialised")
 
-        cache_path = os.path.join(self.cache, hashlib.sha256(uri.encode()).hexdigest())
-        if pathlib.Path(cache_path).is_file():
-            return cache_path
-
+        # Hash the full URI (unchanged scheme) so warm caches populated
+        # before the obstore migration remain valid
+        cache_key = hashlib.sha256(uri.encode()).hexdigest()
+        key = uri.removeprefix(self.CFS_NCEI_BASE + "/")
         try:
-            data = await self.fs._cat_file(uri)
+            return await obstore_fetch_to_cache(
+                self.store, key, self.cache, cache_key=cache_key
+            )
         except FileNotFoundError as e:
             logger.error(
                 f"CFS reforecast file not found at {uri}: cycle/lead may not "
                 "fall on the 5-day reforecast schedule."
             )
             raise e
-
-        with open(cache_path, "wb") as fh:
-            fh.write(data)
-        return cache_path
 
     def _grib_uri(self, time: datetime, lead_time: timedelta) -> str:
         """Build the HTTPS URI for a (time, lead_time) grib file."""

--- a/earth2studio/data/cfs_reforecast.py
+++ b/earth2studio/data/cfs_reforecast.py
@@ -647,8 +647,8 @@ def _decode_cfs_reforecast_grib(
     grib_file : str
         Path to the cached grib file on local disk.
     variables : list of (var_idx, parameterName, typeOfLevel, level, modifier)
-        Variables to extract from this grib file. Each tuple is processed
-        independently against ``pygrib.select``; missing variables emit a
+        Variables to extract from this grib file. All variables are resolved
+        in a single pass over the file's messages; missing variables emit a
         warning but do not abort the others.
 
     Returns
@@ -665,21 +665,34 @@ def _decode_cfs_reforecast_grib(
         logger.error(f"Failed to open grib file {grib_file}")
         raise e
     try:
+        # One pass over the file: pygrib.select() rescans every message per
+        # call, which is O(variables x messages) and dominates fetch time for
+        # large requests (~1.2 s per select on a 524-message pgbf file).
+        # Matching the first message per requested key preserves select()'s
+        # matches[0] behaviour.
+        wanted = {
+            (param_name, type_of_level, level)
+            for _, param_name, type_of_level, level, _ in variables
+        }
+        found: dict[tuple[str, str, int], Any] = {}
+        for grb in grbs:
+            key = (grb.parameterName, grb.typeOfLevel, grb.level)
+            if key in wanted and key not in found:
+                found[key] = grb
+                if len(found) == len(wanted):
+                    break
+
         out: list[tuple[int, np.ndarray]] = []
         for var_idx, param_name, type_of_level, level, modifier in variables:
-            matches = grbs.select(
-                parameterName=param_name,
-                typeOfLevel=type_of_level,
-                level=level,
-            )
-            if not matches:
+            grb = found.get((param_name, type_of_level, level))
+            if grb is None:
                 logger.warning(
                     f"CFS reforecast grib {grib_file} has no record matching "
                     f"parameterName={param_name!r} typeOfLevel={type_of_level!r} "
                     f"level={level}; variable will be left unset."
                 )
                 continue
-            out.append((var_idx, modifier(np.asarray(matches[0].values))))
+            out.append((var_idx, modifier(np.asarray(grb.values))))
         return out
     finally:
         grbs.close()

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -25,7 +25,6 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import obstore as obs
-import pygrib
 import xarray as xr
 from loguru import logger
 from obstore.store import ObjectStore
@@ -36,6 +35,7 @@ from earth2studio.data.utils import (
     async_retry,
     cancellable_to_thread,
     datasource_cache_root,
+    decode_grib_message,
     gather_with_concurrency,
     obstore_fetch_to_cache,
     obstore_store_from_url,
@@ -406,7 +406,7 @@ class GEFS_FX:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(_decode_gefs_grib, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -719,33 +719,3 @@ class GEFS_FX_721x1440(GEFS_FX):
                         f"Requested lead time {delta} needs to be 3 hour interval for first 10 days in GEFS 0.25 degree data"
                     )
 
-
-def _decode_gefs_grib(grib_file: str) -> np.ndarray:
-    """Decode a single-message GEFS grib file into a numpy array.
-
-    Module-level so it can be dispatched to a worker thread and patched in
-    offline tests. Uses pygrib, which is faster and lower memory than
-    xarray/cfgrib for single-message slices.
-
-    Parameters
-    ----------
-    grib_file : str
-        Path to local grib file holding one message
-
-    Returns
-    -------
-    np.ndarray
-        Decoded field values
-    """
-    try:
-        grbs = pygrib.open(grib_file)
-    except Exception:
-        logger.error(f"Failed to open grib file {grib_file}")
-        raise
-    try:
-        return grbs[1].values
-    except Exception:
-        logger.error(f"Failed to read grib file {grib_file}")
-        raise
-    finally:
-        grbs.close()

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -406,7 +406,9 @@ class GEFS_FX:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(
+            decode_grib_message, grib_file, timeout=30.0
+        )
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -718,4 +720,3 @@ class GEFS_FX_721x1440(GEFS_FX):
                     raise ValueError(
                         f"Requested lead time {delta} needs to be 3 hour interval for first 10 days in GEFS 0.25 degree data"
                     )
-

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -391,7 +391,9 @@ class GFS:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(
+            decode_grib_message, grib_file, timeout=30.0
+        )
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -711,4 +713,3 @@ class GFS_FX(GFS):
                 raise ValueError(
                     f"Requested lead time {delta} can only be a max of 384 hours for GFS"
                 )
-

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -25,7 +25,6 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import obstore as obs
-import pygrib
 import xarray as xr
 from loguru import logger
 from obstore.store import ObjectStore
@@ -36,6 +35,7 @@ from earth2studio.data.utils import (
     async_retry,
     cancellable_to_thread,
     datasource_cache_root,
+    decode_grib_message,
     gather_with_concurrency,
     obstore_fetch_to_cache,
     obstore_store_from_url,
@@ -391,7 +391,7 @@ class GFS:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(_decode_gfs_grib, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -712,33 +712,3 @@ class GFS_FX(GFS):
                     f"Requested lead time {delta} can only be a max of 384 hours for GFS"
                 )
 
-
-def _decode_gfs_grib(grib_file: str) -> np.ndarray:
-    """Decode a single-message GFS grib file into a numpy array.
-
-    Module-level so it can be dispatched to a worker thread and patched in
-    offline tests. Uses pygrib, which is faster and lower memory than
-    xarray/cfgrib for single-message slices.
-
-    Parameters
-    ----------
-    grib_file : str
-        Path to local grib file holding one message
-
-    Returns
-    -------
-    np.ndarray
-        Decoded field values
-    """
-    try:
-        grbs = pygrib.open(grib_file)
-    except Exception:
-        logger.error(f"Failed to open grib file {grib_file}")
-        raise
-    try:
-        return grbs[1].values
-    except Exception:
-        logger.error(f"Failed to read grib file {grib_file}")
-        raise
-    finally:
-        grbs.close()

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -490,7 +490,9 @@ class HRRR:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(
+            decode_grib_message, grib_file, timeout=30.0
+        )
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -903,4 +905,3 @@ class HRRR_FX(HRRR):
                     raise ValueError(
                         f"Requested lead time {delta} can only be between [0,18] hours for HRRR forecast not on 6 hour interval {time}"
                     )
-

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -24,7 +24,6 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import obstore as obs
-import pygrib
 import xarray as xr
 from loguru import logger
 from obstore.store import ObjectStore
@@ -35,6 +34,7 @@ from earth2studio.data.utils import (
     async_retry,
     cancellable_to_thread,
     datasource_cache_root,
+    decode_grib_message,
     gather_with_concurrency,
     obstore_fetch_to_cache,
     obstore_store_from_url,
@@ -490,7 +490,7 @@ class HRRR:
             byte_length=byte_length,
         )
         # pygrib decode is blocking and GIL-bound; run in a thread with timeout
-        values = await cancellable_to_thread(_decode_hrrr_grib, grib_file, timeout=30.0)
+        values = await cancellable_to_thread(decode_grib_message, grib_file, timeout=30.0)
         return modifier(values)
 
     def _validate_time(self, times: list[datetime]) -> None:
@@ -904,33 +904,3 @@ class HRRR_FX(HRRR):
                         f"Requested lead time {delta} can only be between [0,18] hours for HRRR forecast not on 6 hour interval {time}"
                     )
 
-
-def _decode_hrrr_grib(grib_file: str) -> np.ndarray:
-    """Decode a single-message HRRR grib file into a numpy array.
-
-    Module-level so it can be dispatched to a worker thread and patched in
-    offline tests. Uses pygrib, which is faster and lower memory than
-    xarray/cfgrib for single-message slices.
-
-    Parameters
-    ----------
-    grib_file : str
-        Path to local grib file holding one message
-
-    Returns
-    -------
-    np.ndarray
-        Decoded field values
-    """
-    try:
-        grbs = pygrib.open(grib_file)
-    except Exception:
-        logger.error(f"Failed to open grib file {grib_file}")
-        raise
-    try:
-        return grbs[1].values
-    except Exception:
-        logger.error(f"Failed to read grib file {grib_file}")
-        raise
-    finally:
-        grbs.close()

--- a/earth2studio/data/ibtracs.py
+++ b/earth2studio/data/ibtracs.py
@@ -23,17 +23,20 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import numpy as np
+import obstore as obs
 import pandas as pd
 import pyarrow as pa
-from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
 from netCDF4 import Dataset
+from obstore.store import ObjectStore
 
 from earth2studio.data.utils import (
     _sync_async,
     async_retry,
     datasource_cache_root,
     gather_with_concurrency,
+    obstore_read_range,
+    obstore_store_from_url,
     prep_data_inputs,
 )
 from earth2studio.lexicon.base import E2STUDIO_SCHEMA
@@ -200,11 +203,11 @@ class IBTrACS:
         self._tmp_cache_hash: str | None = None
 
         # Async HTTP filesystem (initialized lazily)
-        self.fs: HTTPFileSystem | None = None
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialization of HTTP filesystem."""
-        self.fs = HTTPFileSystem(asynchronous=True)
+        """Async initialization of the obstore HTTP store"""
+        self.store = obstore_store_from_url(IBTRACS_BASE_URL)
 
     def __call__(
         self,
@@ -259,7 +262,7 @@ class IBTrACS:
         pd.DataFrame
             IBTrACS track observations.
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time_list, variable_list = prep_data_inputs(time, variable)
@@ -279,7 +282,6 @@ class IBTrACS:
         tasks = self._create_tasks()
 
         # Fetch region files with cache invalidation
-        # HTTPFileSystem manages its own session lazily (no set_session needed)
         coros = [
             async_retry(
                 self._fetch_region_file,
@@ -328,8 +330,8 @@ class IBTrACS:
         task : IBTrACSAsyncTask
             Task containing region and URL info.
         """
-        if self.fs is None:
-            raise ValueError("Filesystem not initialized")
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
         meta_path = task.local_path + ".meta"
 
@@ -338,8 +340,10 @@ class IBTrACS:
         if self._cache and os.path.isfile(task.local_path):
             # Check Last-Modified header
             try:
-                info = await self.fs._info(task.remote_url)
-                server_mtime = info.get("Last-Modified") or info.get("last-modified")
+                key = task.remote_url.removeprefix(IBTRACS_BASE_URL + "/")
+                meta = await obs.head_async(self.store, key)
+                mtime = meta.get("last_modified")
+                server_mtime = str(mtime) if mtime else None
 
                 if server_mtime and os.path.isfile(meta_path):
                     with open(meta_path) as f:
@@ -348,7 +352,7 @@ class IBTrACS:
                         need_download = False
                         if self._verbose:
                             logger.debug(f"Using cached {task.region} (up to date)")
-            except (OSError, KeyError):
+            except (OSError, KeyError, obs.exceptions.BaseError):
                 # If HEAD request fails, just download
                 pass
 
@@ -357,21 +361,20 @@ class IBTrACS:
                 logger.info(f"Downloading IBTrACS {task.region} region data...")
 
             # Download the file
-            data = await self.fs._cat_file(task.remote_url)
+            key = task.remote_url.removeprefix(IBTRACS_BASE_URL + "/")
+            data = await obstore_read_range(self.store, key)
             with open(task.local_path, "wb") as f:
                 f.write(data)
 
             # Save metadata for cache invalidation
             if self._cache:
                 try:
-                    info = await self.fs._info(task.remote_url)
-                    server_mtime = info.get("Last-Modified") or info.get(
-                        "last-modified"
-                    )
-                    if server_mtime:
+                    meta = await obs.head_async(self.store, key)
+                    mtime = meta.get("last_modified")
+                    if mtime:
                         with open(meta_path, "w") as f:
-                            json.dump({"last_modified": server_mtime}, f)
-                except OSError:
+                            json.dump({"last_modified": str(mtime)}, f)
+                except (OSError, obs.exceptions.BaseError):
                     pass
 
     def _compile_dataframe(

--- a/earth2studio/data/isd.py
+++ b/earth2studio/data/isd.py
@@ -26,15 +26,18 @@ from datetime import datetime
 from typing import Any
 
 import numpy as np
+import obstore as obs
 import pandas as pd
 import pyarrow as pa
-import s3fs
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
 from earth2studio.data.utils import (
     _sync_async,
     datasource_cache_root,
+    obstore_read_range,
+    obstore_store_from_url,
     prep_data_inputs,
 )
 from earth2studio.lexicon import ISDLexicon
@@ -147,19 +150,21 @@ class ISD:
         self._tmp_cache_hash: str | None = None
         self._verbose = verbose
 
-        # Filesystem is lazily initialized on first call
-        self.fs: s3fs.S3FileSystem | None = None
+        # Object store is lazily initialized on first call
+        self.store: ObjectStore | None = None
 
         self.async_timeout = async_timeout
 
     async def _async_init(self) -> None:
-        """Async initialization of fs object
+        """Async initialization of the object store
 
         Note
         ----
-        Async fsspec expects initialization inside of the execution loop
+        Unlike async fsspec filesystems, obstore stores are event-loop
+        independent; kept as a lazy async method to preserve the
+        initialization seam.
         """
-        self.fs = s3fs.S3FileSystem(anon=True, client_kwargs={}, asynchronous=True)
+        self.store = obstore_store_from_url("s3://noaa-global-hourly-pds")
 
     def __call__(
         self,
@@ -219,11 +224,8 @@ class ISD:
         pd.DataFrame
             ISD data frame
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        session = await self.fs.set_session(refresh=True)  # type: ignore[union-attr]
 
         time, variable = prep_data_inputs(time, variable)
         schema = self.resolve_fields(fields)
@@ -297,10 +299,6 @@ class ISD:
         result = self._create_observation_dataframe(df, variable, schema)
         result.attrs["source"] = self.SOURCE_ID
 
-        # Close aiohttp client if s3fs
-        if session:
-            await session.close()
-
         return result
 
     def _create_observation_dataframe(
@@ -354,8 +352,8 @@ class ISD:
         pd.DataFrame
             Pandas dataframe of CSV
         """
-        if self.fs is None:
-            raise ValueError("File system is not initialized")
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
 
         s3_url = f"s3://noaa-global-hourly-pds/{year}/{station_id}.csv"
         # Hash the URL for cache file names
@@ -366,17 +364,16 @@ class ISD:
         if self._cache and os.path.isfile(parquet_path):
             df = await asyncio.to_thread(pd.read_parquet, parquet_path)
         else:
-            # Download CSV via s3fs to cache, then read with pandas
+            # Download CSV via obstore, then read with pandas
             try:
-                # file_butter = await self.fs._open(s3_url)
-                async with await self.fs.open_async(s3_url, "rb") as f:
-                    df = await asyncio.to_thread(
-                        pd.read_csv,
-                        io.BytesIO(await f.read()),
-                        parse_dates=["DATE"],
-                        low_memory=False,  # Mixed types
-                    )
-                    await asyncio.to_thread(df.to_parquet, parquet_path, index=False)
+                data = await obstore_read_range(self.store, f"{year}/{station_id}.csv")
+                df = await asyncio.to_thread(
+                    pd.read_csv,
+                    io.BytesIO(data),
+                    parse_dates=["DATE"],
+                    low_memory=False,  # Mixed types
+                )
+                await asyncio.to_thread(df.to_parquet, parquet_path, index=False)
             except FileNotFoundError:
                 # If that station does not have data for this year, return empty
                 if self._verbose:
@@ -494,8 +491,9 @@ class ISD:
         catalog_csv = os.path.join(cache_dir, "isd-history.csv")
 
         if not os.path.isfile(catalog_csv):
-            fs = s3fs.S3FileSystem(anon=True)
-            fs.get("s3://noaa-isd-pds/isd-history.csv", catalog_csv)
+            store = obstore_store_from_url("s3://noaa-isd-pds")
+            data = obs.get(store, "isd-history.csv").bytes()
+            pathlib.Path(catalog_csv).write_bytes(data)
         return pd.read_csv(catalog_csv)
 
     @classmethod

--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -31,13 +31,15 @@ from typing import Any
 import numpy as np
 import xarray as xr
 from loguru import logger
+from obstore.store import ObjectStore
 
 from earth2studio.data.utils import (
     _sync_async,
     async_retry,
     datasource_cache_root,
     gather_with_concurrency,
-    managed_session,
+    obstore_read_range,
+    obstore_store_from_url,
     prep_data_inputs,
 )
 from earth2studio.lexicon.opera import OPERALexicon
@@ -330,18 +332,11 @@ class OPERA:
         self._retries = retries
         self.async_timeout = async_timeout
         self._tmp_cache_hash: str | None = None
-        self.fs: Any = None
+        self.store: ObjectStore | None = None
 
     async def _async_init(self) -> None:
-        """Async initialization of zarr group
-
-        Note
-        ----
-        Async fsspec expects initialization inside of the execution loop
-        """
-        from fsspec.implementations.http import HTTPFileSystem
-
-        self.fs = HTTPFileSystem(asynchronous=True)
+        """Async initialization of the obstore HTTP store"""
+        self.store = obstore_store_from_url(_ARCHIVE_BASE)
 
     def __call__(
         self,
@@ -392,7 +387,7 @@ class OPERA:
         xr.DataArray
             OPERA weather data array
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time_list, variable_list = prep_data_inputs(time, variable)
@@ -408,15 +403,14 @@ class OPERA:
         async def _accumulate(task: _OPERAAsyncTask) -> None:
             results[(task.time_idx, task.var_idx)] = await self.fetch_wrapper(task)
 
-        async with managed_session(self.fs):
-            coros = [_accumulate(task) for task in tasks]
-            await gather_with_concurrency(
-                coros,
-                max_workers=self._async_workers,
-                task_timeout=120.0,
-                desc="Fetching OPERA data",
-                verbose=(not self._verbose),
-            )
+        coros = [_accumulate(task) for task in tasks]
+        await gather_with_concurrency(
+            coros,
+            max_workers=self._async_workers,
+            task_timeout=120.0,
+            desc="Fetching OPERA data",
+            verbose=(not self._verbose),
+        )
 
         # Validate that all variables have the same grid shape.
         shapes = {arr.shape for arr in results.values()}
@@ -528,9 +522,11 @@ class OPERA:
         ValueError
             If the filesystem is not initialised or the quantity is absent.
         """
-        if self.fs is None:
-            raise ValueError("Filesystem not initialized; call _async_init first")
+        if self.store is None:
+            raise ValueError("Object store is not initialized; call _async_init first")
 
+        # Hash the full URL (unchanged scheme) so warm caches populated
+        # before the obstore migration remain valid
         sha = hashlib.sha256(task.url.encode())
         cache_path = os.path.join(self.cache, sha.hexdigest())
 
@@ -539,7 +535,8 @@ class OPERA:
             data_bytes = pathlib.Path(cache_path).read_bytes()
         else:
             logger.debug(f"Fetching {task.url}")
-            data_bytes = await self.fs._cat_file(task.url)
+            key = task.url.removeprefix(_ARCHIVE_BASE + "/")
+            data_bytes = await obstore_read_range(self.store, key)
             with open(cache_path, "wb") as fh:
                 await asyncio.to_thread(fh.write, data_bytes)
 

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -835,6 +835,49 @@ def resolve_async_workers(
     return max(1, min(n_tasks, cap))
 
 
+def decode_grib_message(grib_file: str, message_index: int = 1) -> np.ndarray:
+    """Decode one message from a local grib file into a numpy array.
+
+    Shared by the GRIB byte-range data sources (GFS, HRRR, GEFS, CFS), which
+    cache single-message (or few-submessage) slices to disk. Sync and
+    module-level so callers can dispatch it via ``cancellable_to_thread`` and
+    patch it in offline tests. Uses pygrib, which is faster and lower memory
+    than xarray/cfgrib for single-message slices.
+
+    Parameters
+    ----------
+    grib_file : str
+        Path to local grib file.
+    message_index : int, optional
+        1-based pygrib message index to extract, by default 1. Byte-range
+        slices hold a single message; vector wind packings (e.g. CFS
+        `UGRD`/`VGRD` siblings) hold multiple submessages.
+
+    Returns
+    -------
+    np.ndarray
+        Decoded 2-D field values.
+    """
+    # Local import keeps pygrib (a heavy C extension) out of the import path
+    # of data sources that do not read grib.
+    import pygrib
+
+    try:
+        grbs = pygrib.open(grib_file)
+    except Exception:
+        logger.error(f"Failed to open grib file {grib_file}")
+        raise
+    try:
+        return np.asarray(grbs[message_index].values)
+    except Exception:
+        logger.error(
+            f"Failed to read grib file {grib_file} at message {message_index}"
+        )
+        raise
+    finally:
+        grbs.close()
+
+
 class AsyncReadableStore(
     obspec.GetAsync, obspec.GetRangeAsync, obspec.HeadAsync, Protocol
 ):

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -870,9 +870,7 @@ def decode_grib_message(grib_file: str, message_index: int = 1) -> np.ndarray:
     try:
         return np.asarray(grbs[message_index].values)
     except Exception:
-        logger.error(
-            f"Failed to read grib file {grib_file} at message {message_index}"
-        )
+        logger.error(f"Failed to read grib file {grib_file} at message {message_index}")
         raise
     finally:
         grbs.close()

--- a/test/data/test_cfs.py
+++ b/test/data/test_cfs.py
@@ -292,7 +292,7 @@ def test_cfs_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
         patch(
-            "earth2studio.data.cfs._decode_cfs_grib",
+            "earth2studio.data.cfs.decode_grib_message",
             return_value=fake_grid,
         ),
     ):
@@ -332,7 +332,7 @@ def test_cfs_nomads_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.cfs._decode_cfs_grib", return_value=fake_grid),
+        patch("earth2studio.data.cfs.decode_grib_message", return_value=fake_grid),
     ):
         # Bypass real store by stubbing it to a truthy sentinel.
         ds.store = object()  # type: ignore[assignment]
@@ -368,7 +368,7 @@ def test_cfs_flux_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
         patch(
-            "earth2studio.data.cfs._decode_cfs_grib",
+            "earth2studio.data.cfs.decode_grib_message",
             return_value=fake_grid,
         ),
     ):
@@ -408,7 +408,7 @@ def test_cfs_missing_variable_returns_nan(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.cfs._decode_cfs_grib", return_value=fake_grid),
+        patch("earth2studio.data.cfs.decode_grib_message", return_value=fake_grid),
     ):
         ds.store = object()  # type: ignore[assignment]
         data = ds(_TEST_CYCLE, timedelta(hours=6), ["msl", "z500"])

--- a/test/data/test_gefs.py
+++ b/test/data/test_gefs.py
@@ -342,7 +342,7 @@ def test_gefs_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gefs.decode_grib_message", return_value=fake_grid),
     ):
         # Bypass real store by stubbing it to a truthy sentinel.
         ds.store = object()  # type: ignore[assignment]
@@ -381,7 +381,7 @@ def test_gefs_call_mock_trailing_record(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gefs.decode_grib_message", return_value=fake_grid),
     ):
         ds.store = object()  # type: ignore[assignment]
         data = ds(datetime(2024, 1, 1), timedelta(hours=3), ["t2m"])
@@ -414,7 +414,7 @@ def test_gefs_0p25_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gefs._decode_gefs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gefs.decode_grib_message", return_value=fake_grid),
     ):
         ds.store = object()  # type: ignore[assignment]
         data = ds(

--- a/test/data/test_gfs.py
+++ b/test/data/test_gfs.py
@@ -294,7 +294,7 @@ def test_gfs_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gfs._decode_gfs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gfs.decode_grib_message", return_value=fake_grid),
     ):
         # Bypass real store by stubbing it to a truthy sentinel.
         ds.store = object()  # type: ignore[assignment]
@@ -329,7 +329,7 @@ def test_gfs_fx_call_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gfs._decode_gfs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gfs.decode_grib_message", return_value=fake_grid),
     ):
         ds.store = object()  # type: ignore[assignment]
         data = ds(
@@ -364,7 +364,7 @@ def test_gfs_missing_variable_mock(tmp_path, monkeypatch):
         patch.object(ds, "_async_init", new=AsyncMock(return_value=None)),
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.gfs._decode_gfs_grib", return_value=fake_grid),
+        patch("earth2studio.data.gfs.decode_grib_message", return_value=fake_grid),
     ):
         ds.store = object()  # type: ignore[assignment]
         data = ds(datetime(2024, 1, 1), ["t2m", "z500"])

--- a/test/data/test_hrrr.py
+++ b/test/data/test_hrrr.py
@@ -335,7 +335,7 @@ def test_hrrr_call_mock(source, tmp_path, monkeypatch):
     with (
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+        patch("earth2studio.data.hrrr.decode_grib_message", return_value=fake_grid),
     ):
         data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
 
@@ -372,7 +372,7 @@ def test_hrrr_fx_call_mock(tmp_path, monkeypatch):
     with (
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+        patch("earth2studio.data.hrrr.decode_grib_message", return_value=fake_grid),
     ):
         data = ds(
             datetime(2024, 1, 1),
@@ -405,7 +405,7 @@ def test_hrrr_missing_variable_mock(tmp_path, monkeypatch):
     with (
         patch.object(ds, "_fetch_index", side_effect=_fake_fetch_index),
         patch.object(ds, "_fetch_remote_file", side_effect=_fake_fetch_remote_file),
-        patch("earth2studio.data.hrrr._decode_hrrr_grib", return_value=fake_grid),
+        patch("earth2studio.data.hrrr.decode_grib_message", return_value=fake_grid),
     ):
         data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Closes NVIDIA/physicsnemo-roadmap#2883
closes NVIDIA/physicsnemo-roadmap#2886
closes NVIDIA/physicsnemo-roadmap#2887
closes NVIDIA/physicsnemo-roadmap#2888

Migrates four data sources from fsspec/s3fs/HTTP to obstore, continuing the migration pattern established by the GOES (#1024), GOES GLM, and Himawari AHI (#1043) PRs:

- **ISD** — station CSV and station-history S3 reads move from s3fs to obstore
- **IBTrACS** — HTTP downloads and Last-Modified cache validation move to obstore
- **CFS reforecast** — full-file HTTP fetching moves to obstore, preserving historical cache keys
- **OPERA** — HTTP object reads move to obstore, retaining URL-derived cache keys

Each migration is a single-file commit. Cache-key formats are unchanged, so existing local caches remain valid.

Three additional changes surfaced by benchmarking this PR:

- **CFS reforecast NCEI URL fix** — NCEI retired the `/data/climate-forecast-system/access/reforecast` path (it now serves only a readme), breaking `CFS_Reforecast_FX` / `CFS_Reforecast_FX_Flux` on `main` as well. Both classes now point at the relocated archive (`https://www.ncei.noaa.gov/oa/prod-cfs-reforecast`) with its renamed product subdirs; file naming and date-path layout are unchanged.
- **Single-pass GRIB decode** — CFS reforecast decoding called `pygrib.select()` once per variable, and each call rescans every message in the file (~1.2 s on a 524-message pgbf file), costing ~100 s for a full-lexicon request while the 22 MB download takes ~2 s. Variables are now resolved in one pass over the file's messages, preserving `select()`'s first-match semantics. Decoded arrays verified bit-identical to the old path for all 81 pgbf variables.
- **Shared GRIB decode helper** — GFS, HRRR, GEFS, and CFS each carried a byte-identical private `_decode_*_grib` helper; all four are consolidated into `decode_grib_message` in `earth2studio.data.utils` (net −77 lines). Pure refactor: identical decode logic and thread dispatch, no performance or behavior change for those sources.

### Performance

Each source fetched its full lexicon with `cache=False`, 3 reps, same host and time window; medians shown. CFS rows used the relocated NCEI endpoint on both sides for an apples-to-apples comparison.

| Data source | File type | Before (main) | After (PR) | Speedup |
|---|---|---|---|---|
| ISD (8 vars) | CSV (one per station-year, S3) | ~5.3 s | ~3.0 s | 1.8× |
| IBTrACS (9 vars) | netCDF4 (one per region, HTTPS) | ~6.1 s | ~3.8 s | 1.6× |
| CFS_Reforecast_FX pgbf (81 vars) | GRIB2 (~22 MB, whole file, HTTPS) | ~102 s | 4.7–5.3 s | ~20× |
| CFS_Reforecast_FX_Flux (13 vars) | GRIB2 (~7 MB, whole file, HTTPS) | ~4.6 s | 1.5–1.6 s | ~3× |
| OPERA (3 vars) | HDF5 (ODIM, one per timestep, HTTPS) | ~3.0 s | ~1.7 s | 1.8× |

The CSV/netCDF/HDF5 sources gain from obstore's lower per-request overhead. The GRIB2 sources download one whole file per (time, lead) — the reforecast bucket has no `.idx` companions — so their gain comes from the single-pass decode, not the transfer layer.

The `.idx` byte-range sources (GFS, HRRR, GEFS, CFS operational) are untouched by this PR beyond the helper consolidation. Batching their per-variable range requests through `obstore.get_ranges` (which coalesces ranges under 1 MiB apart) was prototyped and benchmarked, and rejected: full-lexicon CFS_FX (81 vars) was a wash (~3.6 s both ways) and full-lexicon GFS (246 vars) regressed ~10–15% (12.1–12.8 s → 13.3–26.5 s), because `get_ranges` caps at 10 parallel fetches per file while the existing per-range path fans out across up to 64 async workers.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes (`test_isd.py`, `test_ibtracs.py`, `test_cfs.py`, `test_cfs_reforecast.py`, `test_opera.py` pass).
- [x] The documentation is up to date with these changes (docstrings updated for the relocated NCEI archive).
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An issue is linked to this pull request (physicsnemo-roadmap task issues above).
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

No new dependencies; obstore and obspec are already core dependencies.
