### PR TITLE
Use NaN fill for unresolved GRIB fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- GFS, HRRR, and GEFS GRIB sources now fill unresolved output regions with
+  `NaN` instead of zeros or uninitialized memory, making missing index records
+  detectable
 - `UFSObsConv` and `UFSObsSat` now decode diag files in parallel across a
   persistent spawn-based process pool (new `decode_workers` parameter,
   default `"auto"`); each file is decoded once per request window, frames are

--- a/earth2studio/data/gefs.py
+++ b/earth2studio/data/gefs.py
@@ -236,14 +236,15 @@ class GEFS_FX:
         # but this is much much cleaner to deal with, compared to something seen in the
         # NCAR data source.
         xr_array = xr.DataArray(
-            data=np.empty(
+            data=np.full(
                 (
                     len(time),
                     len(lead_time),
                     len(variable),
                     len(self.GEFS_LAT),
                     len(self.GEFS_LON),
-                )
+                ),
+                np.nan,
             ),
             dims=["time", "lead_time", "variable", "lat", "lon"],
             coords={

--- a/earth2studio/data/gfs.py
+++ b/earth2studio/data/gfs.py
@@ -241,8 +241,9 @@ class GFS:
         # but this is much much cleaner to deal with, compared to something seen in the
         # NCAR data source.
         xr_array = xr.DataArray(
-            data=np.zeros(
-                (len(time), 1, len(variable), len(self.GFS_LAT), len(self.GFS_LON))
+            data=np.full(
+                (len(time), 1, len(variable), len(self.GFS_LAT), len(self.GFS_LON)),
+                np.nan,
             ),
             dims=["time", "lead_time", "variable", "lat", "lon"],
             coords={
@@ -660,14 +661,15 @@ class GFS_FX(GFS):
         # but this is much much cleaner to deal with, compared to something seen in the
         # NCAR data source.
         xr_array = xr.DataArray(
-            data=np.zeros(
+            data=np.full(
                 (
                     len(time),
                     len(lead_time),
                     len(variable),
                     len(self.GFS_LAT),
                     len(self.GFS_LON),
-                )
+                ),
+                np.nan,
             ),
             dims=["time", "lead_time", "variable", "lat", "lon"],
             coords={

--- a/earth2studio/data/hrrr.py
+++ b/earth2studio/data/hrrr.py
@@ -298,14 +298,15 @@ class HRRR:
         # Note, this could be more memory efficient and avoid pre-allocation of the array
         # but this is much much cleaner to deal with
         xr_array = xr.DataArray(
-            data=np.zeros(
+            data=np.full(
                 (
                     len(time),
                     1,
                     len(variable),
                     len(self.HRRR_Y),
                     len(self.HRRR_X),
-                )
+                ),
+                np.nan,
             ),
             dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
             coords={
@@ -839,14 +840,15 @@ class HRRR_FX(HRRR):
         # but this is much much cleaner to deal with, compared to something seen in the
         # NCAR data source.
         xr_array = xr.DataArray(
-            data=np.empty(
+            data=np.full(
                 (
                     len(time),
                     len(lead_time),
                     len(variable),
                     len(self.HRRR_Y),
                     len(self.HRRR_X),
-                )
+                ),
+                np.nan,
             ),
             dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
             coords={

--- a/test/data/test_gefs.py
+++ b/test/data/test_gefs.py
@@ -346,15 +346,16 @@ def test_gefs_call_mock(tmp_path, monkeypatch):
     ):
         # Bypass real store by stubbing it to a truthy sentinel.
         ds.store = object()  # type: ignore[assignment]
-        data = ds(datetime(2024, 1, 1), timedelta(hours=3), ["t2m", "z500"])
+        data = ds(datetime(2024, 1, 1), timedelta(hours=3), ["t2m", "z500", "u10m"])
 
-    assert data.shape == (1, 1, 2, 361, 720)
+    assert data.shape == (1, 1, 3, 361, 720)
     # t2m is identity, z500 multiplies HGT by 9.81 — both records used the
-    # same mock grid, so t2m matches the grid and z500 = grid * 9.81.
+    # same mock grid; u10m is missing from the index.
     np.testing.assert_allclose(data.sel(variable="t2m").values[0, 0], fake_grid)
     np.testing.assert_allclose(
         data.sel(variable="z500").values[0, 0], fake_grid * 9.81, rtol=1e-6
     )
+    assert np.isnan(data.sel(variable="u10m").values).all()
 
 
 @pytest.mark.timeout(15)

--- a/test/data/test_gfs.py
+++ b/test/data/test_gfs.py
@@ -335,18 +335,19 @@ def test_gfs_fx_call_mock(tmp_path, monkeypatch):
         data = ds(
             datetime(2024, 1, 1),
             [timedelta(hours=0), timedelta(hours=6)],
-            ["t2m"],
+            ["t2m", "z500"],
         )
 
-    assert data.shape == (1, 2, 1, 721, 1440)
+    assert data.shape == (1, 2, 2, 721, 1440)
     for j in range(2):
-        np.testing.assert_allclose(data.values[0, j, 0], fake_grid)
+        np.testing.assert_allclose(data.sel(variable="t2m").values[0, j], fake_grid)
+    assert np.isnan(data.sel(variable="z500").values).all()
 
 
 @pytest.mark.timeout(15)
 def test_gfs_missing_variable_mock(tmp_path, monkeypatch):
     # If the requested variable is absent from the .idx, _create_tasks warns
-    # and skips it — the output slot keeps its zero initialization.
+    # and skips it, so the output slot must remain detectably missing.
     monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
 
     # Index only has t2m; z500 is missing on purpose.
@@ -370,5 +371,4 @@ def test_gfs_missing_variable_mock(tmp_path, monkeypatch):
         data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
 
     np.testing.assert_allclose(data.sel(variable="t2m").values[0], fake_grid)
-    # Skipped variable keeps the zero fill.
-    assert (data.sel(variable="z500").values == 0.0).all()
+    assert np.isnan(data.sel(variable="z500").values).all()

--- a/test/data/test_hrrr.py
+++ b/test/data/test_hrrr.py
@@ -377,18 +377,19 @@ def test_hrrr_fx_call_mock(tmp_path, monkeypatch):
         data = ds(
             datetime(2024, 1, 1),
             [timedelta(hours=0), timedelta(hours=6)],
-            ["t2m"],
+            ["t2m", "z500"],
         )
 
-    assert data.shape == (1, 2, 1, 1059, 1799)
+    assert data.shape == (1, 2, 2, 1059, 1799)
     for j in range(2):
-        np.testing.assert_allclose(data.values[0, j, 0], fake_grid)
+        np.testing.assert_allclose(data.sel(variable="t2m").values[0, j], fake_grid)
+    assert np.isnan(data.sel(variable="z500").values).all()
 
 
 @pytest.mark.timeout(15)
 def test_hrrr_missing_variable_mock(tmp_path, monkeypatch):
     # If the requested variable is absent from the .idx, _create_tasks warns
-    # and skips it — the output slot keeps its zero initialization.
+    # and skips it, so the output slot must remain detectably missing.
     monkeypatch.setenv("EARTH2STUDIO_CACHE", str(tmp_path))
 
     # Index only has t2m; z500 is missing on purpose.
@@ -410,5 +411,4 @@ def test_hrrr_missing_variable_mock(tmp_path, monkeypatch):
         data = ds(datetime(2024, 1, 1), ["t2m", "z500"])
 
     np.testing.assert_allclose(data.sel(variable="t2m").values[0], fake_grid)
-    # Skipped variable keeps the zero fill.
-    assert (data.sel(variable="z500").values == 0.0).all()
+    assert np.isnan(data.sel(variable="z500").values).all()


### PR DESCRIPTION
# Earth2Studio Pull Request

## Description

Initialize GFS, GFS_FX, HRRR, HRRR_FX, and GEFS_FX output arrays with NaN so variables that do not resolve against a GRIB index remain detectably missing. Successful fetch tasks continue to overwrite their output slots normally.

Existing analysis and forecast mock tests now exercise both successful and unresolved variables without adding duplicate test functions. The changelog documents the behavior change.

Closes #1028.

## Testing

- `uv run --extra data pytest test/data/test_gfs.py test/data/test_hrrr.py test/data/test_gefs.py -q` (43 passed, 31 slow tests skipped)
- `make lint`
- Live GFS request for `["t2m", "tp"]` at 2024-01-01: `t2m` fully finite and unresolved `tp` fully NaN

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

None.
