### PR TITLE
Optimize and migrate MRMS and NClimGridDaily data sources on obstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated MRMS data source from s3fs to obstore; day-directory listings of
   past (complete) days are memoized per instance while the current day is
   always re-listed
+- MRMS grib decoding now computes the regular-grid lat/lon axes from
+  grid-definition header keys instead of `latlons()` (which decodes full 2-D
+  coordinate arrays, ~8 s per file) and runs in a worker thread so concurrent
+  tasks decode in parallel (~6x faster fetches)
 - Migrated NClimGridDaily data source from s3fs to obstore; monthly NetCDF
   files are now downloaded once into the cache and shared across all
   (day, variable) slices instead of being streamed per slice over fsspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hours are memoized per instance while the current hour is always re-listed
 - Migrated Himawari AHI data source from s3fs to obstore with memoized
   minute-directory listings (scans older than an hour)
+- Migrated MRMS data source from s3fs to obstore; day-directory listings of
+  past (complete) days are memoized per instance while the current day is
+  always re-listed
+- Migrated NClimGridDaily data source from s3fs to obstore; monthly NetCDF
+  files are now downloaded once into the cache and shared across all
+  (day, variable) slices instead of being streamed per slice over fsspec
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hours are memoized per instance while the current hour is always re-listed
 - Migrated Himawari AHI data source from s3fs to obstore with memoized
   minute-directory listings (scans older than an hour)
-- Migrated MRMS data source from s3fs to obstore; day-directory listings of
-  past (complete) days are memoized per instance while the current day is
-  always re-listed
-- MRMS grib decoding now computes the regular-grid lat/lon axes from
-  grid-definition header keys instead of `latlons()` (which decodes full 2-D
-  coordinate arrays, ~8 s per file) and runs in a worker thread so concurrent
-  tasks decode in parallel (~6x faster fetches)
+- Migrated MRMS data source from s3fs to obstore, with memoized day-directory
+  listings and threaded, header-based grid decoding
 - Migrated NClimGridDaily data source from s3fs to obstore; monthly NetCDF
   files are now downloaded once into the cache and shared across all
   (day, variable) slices instead of being streamed per slice over fsspec

--- a/earth2studio/data/mrms.py
+++ b/earth2studio/data/mrms.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import gzip
 import hashlib
 import os
@@ -25,12 +26,19 @@ from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pygrib
-import s3fs
 import xarray as xr
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
-from earth2studio.data.utils import _sync_async, datasource_cache_root, prep_data_inputs
+from earth2studio.data.utils import (
+    _sync_async,
+    datasource_cache_root,
+    obstore_list_prefix,
+    obstore_read_range,
+    obstore_store_from_url,
+    prep_data_inputs,
+)
 from earth2studio.lexicon import MRMSLexicon
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
@@ -116,14 +124,15 @@ class MRMS:
         self._verbose = verbose
         self._max_workers = max_workers
         self.async_timeout = async_timeout
-        # Set up S3 filesystem (deferred to first call)
-        self.fs: s3fs.S3FileSystem | None = None
+        # Object store is lazily initialized on first call
+        self.store: ObjectStore | None = None
+        # Memoized day-directory listings; completed (past) days never change
+        # so repeated fetches over the same day share one LIST request.
+        self._list_cache: dict[str, list[str]] = {}
 
     async def _async_init(self) -> None:
-        """Async initialization of S3 filesystem"""
-        self.fs = s3fs.S3FileSystem(
-            anon=True, client_kwargs={}, asynchronous=True, skip_instance_cache=True
-        )
+        """Async initialization of the obstore S3 store"""
+        self.store = obstore_store_from_url(f"s3://{self.MRMS_BUCKET_NAME}")
 
     def __call__(
         self,
@@ -178,7 +187,7 @@ class MRMS:
         xr.DataArray
             MRMS weather data array
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time, variable = prep_data_inputs(time, variable)
@@ -187,9 +196,6 @@ class MRMS:
 
         # Create cache dir if needed
         pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        session = await self.fs.set_session(refresh=True)  # type: ignore[union-attr]
 
         # Group variables by MRMS product and keep (var_index, modifier)
         product_to_vars: dict[str, list[tuple[int, Callable]]] = {}
@@ -263,10 +269,6 @@ class MRMS:
                 {f"actual_time_{v}": ("time", actual_time_by_var[v])}
             )
 
-        # Close aiohttp client if s3fs
-        if session:
-            await session.close()
-
         return out
 
     async def _fetch_task(
@@ -281,7 +283,11 @@ class MRMS:
         # Some MRMS objects can be malformed/truncated upstream; try the next-nearest candidate
         # rather than failing the entire time slice.
         candidates = await self._resolve_s3_time_candidates(
-            self.fs, time, product, self.max_offset_minutes  # type: ignore[arg-type]
+            self.store,  # type: ignore[arg-type]
+            time,
+            product,
+            self.max_offset_minutes,
+            list_cache=self._list_cache,
         )
         if not candidates:
             logger.warning(
@@ -352,11 +358,18 @@ class MRMS:
 
         # Download gz and decompress if not present
         if not pathlib.Path(grib_path).is_file():
-            # Read gzipped payload into memory and decompress to GRIB
-            data = await self.fs._cat_file(s3_uri)  # type: ignore[union-attr]
-            decompressed = gzip.decompress(data)
-            with open(grib_path, "wb") as fout:
-                fout.write(decompressed)
+            if self.store is None:
+                raise ValueError("Object store is not initialized")
+            # Read gzipped payload into memory and decompress to GRIB;
+            # decompression and disk write are blocking, so run in a thread
+            key = s3_uri.removeprefix(f"s3://{self.MRMS_BUCKET_NAME}/")
+            data = await obstore_read_range(self.store, key)
+
+            def _decompress_to_disk() -> None:
+                with open(grib_path, "wb") as fout:
+                    fout.write(gzip.decompress(data))
+
+            await asyncio.to_thread(_decompress_to_disk)
 
         return grib_path
 
@@ -393,10 +406,11 @@ class MRMS:
     @classmethod
     async def _resolve_s3_time_candidates(
         cls,
-        fs: s3fs.S3FileSystem,
+        store: ObjectStore,
         time: datetime,
         product: str,
         max_offset_minutes: float = 10,
+        list_cache: dict[str, list[str]] | None = None,
     ) -> list[tuple[datetime, str]]:
         """Return all candidate MRMS objects within tolerance, sorted nearest-first."""
         # Normalize to timezone-aware UTC for robust datetime arithmetic.
@@ -412,19 +426,22 @@ class MRMS:
             time.strftime("%Y%m%d"),
             t_max.strftime("%Y%m%d"),
         }
+        # Day directories of past days never change and may be memoized; the
+        # current (UTC) day is still being filled and must be re-listed.
+        today_str = datetime.now(timezone.utc).strftime("%Y%m%d")
 
         pattern = re.compile(
             rf"^MRMS_{re.escape(product)}_(\d{{8}})-(\d{{6}})\.grib2\.gz$"
         )
         out: list[tuple[float, datetime, str]] = []
         for date_str in sorted(candidate_dates):
-            dir_uri = (
-                f"s3://{cls.MRMS_BUCKET_NAME}/{cls.MRMS_REGION}/{product}/{date_str}/"
+            prefix = f"{cls.MRMS_REGION}/{product}/{date_str}/"
+            keys = await obstore_list_prefix(
+                store,
+                prefix,
+                cache=list_cache,
+                cacheable=(date_str < today_str),
             )
-            try:
-                keys = await fs._ls(dir_uri)
-            except FileNotFoundError:
-                continue
             for key_path in keys:
                 fname = os.path.basename(key_path)
                 m = pattern.match(fname)
@@ -442,9 +459,9 @@ class MRMS:
                 )
                 diff = abs((ts - time).total_seconds())
                 if diff <= max_offset_minutes * 60:
-                    uri = (
-                        key_path if key_path.startswith("s3://") else f"s3://{key_path}"
-                    )
+                    # Preserve the bucket-prefixed s3:// URI form so cache
+                    # hashes from the s3fs implementation remain valid
+                    uri = f"s3://{cls.MRMS_BUCKET_NAME}/{key_path}"
                     out.append((diff, ts, uri))
 
         out.sort(key=lambda x: (x[0], x[1]))
@@ -513,14 +530,9 @@ class MRMS:
         product = next(iter(products))
 
         async def _resolve_helper() -> bool:
-            fs = s3fs.S3FileSystem(
-                anon=True,
-                client_kwargs={},
-                asynchronous=True,
-                skip_instance_cache=False,
-            )
+            store = obstore_store_from_url(f"s3://{cls.MRMS_BUCKET_NAME}")
             resolved = await cls._resolve_s3_time_candidates(
-                fs, time, product, max_offset_minutes
+                store, time, product, max_offset_minutes
             )
             return len(resolved) > 0
 

--- a/earth2studio/data/mrms.py
+++ b/earth2studio/data/mrms.py
@@ -54,6 +54,46 @@ except ImportError:
     eccodes = None  # type: ignore[assignment]
 
 
+def _decode_mrms_grib(grib_file: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Decode field values and 1-D lat/lon axes from a single-message MRMS grib.
+
+    MRMS CONUS products are on a regular lat/lon grid, so the coordinate axes
+    are computed from the grid-definition header keys. ``latlons()`` decodes
+    full 2-D coordinate arrays and dominates fetch time (~8 s per 3500x7000
+    file vs ~0.1 ms for the header keys); it is kept only as a fallback for
+    non-regular grids.
+
+    Parameters
+    ----------
+    grib_file : str
+        Path to local single-message grib file.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        ``(values, lat, lon)`` with values of shape ``(len(lat), len(lon))``.
+    """
+    grbs = pygrib.open(grib_file)
+    try:
+        grb = grbs[1]
+        values = grb.values  # (ny, nx)
+        try:
+            lat0 = grb.latitudeOfFirstGridPointInDegrees
+            lon0 = grb.longitudeOfFirstGridPointInDegrees
+            dlat = grb.jDirectionIncrementInDegrees
+            dlon = grb.iDirectionIncrementInDegrees
+            lat_step = dlat if grb.jScansPositively else -dlat
+            lat = lat0 + lat_step * np.arange(grb.Nj)
+            lon = lon0 + dlon * np.arange(grb.Ni)
+        except (KeyError, RuntimeError):
+            lats, lons = grb.latlons()
+            lat = lats[:, 0]
+            lon = lons[0, :]
+        return values, lat, lon
+    finally:
+        grbs.close()
+
+
 @check_optional_dependencies("data")
 class MRMS:
     """NOAA Multi-Radar/Multi-Sensor (MRMS) products via AWS S3.
@@ -304,20 +344,14 @@ class MRMS:
 
             grib_file = await self._download_and_decompress_async(s3_uri)
 
-            grbs = None
             try:
-                grbs = pygrib.open(grib_file)
-
-                grb = grbs[1]
-                values = grb.values  # (ny, nx)
-                lats, lons = grb.latlons()
-                lat = lats[:, 0]
-                lon = lons[0, :]
+                # pygrib decode is blocking; run in a thread so concurrent
+                # (time, product) tasks decode in parallel
+                values, lat, lon = await asyncio.to_thread(
+                    _decode_mrms_grib, grib_file
+                )
             except Exception as e:
-                if grbs is None:
-                    logger.error(f"Failed to open grib file {grib_file}")
-                else:
-                    logger.error(f"Failed to read grib file {grib_file}")
+                logger.error(f"Failed to read grib file {grib_file}")
                 last_exc = e
                 if "End of resource reached when reading message" in str(
                     e
@@ -328,9 +362,6 @@ class MRMS:
                     )
                     continue
                 raise
-            finally:
-                if grbs is not None:
-                    grbs.close()
 
             return {
                 "time_index": time_index,

--- a/earth2studio/data/mrms.py
+++ b/earth2studio/data/mrms.py
@@ -347,9 +347,7 @@ class MRMS:
             try:
                 # pygrib decode is blocking; run in a thread so concurrent
                 # (time, product) tasks decode in parallel
-                values, lat, lon = await asyncio.to_thread(
-                    _decode_mrms_grib, grib_file
-                )
+                values, lat, lon = await asyncio.to_thread(_decode_mrms_grib, grib_file)
             except Exception as e:
                 logger.error(f"Failed to read grib file {grib_file}")
                 last_exc = e

--- a/earth2studio/data/mrms.py
+++ b/earth2studio/data/mrms.py
@@ -381,17 +381,18 @@ class MRMS:
 
     async def _download_and_decompress_async(self, s3_uri: str) -> str:
         """Async download of gzipped GRIB2 from S3 and decompress into cache; return path."""
+        if self.store is None:
+            raise ValueError("Object store is not initialized")
+        key = s3_uri.removeprefix(f"s3://{self.MRMS_BUCKET_NAME}/")
+
         # Cache filenames derived from key
-        key_hash = hashlib.sha256(s3_uri.encode()).hexdigest()
+        key_hash = hashlib.sha256(key.encode()).hexdigest()
         grib_path = os.path.join(self.cache, f"{key_hash}.grib2")
 
         # Download gz and decompress if not present
         if not pathlib.Path(grib_path).is_file():
-            if self.store is None:
-                raise ValueError("Object store is not initialized")
             # Read gzipped payload into memory and decompress to GRIB;
             # decompression and disk write are blocking, so run in a thread
-            key = s3_uri.removeprefix(f"s3://{self.MRMS_BUCKET_NAME}/")
             data = await obstore_read_range(self.store, key)
 
             def _decompress_to_disk() -> None:

--- a/earth2studio/data/nclimgrid.py
+++ b/earth2studio/data/nclimgrid.py
@@ -25,12 +25,18 @@ from datetime import datetime
 from pathlib import Path
 
 import numpy as np
-import s3fs
 import xarray as xr
 from loguru import logger
+from obstore.store import ObjectStore
 from tqdm.asyncio import tqdm
 
-from earth2studio.data.utils import _sync_async, datasource_cache_root, prep_data_inputs
+from earth2studio.data.utils import (
+    _sync_async,
+    datasource_cache_root,
+    obstore_fetch_to_cache,
+    obstore_store_from_url,
+    prep_data_inputs,
+)
 from earth2studio.lexicon.nclimgrid import NClimGridLexicon
 from earth2studio.utils.type import TimeArray, VariableArray
 
@@ -96,18 +102,13 @@ class NClimGridDaily:
         self._verbose = verbose
         self._tmp_cache_hash: str | None = None
         self.async_timeout = async_timeout
-        self.fs: s3fs.S3FileSystem | None = None
+        self.store: ObjectStore | None = None
+        # Local paths of monthly NetCDF files downloaded for the current fetch
+        self._monthly_nc_paths: dict[str, str] = {}
 
     async def _async_init(self) -> None:
-        """Async initialization of filesystem.
-
-        Note
-        ----
-        Async fsspec expects initialization inside the execution loop.
-        """
-        self.fs = s3fs.S3FileSystem(
-            anon=True, client_kwargs={}, asynchronous=False, skip_instance_cache=True
-        )
+        """Async initialization of the obstore S3 store"""
+        self.store = obstore_store_from_url(f"s3://{self.NCLIMGRID_BUCKET_NAME}")
 
     def __call__(
         self,
@@ -159,7 +160,7 @@ class NClimGridDaily:
         xr.DataArray
             NClimGrid weather data array with dimensions [time, variable, lat, lon].
         """
-        if self.fs is None:
+        if self.store is None:
             await self._async_init()
 
         time_list, variable_list = prep_data_inputs(time, variable)
@@ -175,6 +176,21 @@ class NClimGridDaily:
         self._validate_time(time_list)
 
         tasks = self._create_tasks(time_list, variable_list)
+
+        # Download each needed monthly NetCDF once up front; every (day,
+        # variable) task for that month then reads the same local file. Only
+        # months whose per-slice caches are all warm skip the download.
+        missing_uris = sorted(
+            {
+                task.nc_uri
+                for task in tasks
+                if not os.path.exists(self._slice_cache_path(task))
+            }
+        )
+        monthly_paths = await asyncio.gather(
+            *(self._fetch_monthly_file(uri) for uri in missing_uris)
+        )
+        self._monthly_nc_paths = dict(zip(missing_uris, monthly_paths))
 
         async_tasks = [self.fetch_wrapper(task) for task in tasks]
         results = await tqdm.gather(
@@ -286,22 +302,14 @@ class NClimGridDaily:
             f"from {task.nc_uri}"
         )
 
-        # Build a cache key from the URI, variable, and date
-        sha = hashlib.sha256(
-            (str(task.nc_uri) + str(task.native_key) + str(task.target_date)).encode()
-        )
-        cache_path = os.path.join(self.cache, sha.hexdigest())
+        cache_path = self._slice_cache_path(task)
 
         if os.path.exists(cache_path):
             ds = xr.open_dataarray(cache_path, engine="h5netcdf", cache=False)
         else:
-            if self.fs is None:
-                raise ValueError(
-                    "File store is not initialized! If calling fetch directly "
-                    "make sure the data source is initialized inside the async loop."
-                )
+            nc_path = self._monthly_nc_paths[task.nc_uri]
             da = await asyncio.to_thread(
-                self._read_s3_variable, task.nc_uri, task.native_key, task.target_date
+                self._read_local_variable, nc_path, task.native_key, task.target_date
             )
 
             # Apply lexicon modifier (unit conversion)
@@ -327,19 +335,37 @@ class NClimGridDaily:
 
         return ds
 
-    def _read_s3_variable(
-        self, nc_uri: str, native_key: str, target_date: datetime
-    ) -> xr.DataArray:
-        """Read a variable from an S3-hosted NetCDF file synchronously.
+    def _slice_cache_path(self, task: NClimGridDailyAsyncTask) -> str:
+        """Cache file path for a single (variable, day) slice."""
+        sha = hashlib.sha256(
+            (str(task.nc_uri) + str(task.native_key) + str(task.target_date)).encode()
+        )
+        return os.path.join(self.cache, sha.hexdigest())
 
-        This must run in a worker thread (via ``asyncio.to_thread``) because
-        ``self.fs`` is a synchronous S3FileSystem whose ``open()`` call
-        internally uses ``fsspec.asyn.sync()`` — incompatible with being called
-        from fsspec's own IO loop.
+    async def _fetch_monthly_file(self, nc_uri: str) -> str:
+        """Download a monthly NetCDF into the cache and return its local path."""
+        if self.store is None:
+            raise ValueError(
+                "Object store is not initialized! If calling fetch directly "
+                "make sure the data source is initialized inside the async loop."
+            )
+        key = nc_uri.removeprefix(f"s3://{self.NCLIMGRID_BUCKET_NAME}/")
+        return await obstore_fetch_to_cache(
+            self.store,
+            key,
+            self.cache,
+            cache_key=hashlib.sha256(nc_uri.encode()).hexdigest() + ".nc",
+        )
+
+    def _read_local_variable(
+        self, nc_path: str, native_key: str, target_date: datetime
+    ) -> xr.DataArray:
+        """Read a variable slice from a locally cached monthly NetCDF file.
+
+        Runs in a worker thread (via ``asyncio.to_thread``) because h5netcdf
+        decode is blocking.
         """
-        assert self.fs is not None  # noqa: S101  # Guaranteed by caller check
-        with self.fs.open(nc_uri, "rb") as f:
-            dataset = xr.open_dataset(f, engine="h5netcdf", cache=False)
+        with xr.open_dataset(nc_path, engine="h5netcdf", cache=False) as dataset:
             da = dataset[native_key].sel(time=str(target_date))
             da = da.load()
         return da

--- a/test/data/test_nclimgrid.py
+++ b/test/data/test_nclimgrid.py
@@ -173,7 +173,7 @@ def test_nclimgrid_create_tasks_invalid_variable():
 
 
 def test_nclimgrid_call_mock(tmp_path: pathlib.Path):
-    """Test NClimGridDaily __call__ with mocked S3 filesystem (no network)."""
+    """Test NClimGridDaily __call__ with a mocked monthly download (no network)."""
     # Create a mock monthly NetCDF with fake CONUS grid
     lat = np.linspace(24.0, 50.0, 10, dtype=np.float32)
     lon = np.linspace(-125.0, -67.0, 15, dtype=np.float32)
@@ -195,13 +195,17 @@ def test_nclimgrid_call_mock(tmp_path: pathlib.Path):
     nc_path = tmp_path / "mock_nclimgrid.nc"
     mock_ds.to_netcdf(nc_path)
 
-    mock_fs = MagicMock()
-    mock_fs.open.return_value.__enter__ = lambda s: open(nc_path, "rb")
-    mock_fs.open.return_value.__exit__ = MagicMock(return_value=False)
+    async def fake_fetch_monthly_file(self, nc_uri: str) -> str:
+        return str(nc_path)
 
-    with patch.object(NClimGridDaily, "_async_init", return_value=None):
+    with (
+        patch.object(NClimGridDaily, "_async_init", return_value=None),
+        patch.object(
+            NClimGridDaily, "_fetch_monthly_file", fake_fetch_monthly_file
+        ),
+    ):
         ds = NClimGridDaily(cache=False)
-        ds.fs = mock_fs
+        ds.store = MagicMock()
 
         data = ds(datetime(2010, 7, 1), ["t2m_max", "tp"])
 

--- a/test/data/test_nclimgrid.py
+++ b/test/data/test_nclimgrid.py
@@ -200,9 +200,7 @@ def test_nclimgrid_call_mock(tmp_path: pathlib.Path):
 
     with (
         patch.object(NClimGridDaily, "_async_init", return_value=None),
-        patch.object(
-            NClimGridDaily, "_fetch_monthly_file", fake_fetch_monthly_file
-        ),
+        patch.object(NClimGridDaily, "_fetch_monthly_file", fake_fetch_monthly_file),
     ):
         ds = NClimGridDaily(cache=False)
         ds.store = MagicMock()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

Closes NVIDIA/physicsnemo-roadmap#2882, closes NVIDIA/physicsnemo-roadmap#2885.

Migrates the MRMS and NClimGridDaily data sources from s3fs to obstore, continuing the migration series (GOES #1024, Himawari AHI #1043, ISD/IBTrACS/CFS-reforecast/OPERA #1058):

- **MRMS** — S3 object reads move to obstore via the shared byte-range helpers. Day-directory listings go through `obstore_list_prefix` with per-instance memoization: past (complete) days are cached so repeated fetches over the same day share one LIST request, while the current UTC day is always re-listed (the GOES pattern). Gzip decompression and cache writes now run in a worker thread. Cache file names hash the same bucket-prefixed `s3://` URIs as before, so warm caches remain valid.
- **MRMS decode fix** — fetch time was dominated by `latlons()`, which decodes full 2-D coordinate arrays (~8 s per 3500×7000 file) even though the source only keeps the 1-D axes of the regular CONUS grid. The axes are now computed from grid-definition header keys (~0.1 ms, identical to within 2×10⁻⁶ degrees on the 0.01° grid), with `latlons()` kept as a fallback for non-regular grids. The decode also moves into a worker thread so concurrent (time, product) tasks no longer serialize on the event loop.
- **NClimGridDaily** — the synchronous s3fs streaming reads (per-slice HDF5 seeks over the network) are replaced by downloading each monthly NetCDF (~58 MB) once into the cache via `obstore_fetch_to_cache`, shared by every (day, variable) slice of that month. Months whose per-slice caches are already warm skip the download entirely.

### Performance

Full lexicon, `cache=False`, 3 reps, same host and time window:

| Data source | File type | Before (main) | After (PR) | Speedup |
|---|---|---|---|---|
| MRMS (2 vars, 2 same-day times) | GRIB2 gz (one per product/time, S3) | 31.4–36.8 s | 4.6–5.4 s | ~6.4× |
| NClimGridDaily (4 vars, 3 days) | NetCDF (monthly, ~58 MB, S3) | 6.4–16.4 s | 4.6–5.8 s | ~1.2× median, no seek-storm outliers |

Nearly all of the MRMS win comes from the header-key axis computation and threaded decode; the obstore transport itself was a wash there (gunzip is 0.01 s, download 0.6 s — `latlons()` was ~8 s of every ~9 s task). Output verified: identical shapes, no NaN change, axes match `latlons()` to float rounding.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes (`test_mrms.py`, `test_nclimgrid.py`; mocked NClimGrid test updated to the new download seam).
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An issue is linked to this pull request (physicsnemo-roadmap task issues above).
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

No new dependencies; obstore and obspec are already core dependencies.
