### PR TITLE
Fix GHCNDaily cold-cache crash from sync s3fs call inside the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the reflectivity sentinel `-99.0 dBZ`.
 - Fixed `GHCNHourly` station discovery to use the published GHCNh station
   list (`ghcnh-station-list.csv`) instead of the GHCN-Daily station list.
+- Fixed `GHCNDaily` crashing with `NotImplementedError: Calling sync() from
+  within a running loop` on every fetch with a cold cache (station list not
+  yet downloaded); the sync station-list download now runs in a worker thread.
 - Fixed `AIFS2` and `AIFS2ENS` assigning time-dependent forcing values to the wrong
   samples when processing multiple batches and initialization times.
 - Fixed `AsyncZarrBackend` discarding exceptions raised by non-blocking writes. A write

--- a/earth2studio/data/ghcn.py
+++ b/earth2studio/data/ghcn.py
@@ -507,7 +507,11 @@ class GHCNDaily(_GHCNBase):
 
         async with managed_session(self.fs) as session:  # noqa: F841
             if self._station_meta is None:
-                self._station_meta = self.get_station_metadata()
+                # get_station_metadata downloads the station list with a sync
+                # s3fs call; s3fs's instance cache can hand back the running
+                # loop's filesystem, and fsspec then refuses sync() from inside
+                # a running loop. A worker thread gives it a loop-free thread.
+                self._station_meta = await asyncio.to_thread(self.get_station_metadata)
 
             # Build unique (year, product) pairs needed. Tolerance windows can
             # span year boundaries, so enumerate every year in [tmin, tmax].


### PR DESCRIPTION
## Description

Every `GHCNDaily` fetch with a cold cache (station list not yet downloaded) crashes with:

```
NotImplementedError: Calling sync() from within a running loop
```

`get_station_metadata` downloads `ghcnd-stations.txt` with a sync `s3fs` call, but it is invoked from inside the async `fetch`. s3fs's instance cache can hand back the running loop's filesystem, and fsspec then refuses `sync()` from inside a running loop. Once the station list is cached on disk the code path is skipped, which is why warm-cache runs (and CI with cached fixtures) don't see it.

Fix: run the download in a worker thread via `asyncio.to_thread`, giving fsspec's `sync()` the loop-free thread it expects. `GHCNHourly` is unaffected — its `fetch` never calls `get_station_metadata`.

Reproduced on `main` and verified fixed with a cold-cache `GHCNDaily` fetch (`NotImplementedError` before, 3 rows returned after). #1063 also resolves this as part of the obstore migration; this is the minimal standalone fix so users on `main` aren't blocked until that lands.

## Checklist

- [x] Bug reproduced on main and verified fixed
- [x] CHANGELOG.md updated
- [x] black / ruff clean, `test/data/test_ghcn_daily.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)