### PR TITLE
fix: verbose flag is inverted when passed to progress helper

### DIFF
--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -415,7 +415,7 @@ class OPERA:
                 max_workers=self._async_workers,
                 task_timeout=120.0,
                 desc="Fetching OPERA data",
-                verbose=(not self._verbose),
+                verbose=self._verbose,
             )
 
         # Validate that all variables have the same grid shape.


### PR DESCRIPTION
⚠️ **On hold pending human review** — Greptile feedback (see comments) points out that `gather_with_concurrency` passes its `verbose` argument to `tqdm.gather(..., disable=verbose)`. The original `verbose=(not self._verbose)` was therefore intentional: it preserves OPERA's documented behavior where `verbose=True` shows progress and `verbose=False` hides it. The change proposed below would invert that behavior, so the correct resolution is a full revert. Because a full revert leaves this branch identical to `main`, I am not force-pushing an empty commit; please close this PR or let me know if it should be converted into a regression-test/comment PR.

---

This PR addresses the following issue in `earth2studio/data/opera.py`: verbose flag is inverted when passed to progress helper.

## Changes
- `earth2studio/data/opera.py`: verbose flag is inverted when passed to progress helper.

## Details
```diff
--- a/earth2studio/data/opera.py
+++ b/earth2studio/data/opera.py
@@ -1,7 +1,7 @@
-            await gather_with_concurrency(
-                coros,
-                max_workers=self._async_workers,
-                task_timeout=120.0,
-                desc="Fetching OPERA data",
-                verbose=(not self._verbose),
-            )
+            await gather_with_concurrency(
+                coros,
+                max_workers=self._async_workers,
+                task_timeout=120.0,
+                desc="Fetching OPERA data",
+                verbose=self._verbose,
+            )
```

## Tests
- `tests/data/test_opera.py`

```diff
--- a/tests/data/test_opera.py
+++ b/tests/data/test_opera.py
@@ -0,0 +0,0 @@
 import pytest
 from datetime import datetime
 from unittest.mock import patch, MagicMock
 import numpy as np
 
 from earth2studio.data.opera import OPERA
 
 
 @pytest.mark.parametrize("verbose", [True, False])
 @pytest.mark.asyncio
 async def test_opera_verbose_not_inverted(verbose):
     """OPERA(verbose=...) must be forwarded to gather_with_concurrency unchanged."""
     opera = OPERA(verbose=verbose)
     dummy_array = np.zeros((2200, 1900), dtype=np.float32)
 
     with patch.object(opera, "fs", MagicMock()), \
          patch.object(opera, "fetch_array", return_value=dummy_array), \
          patch("earth2studio.data.opera.gather_with_concurrency") as mock_gather:
         await opera.fetch([datetime(2024, 7, 1, 0, 0)], ["t2m"])
 
         assert mock_gather.call_count == 1
         _, kwargs = mock_gather.call_args
         assert kwargs.get("verbose") is verbose
```
