### PR TITLE
Aurora bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Aurora.create_iterator` first yield pairing a lead-sliced tensor with
+  unsliced coords: `lead_time` kept `[-6h, 0h]` while the tensor held one
+  step. Coords are now sliced the same way as FuXi, DLWP and FengWu, so the
+  initial condition is yielded at `lead_time=[0h]`
+
 - Fixed `CFS_Reforecast_FX` and `CFS_Reforecast_FX_Flux` pointing at the retired
   NCEI archive path; the reforecast archive moved to
   `https://www.ncei.noaa.gov/oa/prod-cfs-reforecast` with renamed product subdirs

--- a/earth2studio/models/px/aurora.py
+++ b/earth2studio/models/px/aurora.py
@@ -405,7 +405,11 @@ class Aurora(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
         self.output_coords(coords)
 
-        yield x[:, :, 1:], coords
+        # First yield is the initial condition: drop the t-6h history frame
+        # from the tensor AND the coords, so lead_time matches the data.
+        coords_out = coords.copy()
+        coords_out["lead_time"] = coords["lead_time"][1:]
+        yield x[:, :, 1:], coords_out
 
         while True:
             # Front hook

--- a/test/models/px/test_aurora.py
+++ b/test/models/px/test_aurora.py
@@ -134,7 +134,14 @@ def test_aurora_iter(ensemble, device):
         time = [time]
 
     # Get generator
-    next(p_iter)  # Skip first which should return the input
+    # First yield is the initial condition at lead time 0: the t-6h history
+    # frame is dropped from tensor AND coords, which must agree (regression
+    # test for coords previously keeping lead_time=[-6h, 0h] while the
+    # tensor was sliced to one step).
+    out, out_coords = next(p_iter)
+    assert out.shape[2] == 1
+    assert out_coords["lead_time"].shape == (1,)
+    assert out_coords["lead_time"][0] == np.timedelta64(0, "h")
     for i, (out, out_coords) in enumerate(p_iter):
         assert len(out.shape) == 6
         assert out.shape == torch.Size([ensemble, len(time), 1, 69, 720, 1440])


### PR DESCRIPTION
## Description
Fixed `Aurora.create_iterator` first yield pairing a lead-sliced tensor with unsliced coords: `lead_time` kept `[-6h, 0h]` while the tensor held one step. Coords are now sliced the same way as FuXi, DLWP and FengWu, so the initial condition is yielded at `lead_time=[0h]`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

