### PR TITLE
More CI fixes for examples

### DIFF
--- a/.github/actions/build-docs-section/action.yml
+++ b/.github/actions/build-docs-section/action.yml
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build docs example section
+description: Execute one example section and update its caches.
+
+inputs:
+  section:
+    description: Top-level example section to execute.
+    required: true
+  gallery-cache-name:
+    description: Stable gallery cache scope shared by all sections.
+    default: main
+  data-cache-name:
+    description: Stable section data cache scope.
+    default: main
+  model-cache-name:
+    description: Stable section model cache scope.
+    default: main
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git safe directory
+      shell: bash
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Prepare section cache directories
+      shell: bash
+      env:
+        SECTION: ${{ inputs.section }}
+      run: mkdir -p "docs-data/${SECTION}" "docs-models/${SECTION}"
+
+    # Lookup and restore are separate so a normal miss is allowed while a failed download fails the job.
+    - name: Find section data cache
+      id: docs-data-cache-lookup
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: docs-data/${{ inputs.section }}
+        key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ inputs.section }}-
+          e2s-docs-data-${{ runner.os }}-main-${{ inputs.section }}-
+        lookup-only: true
+
+    - name: Restore section data cache
+      if: steps.docs-data-cache-lookup.outputs.cache-matched-key != ''
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: docs-data/${{ inputs.section }}
+        key: ${{ steps.docs-data-cache-lookup.outputs.cache-matched-key }}
+        fail-on-cache-miss: true
+
+    - name: Find section model cache
+      id: docs-model-cache-lookup
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: docs-models/${{ inputs.section }}
+        key: e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-
+          e2s-docs-model-${{ runner.os }}-main-${{ inputs.section }}-
+        lookup-only: true
+
+    - name: Restore section model cache
+      if: steps.docs-model-cache-lookup.outputs.cache-matched-key != ''
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: docs-models/${{ inputs.section }}
+        key: ${{ steps.docs-model-cache-lookup.outputs.cache-matched-key }}
+        fail-on-cache-miss: true
+
+    - name: Find rolling gallery cache
+      id: gallery-cache-lookup
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: .e2sgallery
+        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.section }}
+        restore-keys: |
+          e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-
+          e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-
+          e2s-gallery-${{ runner.os }}-main-
+        lookup-only: true
+
+    - name: Restore rolling gallery cache
+      if: steps.gallery-cache-lookup.outputs.cache-matched-key != ''
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: .e2sgallery
+        key: ${{ steps.gallery-cache-lookup.outputs.cache-matched-key }}
+        fail-on-cache-miss: true
+
+    - name: Measure restored section caches
+      id: restored-cache-size
+      shell: bash
+      env:
+        SECTION: ${{ inputs.section }}
+      run: |
+        data_bytes=$(du -sb "docs-data/${SECTION}" | cut -f1)
+        model_bytes=$(du -sb "docs-models/${SECTION}" | cut -f1)
+        echo "data-bytes=${data_bytes}" >> "${GITHUB_OUTPUT}"
+        echo "model-bytes=${model_bytes}" >> "${GITHUB_OUTPUT}"
+
+    - name: Prepare CI directories
+      shell: bash
+      env:
+        EARTH2STUDIO_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data/${{ inputs.section }}
+        EARTH2STUDIO_MODEL_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+      run: python3 test/_ci/prepare_ci_paths.py
+
+    - name: Show GPU information
+      shell: bash
+      run: nvidia-smi
+
+    - name: Check uv lockfile
+      shell: bash
+      run: uv lock --check
+
+    - name: Execute example section
+      shell: bash
+      env:
+        EARTH2STUDIO_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data/${{ inputs.section }}
+        EARTH2STUDIO_MODEL_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        SECTION: ${{ inputs.section }}
+        UV_LINK_MODE: symlink
+      run: test/_ci/build_docs_examples.sh "${SECTION}"
+
+    - name: Inspect updated caches
+      id: updated-cache-state
+      shell: bash
+      env:
+        DATA_BYTES_BEFORE: ${{ steps.restored-cache-size.outputs.data-bytes }}
+        MODEL_BYTES_BEFORE: ${{ steps.restored-cache-size.outputs.model-bytes }}
+        SECTION: ${{ inputs.section }}
+      run: |
+        if ! find .e2sgallery -type f -print -quit 2>/dev/null | grep -q .; then
+          echo "Example execution did not produce a gallery cache." >&2
+          exit 1
+        fi
+
+        data_bytes_after=$(du -sb "docs-data/${SECTION}" | cut -f1)
+        model_bytes_after=$(du -sb "docs-models/${SECTION}" | cut -f1)
+
+        if find "docs-data/${SECTION}" -type f -print -quit | grep -q . && \
+          [ "${data_bytes_after}" != "${DATA_BYTES_BEFORE}" ]; then
+          echo "data-changed=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "data-changed=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+        if find "docs-models/${SECTION}" -type f -print -quit | grep -q . && \
+          [ "${model_bytes_after}" != "${MODEL_BYTES_BEFORE}" ]; then
+          echo "model-changed=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "model-changed=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Save rolling gallery cache
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: .e2sgallery
+        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.section }}
+
+    - name: Save section data cache
+      if: steps.updated-cache-state.outputs.data-changed == 'true'
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      continue-on-error: true
+      with:
+        path: docs-data/${{ inputs.section }}
+        key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    - name: Save section model cache
+      if: steps.updated-cache-state.outputs.model-changed == 'true'
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      continue-on-error: true
+      with:
+        path: docs-models/${{ inputs.section }}
+        key: e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/actions/build-docs-section/action.yml
+++ b/.github/actions/build-docs-section/action.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 name: Build docs example section
-description: Execute one example section and update its caches.
+description: Execute one example section and update its data and gallery caches.
 
 inputs:
   section:
@@ -27,9 +27,6 @@ inputs:
   data-cache-name:
     description: Stable section data cache scope.
     default: main
-  model-cache-name:
-    description: Stable section model cache scope.
-    default: main
 
 runs:
   using: composite
@@ -38,11 +35,11 @@ runs:
       shell: bash
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-    - name: Prepare section cache directories
+    - name: Prepare section directories
       shell: bash
       env:
         SECTION: ${{ inputs.section }}
-      run: mkdir -p "docs-data/${SECTION}" "docs-models/${SECTION}"
+      run: mkdir -p "docs-data/${SECTION}" "${RUNNER_TEMP}/earth2studio-models"
 
     # Lookup and restore are separate so a normal miss is allowed while a failed download fails the job.
     - name: Find section data cache
@@ -62,25 +59,6 @@ runs:
       with:
         path: docs-data/${{ inputs.section }}
         key: ${{ steps.docs-data-cache-lookup.outputs.cache-matched-key }}
-        fail-on-cache-miss: true
-
-    - name: Find section model cache
-      id: docs-model-cache-lookup
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      with:
-        path: docs-models/${{ inputs.section }}
-        key: e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-
-          e2s-docs-model-${{ runner.os }}-main-${{ inputs.section }}-
-        lookup-only: true
-
-    - name: Restore section model cache
-      if: steps.docs-model-cache-lookup.outputs.cache-matched-key != ''
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      with:
-        path: docs-models/${{ inputs.section }}
-        key: ${{ steps.docs-model-cache-lookup.outputs.cache-matched-key }}
         fail-on-cache-miss: true
 
     - name: Find rolling gallery cache
@@ -110,16 +88,14 @@ runs:
         SECTION: ${{ inputs.section }}
       run: |
         data_bytes=$(du -sb "docs-data/${SECTION}" | cut -f1)
-        model_bytes=$(du -sb "docs-models/${SECTION}" | cut -f1)
         echo "data-bytes=${data_bytes}" >> "${GITHUB_OUTPUT}"
-        echo "model-bytes=${model_bytes}" >> "${GITHUB_OUTPUT}"
 
     - name: Prepare CI directories
       shell: bash
       env:
-        EARTH2STUDIO_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_CACHE: ${{ runner.temp }}/earth2studio-models
         EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data/${{ inputs.section }}
-        EARTH2STUDIO_MODEL_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_MODEL_CACHE: ${{ runner.temp }}/earth2studio-models
       run: python3 test/_ci/prepare_ci_paths.py
 
     - name: Show GPU information
@@ -133,9 +109,9 @@ runs:
     - name: Execute example section
       shell: bash
       env:
-        EARTH2STUDIO_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_CACHE: ${{ runner.temp }}/earth2studio-models
         EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data/${{ inputs.section }}
-        EARTH2STUDIO_MODEL_CACHE: ${{ github.workspace }}/docs-models/${{ inputs.section }}
+        EARTH2STUDIO_MODEL_CACHE: ${{ runner.temp }}/earth2studio-models
         SECTION: ${{ inputs.section }}
         UV_LINK_MODE: symlink
       run: test/_ci/build_docs_examples.sh "${SECTION}"
@@ -145,7 +121,6 @@ runs:
       shell: bash
       env:
         DATA_BYTES_BEFORE: ${{ steps.restored-cache-size.outputs.data-bytes }}
-        MODEL_BYTES_BEFORE: ${{ steps.restored-cache-size.outputs.model-bytes }}
         SECTION: ${{ inputs.section }}
       run: |
         if ! find .e2sgallery -type f -print -quit 2>/dev/null | grep -q .; then
@@ -154,20 +129,12 @@ runs:
         fi
 
         data_bytes_after=$(du -sb "docs-data/${SECTION}" | cut -f1)
-        model_bytes_after=$(du -sb "docs-models/${SECTION}" | cut -f1)
 
         if find "docs-data/${SECTION}" -type f -print -quit | grep -q . && \
           [ "${data_bytes_after}" != "${DATA_BYTES_BEFORE}" ]; then
           echo "data-changed=true" >> "${GITHUB_OUTPUT}"
         else
           echo "data-changed=false" >> "${GITHUB_OUTPUT}"
-        fi
-
-        if find "docs-models/${SECTION}" -type f -print -quit | grep -q . && \
-          [ "${model_bytes_after}" != "${MODEL_BYTES_BEFORE}" ]; then
-          echo "model-changed=true" >> "${GITHUB_OUTPUT}"
-        else
-          echo "model-changed=false" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Save rolling gallery cache
@@ -183,11 +150,3 @@ runs:
       with:
         path: docs-data/${{ inputs.section }}
         key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-    - name: Save section model cache
-      if: steps.updated-cache-state.outputs.model-changed == 'true'
-      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
-      continue-on-error: true
-      with:
-        path: docs-models/${{ inputs.section }}
-        key: e2s-docs-model-${{ runner.os }}-${{ inputs.model-cache-name }}-${{ inputs.section }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/actions/build-light-docs/action.yml
+++ b/.github/actions/build-light-docs/action.yml
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build light docs
-description: Build API docs and stale/new examples using the gallery cache.
+name: Build docs
+description: Build docs from the gallery cache with optional example execution.
 
 inputs:
   artifact-name:
@@ -30,8 +30,11 @@ inputs:
   data-cache-name:
     description: Stable docs data cache scope to restore and optionally update.
     default: main
+  execute-examples:
+    description: Whether to execute stale or new examples during the build.
+    default: "false"
   save-caches:
-    description: Whether to save updated docs caches.
+    description: Whether to save updated gallery and full-build data caches.
     default: "false"
   upload-artifact:
     description: Whether to upload the built HTML artifact.
@@ -48,9 +51,11 @@ runs:
       shell: bash
       run: mkdir -p "${RUNNER_TEMP}/earth2studio-models"
 
-    - name: Restore docs data cache
+    # Look up first so an absent cache is allowed while a failed download remains fatal.
+    - name: Find docs data cache
+      if: inputs.execute-examples == 'true'
+      id: docs-data-cache-lookup
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      continue-on-error: true
       with:
         path: docs-data
         key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -58,6 +63,15 @@ runs:
           e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-
           e2s-docs-data-${{ runner.os }}-main-
           e2s-docs-data-${{ runner.os }}-
+        lookup-only: true
+
+    - name: Restore docs data cache
+      if: inputs.execute-examples == 'true' && steps.docs-data-cache-lookup.outputs.cache-matched-key != ''
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: docs-data
+        key: ${{ steps.docs-data-cache-lookup.outputs.cache-matched-key }}
+        fail-on-cache-miss: true
 
     - name: Restore gallery cache
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -86,6 +100,16 @@ runs:
       run: uv lock --check
 
     - name: Build light Zensical site
+      if: inputs.execute-examples != 'true'
+      shell: bash
+      env:
+        EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data
+        EARTH2STUDIO_MODEL_CACHE: ${{ runner.temp }}/earth2studio-models
+        UV_LINK_MODE: symlink
+      run: make docs
+
+    - name: Build full Zensical site
+      if: inputs.execute-examples == 'true'
       shell: bash
       env:
         EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data
@@ -112,10 +136,23 @@ runs:
         path: .e2sgallery
         key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
 
+    - name: Check docs data cache
+      if: inputs.execute-examples == 'true' && inputs.save-caches == 'true'
+      id: docs-data-cache-check
+      shell: bash
+      run: |
+        if find docs-data -type f -print -quit | grep -q .; then
+          echo "populated=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "populated=false" >> "${GITHUB_OUTPUT}"
+        fi
+
     - name: Save docs data cache
       if: >
         success() &&
-        inputs.save-caches == 'true'
+        inputs.execute-examples == 'true' &&
+        inputs.save-caches == 'true' &&
+        steps.docs-data-cache-check.outputs.populated == 'true'
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
       continue-on-error: true
       with:

--- a/.github/actions/build-light-docs/action.yml
+++ b/.github/actions/build-light-docs/action.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 name: Build docs
-description: Build docs from the gallery cache with optional example execution.
+description: Build docs without executing examples, using retained gallery results.
 
 inputs:
   artifact-name:
@@ -27,14 +27,8 @@ inputs:
   gallery-cache-name:
     description: Stable gallery cache scope to restore and optionally update.
     default: main
-  data-cache-name:
-    description: Stable docs data cache scope to restore and optionally update.
-    default: main
-  execute-examples:
-    description: Whether to execute stale or new examples during the build.
-    default: "false"
   save-caches:
-    description: Whether to save updated gallery and full-build data caches.
+    description: Whether to save the rendered gallery cache.
     default: "false"
   upload-artifact:
     description: Whether to upload the built HTML artifact.
@@ -47,42 +41,30 @@ runs:
       shell: bash
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-    - name: Prepare runner temp model cache
+    - name: Prepare runtime cache directories
       shell: bash
-      run: mkdir -p "${RUNNER_TEMP}/earth2studio-models"
+      run: mkdir -p docs-data "${RUNNER_TEMP}/earth2studio-models"
 
-    # Look up first so an absent cache is allowed while a failed download remains fatal.
-    - name: Find docs data cache
-      if: inputs.execute-examples == 'true'
-      id: docs-data-cache-lookup
+    # Lookup and restore are separate so a normal miss is allowed while a failed download fails the job.
+    - name: Find gallery cache
+      id: gallery-cache-lookup
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      with:
-        path: docs-data
-        key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-
-          e2s-docs-data-${{ runner.os }}-main-
-          e2s-docs-data-${{ runner.os }}-
-        lookup-only: true
-
-    - name: Restore docs data cache
-      if: inputs.execute-examples == 'true' && steps.docs-data-cache-lookup.outputs.cache-matched-key != ''
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      with:
-        path: docs-data
-        key: ${{ steps.docs-data-cache-lookup.outputs.cache-matched-key }}
-        fail-on-cache-miss: true
-
-    - name: Restore gallery cache
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-      continue-on-error: true
       with:
         path: .e2sgallery
-        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-render
         restore-keys: |
+          e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-
           e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-
           e2s-gallery-${{ runner.os }}-main-
-          e2s-gallery-${{ runner.os }}-
+        lookup-only: true
+
+    - name: Restore gallery cache
+      if: steps.gallery-cache-lookup.outputs.cache-matched-key != ''
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: .e2sgallery
+        key: ${{ steps.gallery-cache-lookup.outputs.cache-matched-key }}
+        fail-on-cache-miss: true
 
     - name: Prepare CI directories
       shell: bash
@@ -99,23 +81,13 @@ runs:
       shell: bash
       run: uv lock --check
 
-    - name: Build light Zensical site
-      if: inputs.execute-examples != 'true'
+    - name: Build Zensical site
       shell: bash
       env:
         EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data
         EARTH2STUDIO_MODEL_CACHE: ${{ runner.temp }}/earth2studio-models
         UV_LINK_MODE: symlink
       run: make docs
-
-    - name: Build full Zensical site
-      if: inputs.execute-examples == 'true'
-      shell: bash
-      env:
-        EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data
-        EARTH2STUDIO_MODEL_CACHE: ${{ runner.temp }}/earth2studio-models
-        UV_LINK_MODE: symlink
-      run: make docs-full
 
     - name: Upload docs artifact
       if: inputs.upload-artifact == 'true'
@@ -126,35 +98,24 @@ runs:
         if-no-files-found: error
         retention-days: ${{ inputs.artifact-retention-days }}
 
-    - name: Save gallery cache
-      if: >
-        success() &&
-        inputs.save-caches == 'true'
-      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
-      continue-on-error: true
-      with:
-        path: .e2sgallery
-        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-    - name: Check docs data cache
-      if: inputs.execute-examples == 'true' && inputs.save-caches == 'true'
-      id: docs-data-cache-check
+    - name: Check gallery cache
+      if: inputs.save-caches == 'true'
+      id: gallery-cache-check
       shell: bash
       run: |
-        if find docs-data -type f -print -quit | grep -q .; then
+        if find .e2sgallery -type f -print -quit 2>/dev/null | grep -q .; then
           echo "populated=true" >> "${GITHUB_OUTPUT}"
         else
           echo "populated=false" >> "${GITHUB_OUTPUT}"
         fi
 
-    - name: Save docs data cache
+    - name: Save gallery cache
       if: >
         success() &&
-        inputs.execute-examples == 'true' &&
         inputs.save-caches == 'true' &&
-        steps.docs-data-cache-check.outputs.populated == 'true'
+        steps.gallery-cache-check.outputs.populated == 'true'
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
       continue-on-error: true
       with:
-        path: docs-data
-        key: e2s-docs-data-${{ runner.os }}-${{ inputs.data-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: .e2sgallery
+        key: e2s-gallery-${{ runner.os }}-${{ inputs.gallery-cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}-render

--- a/.github/workflows/e2s-ci-test-pr.yml
+++ b/.github/workflows/e2s-ci-test-pr.yml
@@ -194,7 +194,6 @@ jobs:
           artifact-name: docs-pr-html
           artifact-retention-days: "10"
           gallery-cache-name: main
-          data-cache-name: main
           save-caches: "false"
 
   test:

--- a/.github/workflows/e2s-ci-test-pr.yml
+++ b/.github/workflows/e2s-ci-test-pr.yml
@@ -191,10 +191,9 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/build-light-docs
         with:
-          artifact-name: docs-pr-html
-          artifact-retention-days: "10"
           gallery-cache-name: main
           save-caches: "false"
+          upload-artifact: "false"
 
   test:
     name: Test

--- a/.github/workflows/e2s-docs-full.yml
+++ b/.github/workflows/e2s-docs-full.yml
@@ -18,22 +18,6 @@ name: e2s-docs-full
 
 on:
   workflow_dispatch:
-    inputs:
-      section:
-        description: Example section to execute
-        required: true
-        default: all
-        type: choice
-        options:
-          - all
-          - 01_getting_started
-          - 02_medium_range
-          - 03_downscaling
-          - 04_nowcasting
-          - 05_data_assimilation
-          - 06_seasonal
-          - 07_misc
-          - 08_extend
 
 permissions:
   contents: read
@@ -63,13 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       doc-version: ${{ steps.docs-meta.outputs.doc-version }}
-      sections: ${{ steps.docs-meta.outputs.sections }}
     steps:
-      - name: Resolve docs version and sections
+      - name: Resolve docs version
         id: docs-meta
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          SELECTED_SECTION: ${{ inputs.section }}
         run: |
           set -euo pipefail
 
@@ -85,37 +67,88 @@ jobs:
             exit 1
           fi
 
-          case "$SELECTED_SECTION" in
-            all)
-              sections='["01_getting_started","02_medium_range","03_downscaling","04_nowcasting","05_data_assimilation","06_seasonal","07_misc","08_extend"]'
-              ;;
-            01_getting_started|02_medium_range|03_downscaling|04_nowcasting|05_data_assimilation|06_seasonal|07_misc|08_extend)
-              sections="[\"${SELECTED_SECTION}\"]"
-              ;;
-            *)
-              echo "Unknown example section: ${SELECTED_SECTION}" >&2
-              exit 1
-              ;;
-          esac
-
           echo "doc-version=${doc_version}" >> "$GITHUB_OUTPUT"
-          echo "sections=${sections}" >> "$GITHUB_OUTPUT"
 
           echo "### Full docs build" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch: \`${GITHUB_REF_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- DOC_VERSION: \`${doc_version}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Sections: \`${SELECTED_SECTION}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-api-docs:
+    name: Publish API docs from gallery cache
+    needs: metadata
+    permissions:
+      contents: write
+      packages: read
+    runs-on: linux-amd64-gpu-h100-latest-1
+    timeout-minutes: 180
+    container:
+      image: *e2s_ci_image
+      options: --shm-size=20g --cap-add=SYS_NICE
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      DOC_VERSION: ${{ needs.metadata.outputs.doc-version }}
+      FLASH_ATTN_CUDA_ARCHS: "90"
+      MAX_JOBS: "8"
+      NATTEN_CUDA_ARCH: "9.0"
+      NATTEN_N_WORKERS: "8"
+      NVCC_THREADS: "2"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Build API docs from retained gallery results
+        uses: ./.github/actions/build-light-docs
+        with:
+          artifact-name: docs-api-html
+          artifact-retention-days: "10"
+          gallery-cache-name: ${{ github.ref_name }}
+          save-caches: "false"
+          upload-artifact: "true"
+
+      - name: Deploy API docs
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "${DOCS_PAGES_BRANCH}" --depth=1
+          uv run mike deploy "${DOC_VERSION}" \
+            --title "${DOC_VERSION}" \
+            --branch "${DOCS_PAGES_BRANCH}" \
+            --message "Deploy cached docs ${DOC_VERSION} for ${GITHUB_SHA}" \
+            --push
+          if [[ "${DOC_VERSION}" == "main" ]]; then
+            uv run mike set-default main \
+              --branch "${DOCS_PAGES_BRANCH}" \
+              --message "Set default docs version to main" \
+              --push
+          fi
 
   execute-sections:
     name: Execute ${{ matrix.section }}
-    needs: metadata
+    needs:
+      - metadata
+      - publish-api-docs
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 180
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        section: ${{ fromJSON(needs.metadata.outputs.sections) }}
+        section:
+          - 01_getting_started
+          - 02_medium_range
+          - 03_downscaling
+          - 04_nowcasting
+          - 05_data_assimilation
+          - 06_seasonal
+          - 07_misc
+          - 08_extend
     container:
       image: *e2s_ci_image
       options: --shm-size=20g --cap-add=SYS_NICE

--- a/.github/workflows/e2s-docs-full.yml
+++ b/.github/workflows/e2s-docs-full.yml
@@ -111,6 +111,7 @@ jobs:
           artifact-retention-days: "10"
           gallery-cache-name: ${{ github.ref_name }}
           data-cache-name: ${{ github.ref_name }}
+          execute-examples: "true"
           save-caches: "true"
           upload-artifact: "false"
         env:

--- a/.github/workflows/e2s-docs-full.yml
+++ b/.github/workflows/e2s-docs-full.yml
@@ -18,6 +18,22 @@ name: e2s-docs-full
 
 on:
   workflow_dispatch:
+    inputs:
+      section:
+        description: Example section to execute
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - 01_getting_started
+          - 02_medium_range
+          - 03_downscaling
+          - 04_nowcasting
+          - 05_data_assimilation
+          - 06_seasonal
+          - 07_misc
+          - 08_extend
 
 permissions:
   contents: read
@@ -37,25 +53,72 @@ env:
   DOC_PUBLIC_BUILD: "false"
   DOCS_PAGES_BRANCH: gh-pages
   EARTH2STUDIO_CACHE: ${{ github.workspace }}/.cache/earth2studio
-  EARTH2STUDIO_DATA_CACHE: ${{ github.workspace }}/docs-data
   TORCH_ALLOW_TF32_CUBLAS_OVERRIDE: "1"
   UV_PYTHON: "3.13.13"
 
 jobs:
-  build-docs:
-    name: Build and publish full docs
+  metadata:
+    name: Resolve docs build
     if: github.repository == 'NVIDIA/earth2studio' && github.ref_type == 'branch' && (github.ref_name == github.event.repository.default_branch || endsWith(github.ref_name, '-rc'))
-    permissions:
-      contents: write
-      packages: read
+    runs-on: ubuntu-latest
     outputs:
       doc-version: ${{ steps.docs-meta.outputs.doc-version }}
-      is-rc: ${{ steps.docs-meta.outputs.is-rc }}
+      sections: ${{ steps.docs-meta.outputs.sections }}
+    steps:
+      - name: Resolve docs version and sections
+        id: docs-meta
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SELECTED_SECTION: ${{ inputs.section }}
+        run: |
+          set -euo pipefail
+
+          ref_name="${GITHUB_REF_NAME##*/}"
+          doc_version="main"
+
+          if [[ "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            :
+          elif [[ "$ref_name" =~ ^([0-9]+[.][0-9]+[.][0-9]+[0-9A-Za-z._]*)-rc$ ]]; then
+            doc_version="${BASH_REMATCH[1]}"
+          else
+            echo "Ref '${GITHUB_REF_NAME}' is not a trusted docs publication ref." >&2
+            exit 1
+          fi
+
+          case "$SELECTED_SECTION" in
+            all)
+              sections='["01_getting_started","02_medium_range","03_downscaling","04_nowcasting","05_data_assimilation","06_seasonal","07_misc","08_extend"]'
+              ;;
+            01_getting_started|02_medium_range|03_downscaling|04_nowcasting|05_data_assimilation|06_seasonal|07_misc|08_extend)
+              sections="[\"${SELECTED_SECTION}\"]"
+              ;;
+            *)
+              echo "Unknown example section: ${SELECTED_SECTION}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "doc-version=${doc_version}" >> "$GITHUB_OUTPUT"
+          echo "sections=${sections}" >> "$GITHUB_OUTPUT"
+
+          echo "### Full docs build" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`${GITHUB_REF_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- DOC_VERSION: \`${doc_version}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Sections: \`${SELECTED_SECTION}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  execute-sections:
+    name: Execute ${{ matrix.section }}
+    needs: metadata
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        section: ${{ fromJSON(needs.metadata.outputs.sections) }}
     container:
       image: *e2s_ci_image
-      options: --shm-size=20g
+      options: --shm-size=20g --cap-add=SYS_NICE
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -66,54 +129,19 @@ jobs:
       NATTEN_N_WORKERS: "8"
       NVCC_THREADS: "2"
     steps:
-      - name: Resolve docs version
-        id: docs-meta
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-
-          ref_name="${GITHUB_REF_NAME##*/}"
-          doc_version="main"
-          is_rc="false"
-
-          if [[ "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
-            :
-          elif [[ "$ref_name" =~ ^([0-9]+[.][0-9]+[.][0-9]+[0-9A-Za-z._]*)-rc$ ]]; then
-            doc_version="${BASH_REMATCH[1]}"
-            is_rc="true"
-          else
-            echo "Ref '${GITHUB_REF_NAME}' is not a trusted docs publication ref." >&2
-            exit 1
-          fi
-
-          echo "DOC_VERSION=${doc_version}" >> "$GITHUB_ENV"
-          echo "doc-version=${doc_version}" >> "$GITHUB_OUTPUT"
-          echo "is-rc=${is_rc}" >> "$GITHUB_OUTPUT"
-
-          echo "### Full docs build" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Branch: \`${GITHUB_REF_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- DOC_VERSION: \`${doc_version}\`" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
-      - name: Configure git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Build full Zensical site
-        uses: ./.github/actions/build-light-docs
+      - name: Execute example section
+        uses: ./.github/actions/build-docs-section
         with:
-          artifact-name: docs-full-html
-          artifact-retention-days: "10"
+          section: ${{ matrix.section }}
           gallery-cache-name: ${{ github.ref_name }}
           data-cache-name: ${{ github.ref_name }}
-          execute-examples: "true"
-          save-caches: "true"
-          upload-artifact: "false"
+          model-cache-name: ${{ github.ref_name }}
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_KEY }}
           EARTHMOVER_API_KEY: ${{ secrets.EARTHMOVER_API_KEY }}
@@ -121,6 +149,43 @@ jobs:
           EUMETSAT_CONSUMER_KEY: ${{ secrets.EUMETSAT_CONSUMER_KEY }}
           EUMETSAT_CONSUMER_SECRET: ${{ secrets.EUMETSAT_CONSUMER_SECRET }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  render-docs:
+    name: Render and publish full docs
+    needs:
+      - metadata
+      - execute-sections
+    permissions:
+      contents: write
+      packages: read
+    runs-on: linux-amd64-gpu-h100-latest-1
+    timeout-minutes: 180
+    container:
+      image: *e2s_ci_image
+      options: --shm-size=20g --cap-add=SYS_NICE
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      DOC_VERSION: ${{ needs.metadata.outputs.doc-version }}
+      FLASH_ATTN_CUDA_ARCHS: "90"
+      MAX_JOBS: "8"
+      NATTEN_CUDA_ARCH: "9.0"
+      NATTEN_N_WORKERS: "8"
+      NVCC_THREADS: "2"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Build Zensical site from gallery cache
+        uses: ./.github/actions/build-light-docs
+        with:
+          gallery-cache-name: ${{ github.ref_name }}
+          save-caches: "false"
+          upload-artifact: "false"
 
       - name: Deploy full docs
         run: |

--- a/.github/workflows/e2s-docs-full.yml
+++ b/.github/workflows/e2s-docs-full.yml
@@ -141,7 +141,6 @@ jobs:
           section: ${{ matrix.section }}
           gallery-cache-name: ${{ github.ref_name }}
           data-cache-name: ${{ github.ref_name }}
-          model-cache-name: ${{ github.ref_name }}
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_KEY }}
           EARTHMOVER_API_KEY: ${{ secrets.EARTHMOVER_API_KEY }}

--- a/.github/workflows/e2s-docs-light.yml
+++ b/.github/workflows/e2s-docs-light.yml
@@ -92,7 +92,6 @@ jobs:
           artifact-name: docs-light-html
           artifact-retention-days: "1"
           gallery-cache-name: main
-          data-cache-name: main
           save-caches: "true"
           upload-artifact: "false"
         env:

--- a/.github/workflows/util-clear-cache.yml
+++ b/.github/workflows/util-clear-cache.yml
@@ -30,7 +30,9 @@ on:
           - pre-commit
           - model
           - gallery
+          - docs-assets
           - docs-data
+          - docs-models
           - testmon
       dry_run:
         description: List matching caches without deleting them
@@ -57,7 +59,7 @@ jobs:
 
           case "$CACHE_GROUP" in
             all)
-              key_regex="^e2s-(uv|pre-commit|model|gallery|docs-data|testmon)-"
+              key_regex="^e2s-(uv|pre-commit|model|gallery|docs-(data|model)|testmon)-"
               ;;
             uv)
               key_regex="^e2s-uv-"
@@ -71,8 +73,14 @@ jobs:
             gallery)
               key_regex="^e2s-gallery-"
               ;;
+            docs-assets)
+              key_regex="^e2s-docs-(data|model)-"
+              ;;
             docs-data)
               key_regex="^e2s-docs-data-"
+              ;;
+            docs-models)
+              key_regex="^e2s-docs-model-"
               ;;
             testmon)
               key_regex="^e2s-testmon-"

--- a/.github/workflows/util-clear-cache.yml
+++ b/.github/workflows/util-clear-cache.yml
@@ -30,9 +30,7 @@ on:
           - pre-commit
           - model
           - gallery
-          - docs-assets
           - docs-data
-          - docs-models
           - testmon
       dry_run:
         description: List matching caches without deleting them
@@ -59,7 +57,7 @@ jobs:
 
           case "$CACHE_GROUP" in
             all)
-              key_regex="^e2s-(uv|pre-commit|model|gallery|docs-(data|model)|testmon)-"
+              key_regex="^e2s-(uv|pre-commit|model|gallery|docs-data|testmon)-"
               ;;
             uv)
               key_regex="^e2s-uv-"
@@ -73,14 +71,8 @@ jobs:
             gallery)
               key_regex="^e2s-gallery-"
               ;;
-            docs-assets)
-              key_regex="^e2s-docs-(data|model)-"
-              ;;
             docs-data)
               key_regex="^e2s-docs-data-"
-              ;;
-            docs-models)
-              key_regex="^e2s-docs-model-"
               ;;
             testmon)
               key_regex="^e2s-testmon-"

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -127,13 +127,14 @@ declared extras against the repository's `uv.lock`; the documentation environmen
 preinstall every project extra.
 
 In CI, pull-request and main-branch documentation builds run `make docs` and never execute
-examples. The manually dispatched `e2s-docs-full` workflow first builds, uploads, and deploys the
-API site from the latest available Gallery cache. A missing Gallery cache is allowed. This initial
-publish gates eight sequential section jobs, ensuring that an API update remains published even if
-a later example fails. Each section restores its own data cache, then publishes an updated shared
-Gallery cache for the next section. Model downloads remain local to the section runner and are not
-saved. After every section succeeds, a final job renders and deploys the complete site from the
-updated Gallery cache without rerunning examples.
+examples. Pull-request validation only checks that the site builds: it does not upload an HTML
+artifact, deploy the site, or update caches. The manually dispatched `e2s-docs-full` workflow first
+builds, uploads, and deploys the API site from the latest available Gallery cache. A missing Gallery
+cache is allowed. This initial publish gates eight sequential section jobs, ensuring that an API
+update remains published even if a later example fails. Each section restores its own data cache,
+then publishes an updated shared Gallery cache for the next section. Model downloads remain local
+to the section runner and are not saved. After every section succeeds, a final job renders and
+deploys the complete site from the updated Gallery cache without rerunning examples.
 
 The `util-clear-cache` workflow can clear Gallery and section data caches independently.
 

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -126,6 +126,16 @@ regenerates the gallery before the final site build. Project-mode examples synch
 declared extras against the repository's `uv.lock`; the documentation environment does not
 preinstall every project extra.
 
+In CI, pull-request and main-branch documentation builds run `make docs` and never execute
+examples. The manually dispatched `e2s-docs-full` workflow runs the selected example sections as
+sequential jobs. Each section restores its own data and model caches, then publishes an updated
+shared Gallery cache for the next section. A final job renders and deploys the complete site from
+that Gallery cache without rerunning examples. The workflow can execute all sections or one
+selected section; retained results for other sections remain available to the final render.
+
+The `util-clear-cache` workflow can clear Gallery, docs data, and docs model caches independently,
+or clear both section asset cache families with the `docs-assets` option.
+
 For local development with live reload, use:
 
 ```bash

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -128,13 +128,13 @@ preinstall every project extra.
 
 In CI, pull-request and main-branch documentation builds run `make docs` and never execute
 examples. The manually dispatched `e2s-docs-full` workflow runs the selected example sections as
-sequential jobs. Each section restores its own data and model caches, then publishes an updated
-shared Gallery cache for the next section. A final job renders and deploys the complete site from
-that Gallery cache without rerunning examples. The workflow can execute all sections or one
-selected section; retained results for other sections remain available to the final render.
+sequential jobs. Each section restores its own data cache, then publishes an updated shared
+Gallery cache for the next section. Model downloads remain local to the section runner and are not
+saved. A final job renders and deploys the complete site from that Gallery cache without rerunning
+examples. The workflow can execute all sections or one selected section; retained results for
+other sections remain available to the final render.
 
-The `util-clear-cache` workflow can clear Gallery, docs data, and docs model caches independently,
-or clear both section asset cache families with the `docs-assets` option.
+The `util-clear-cache` workflow can clear Gallery and section data caches independently.
 
 For local development with live reload, use:
 

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -1,174 +1,87 @@
 # Documentation
 
-Earth2Studio uses [MkDocs](https://www.mkdocs.org/) with the
-[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme to build
-static documentation hosted on GitHub Pages. The docs are organized around three
-main areas:
+Earth2Studio builds its documentation with
+[MkDocs](https://www.mkdocs.org/) and
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
 
-1. API documentation is required for public Earth2Studio classes and functions.
-   [Interrogate](https://github.com/econchick/interrogate) is used to enforce that
-   public methods are documented.
+## Source layout
 
-2. Examples are rendered with `earth2studio-gallery`, which executes percent-format
-   Python examples in the project documentation environment and then renders the
-   retained results into a MkDocs Material gallery.
+- `docs/modules/`: API landing pages consumed by `docs/generate_api.py`.
+- `docs/userguide/`: conceptual and developer guides.
+- `examples/`: executable gallery sources.
+- `docs/examples/`: generated gallery pages; do not edit these directly.
 
-3. API landing pages are Markdown files in `docs/modules/` with autosummary
-   blocks read by `docs/generate_api.py`. Model and data-source badges are rendered
-   and filtered with `mkdocs-badges`.
+The docs generators also create the model catalog, installation options, and scorecard pages.
+`earth2studio-gallery` renders examples and retained execution results without Sphinx.
 
-4. The user guide is written in Markdown and documents concepts that cannot be fully
-   communicated in examples.
+## Docstrings
 
-## API Documentation
+Public classes and functions require docstrings; Interrogate enforces coverage. Use
+[NumPy-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
+with these conventions:
 
-API documentation or doc-strings are a requirement for public Earth2Studio classes and
-functions. Consistent documentation styling improves user and developer experience. To
-make doc-strings between different parts of the code as consistent as possible, the
-following styles are used:
-
-- [NumPy style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
-  doc-strings are used in all Python files.
-
-- The doc string description starts on the same line as the first `"""`.
-
-- Class doc-strings are placed under the class definition not the `__init__` function.
-
-- Type hints are included in the doc strings for each input argument / returned object.
-
-- Optional/keyword arguments are denoted by `optional` following the type hint. The
-  default value is provided by adding ", by default [default value]" to the end of the
-  doc string.
-
-- Periods should be used at the end of complete sentences, but are not required at the
-  end of "by default [default value]" or incomplete sentences.
-
-For VSCode users, the
-[autoDocstring extension](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring)
-is highly encouraged. Refer to the following doc-string samples for guidance:
+- Start the summary on the opening `"""` line.
+- Document classes on the class definition, not `__init__`.
+- Include argument and return types.
+- Mark optional arguments and state their defaults.
+- End complete sentences with periods.
 
 ```python
 def timearray_to_datetime(time: TimeArray) -> list[datetime]:
-    """Simple converter from numpy datetime64 array into a list of datetimes.
+    """Convert a NumPy datetime64 array into Python datetimes.
 
     Parameters
     ----------
     time : TimeArray
-        Numpy datetime64 array
+        NumPy datetime64 array.
 
     Returns
     -------
     list[datetime]
-        List of datetime object
+        Converted datetime objects.
     """
 ```
 
-```python
-class CorrelatedSphericalGaussian:
-    """Produces Gaussian random field on the sphere with Matern covariance peturbation
-    method output to a lat lon grid.
+## Local builds
 
-    Warning
-    -------
-    Presently this method generates noise on equirectangular grid of size [N, 2*N] when
-    N is even or [N+1, 2*N] when N is odd.
+- `make docs`: generate all pages and build from retained example results.
+- `make docs-full`: execute stale examples, regenerate the gallery, and build.
+- `make docs-dev`: serve locally with live reload.
+- `make docs-dev FILENAME=<selector>`: execute one example, then serve the complete gallery.
 
-    Parameters
-    ----------
-    noise_amplitude : float | torch.Tensor
-        Overall amplitude scaling factor for the noise field. Must be provided.
-    sigma : float, optional
-        Standard deviation of the noise field, by default 1.0
-    length_scale : float, optional
-        Spatial correlation length scale in meters, by default 5.0e5
-    time_scale : float, optional
-        Temporal correlation scale in hours for the AR(1) process, by default 48.0
-
-    Raises
-    ------
-    ValueError
-        If noise_amplitude is not provided
-    """
-    ...
-```
-
-## Example Documentation
-
-Examples in Earth2Studio are created with the intent to teach or demonstrate a specific
-feature, workflow, concept, or use case to users. If you are interested in contributing
-an example, reach out to us in a GitHub issue to discuss further. The example scripts
-used to populate the documentation are placed in the
-[examples](https://github.com/NVIDIA/earth2studio/tree/main/examples) folder of the repo.
-
-The MkDocs documentation uses `earth2studio-gallery` instead of Sphinx Gallery. The
-source examples remain in the repository under `examples/`, and generated gallery pages
-are written to `docs/examples/` during the docs build.
-
-## Building Documentation
-
-To build the documentation locally, use:
-
-```bash
-make docs
-```
-
-This generates the API, catalog, installation, scorecard, and gallery pages from retained
-example results before building the site.
-
-To execute stale examples and build the complete documentation, use:
-
-```bash
-make docs-full
-```
-
-The full build runs the same page generation, executes stale examples section by section, then
-regenerates the gallery before the final site build. Project-mode examples synchronize their
-declared extras against the repository's `uv.lock`; the documentation environment does not
-preinstall every project extra.
-
-In CI, pull-request and main-branch documentation builds run `make docs` and never execute
-examples. Pull-request validation only checks that the site builds: it does not upload an HTML
-artifact, deploy the site, or update caches. The manually dispatched `e2s-docs-full` workflow first
-builds, uploads, and deploys the API site from the latest available Gallery cache. A missing Gallery
-cache is allowed. This initial publish gates eight sequential section jobs, ensuring that an API
-update remains published even if a later example fails. Each section restores its own data cache,
-then publishes an updated shared Gallery cache for the next section. Model downloads remain local
-to the section runner and are not saved. After every section succeeds, a final job renders and
-deploys the complete site from the updated Gallery cache without rerunning examples.
-
-The `util-clear-cache` workflow can clear Gallery and section data caches independently.
-
-For local development with live reload, use:
-
-```bash
-make docs-dev
-```
-
-To execute and refresh a single example before serving the site, pass a gallery selector:
+For example:
 
 ```bash
 make docs-dev FILENAME=01_getting_started/01_deterministic_workflow.py
 ```
 
-Only the selected example is executed. The complete gallery is then rendered from
-source and any retained execution artifacts.
+Build output is written to `site/`. Project-mode examples use the repository's `pyproject.toml`
+and `uv.lock`, syncing only their declared extras.
 
-Build files are written to `site/`.
+## CI builds
 
-The empty `docs/.nojekyll` file is intentionally kept in the MkDocs `docs_dir`.
-MkDocs copies it to the root of the built site, which tells GitHub Pages to serve
-asset directories such as `_static/` and `examples/_assets/` without Jekyll
-filtering. Keep this as a source file rather than adding a custom copy step to the
-docs build pipeline.
+- Pull requests run `make docs` only. They do not execute examples, upload the site, write caches,
+  or deploy.
+- Pushes to `main` run the cache-only docs workflow and deploy the site.
+- The manual full workflow publishes the cache-only site, runs all eight example sections
+  sequentially, then publishes the site again with the updated Gallery results.
 
-## Versioning
+Each example section has its own data cache. Gallery results use one rolling cache passed between
+sections. Missing caches are valid cold starts; interrupted restores fail the job. Model downloads
+are not cached. The remaining sections continue after a section failure, but the final publish
+requires every section to succeed.
 
-Documentation versioning uses [Mike](https://github.com/jimporter/mike). To build and
-publish a versioned docs tree from a release branch, set `DOC_VERSION` and optionally
-`DOC_ALIAS`:
+Use the `util-clear-cache` workflow to clear Gallery or docs-data caches.
+
+## GitHub Pages
+
+Keep `docs/.nojekyll` in the source tree. It allows GitHub Pages to serve generated directories
+such as `_static/` and `examples/_assets/`.
+
+Versioned deployments use [Mike](https://github.com/jimporter/mike):
 
 ```bash
 DOC_VERSION=0.18.0 DOC_ALIAS=latest make docs-deploy-version
 ```
 
-Versioned docs are deployed under the `v/` prefix on the `gh-pages` branch.
+Versions are published beneath `v/` on the `gh-pages` branch.

--- a/docs/userguide/developer/documentation.md
+++ b/docs/userguide/developer/documentation.md
@@ -127,12 +127,13 @@ declared extras against the repository's `uv.lock`; the documentation environmen
 preinstall every project extra.
 
 In CI, pull-request and main-branch documentation builds run `make docs` and never execute
-examples. The manually dispatched `e2s-docs-full` workflow runs the selected example sections as
-sequential jobs. Each section restores its own data cache, then publishes an updated shared
+examples. The manually dispatched `e2s-docs-full` workflow first builds, uploads, and deploys the
+API site from the latest available Gallery cache. A missing Gallery cache is allowed. This initial
+publish gates eight sequential section jobs, ensuring that an API update remains published even if
+a later example fails. Each section restores its own data cache, then publishes an updated shared
 Gallery cache for the next section. Model downloads remain local to the section runner and are not
-saved. A final job renders and deploys the complete site from that Gallery cache without rerunning
-examples. The workflow can execute all sections or one selected section; retained results for
-other sections remain available to the final render.
+saved. After every section succeeds, a final job renders and deploys the complete site from the
+updated Gallery cache without rerunning examples.
 
 The `util-clear-cache` workflow can clear Gallery and section data caches independently.
 

--- a/test/_ci/build_docs_examples.sh
+++ b/test/_ci/build_docs_examples.sh
@@ -21,6 +21,22 @@ docs_jobs="${DOCS_JOBS:-1}"
 uv_docs=(uv run --locked --group docs)
 log_dir="${DOCS_EXAMPLE_LOG_DIR:-docs/_build/example-logs}"
 main_log="${log_dir}/docs-examples.log"
+requested_section="${1:-}"
+
+if [ "$#" -gt 1 ]; then
+    echo "Usage: $0 [SECTION]" >&2
+    exit 2
+fi
+if [ -n "${requested_section}" ]; then
+    if [[ ! "${requested_section}" =~ ^[0-9][0-9]_[A-Za-z0-9_-]+$ ]]; then
+        echo "Invalid example section: ${requested_section}" >&2
+        exit 2
+    fi
+    if [ ! -d "examples/${requested_section}" ]; then
+        echo "Example section does not exist: ${requested_section}" >&2
+        exit 2
+    fi
+fi
 
 mkdir -p "${log_dir}"
 exec > >(tee -a "${main_log}") 2>&1
@@ -30,7 +46,14 @@ echo "Example execution log: ${main_log}"
 # Rebuild examples from source, section by section, so stale examples are refreshed.
 rm -rf docs/examples examples/outputs
 
-mapfile -t sections < <(find examples -mindepth 1 -maxdepth 1 -type d -name "[0-9]*" | sort)
+if [ -n "${requested_section}" ]; then
+    sections=("examples/${requested_section}")
+else
+    mapfile -t sections < <(
+        find examples -mindepth 1 -maxdepth 1 -type d -name "[0-9]*" | sort
+    )
+fi
+
 for section in "${sections[@]}"; do
     selector="${section#examples/}"
     echo "::group::Build docs examples: ${selector}"


### PR DESCRIPTION
## Summary

- publish a cache-only API documentation build before executing examples
- execute all example sections sequentially with section-specific data caches and a rolling shared Gallery cache
- render and publish the complete site after all sections finish
- treat an absent cache as a cold start while failing on interrupted cache restores
- avoid saving empty or unchanged docs data caches and keep model downloads ephemeral
- keep pull-request and regular main-branch docs builds cache-only
- retain explicit Gallery and docs-data cleanup through the cache utility workflow

## Validation

- `uvx pre-commit run --files ...`
- `bash -n test/_ci/build_docs_examples.sh`
- section-selector validation
- `make -n docs` and `make -n docs-full` routing checks
- `git diff --check`
