### PR TITLE
fix: synchronize FengWu ONNX I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,16 +136,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed intermittent repeated FengWu forecast timesteps by synchronizing ONNX
   Runtime I/O buffers with PyTorch.
-
 - Fixed HRRR GRIB index lookups for total precipitation at lead zero and for
   snow depth, snow cover, and total cloud cover at positive forecast lead
   times.
 - Fixed the March 22, 2021 GFS archive cutoff and historical `GFS_FX` total
   precipitation lookups.
-
 - Fixed `lat_weight` returning a small negative weight at the poles in
   float32, which could give NaN under `sqrt`. Weights are now clamped to be non-negative.
-
 - Fixed `SamudrACE` inference being non-reproducible run-to-run: toggling
   `torch.backends.cudnn.benchmark` on and off around each coupled cycle
   re-triggered cuDNN's GPU-timing-based algorithm search every cycle
@@ -153,7 +150,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unsliced coords: `lead_time` kept `[-6h, 0h]` while the tensor held one
   step. Coords are now sliced the same way as FuXi, DLWP and FengWu, so the
   initial condition is yielded at `lead_time=[0h]`
-
 - Fixed `CFS_Reforecast_FX` and `CFS_Reforecast_FX_Flux` pointing at the retired
   NCEI archive path; the reforecast archive moved to
   `https://www.ncei.noaa.gov/oa/prod-cfs-reforecast` with renamed product subdirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed intermittent repeated FengWu forecast timesteps by synchronizing ONNX
+  Runtime I/O buffers with PyTorch.
+
 - Fixed HRRR GRIB index lookups for total precipitation at lead zero and for
   snow depth, snow cover, and total cloud cover at positive forecast lead
   times.

--- a/earth2studio/models/px/fengwu.py
+++ b/earth2studio/models/px/fengwu.py
@@ -308,7 +308,9 @@ class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # Forward pass, fengwu onnx supports batched
         bind_input("input", x)
         output = bind_output("output", like=x)
+        binding.synchronize_inputs()
         ort_session.run_with_iobinding(binding)
+        binding.synchronize_outputs()
 
         # ONNX model outputs two time-steps, take the first
         output_tensor = output[:].contiguous()


### PR DESCRIPTION
## Description

Closes #980.

FengWu binds PyTorch CUDA tensors directly to ONNX Runtime, but inference could
start before the input buffers were ready or return before the output buffers
were safe for PyTorch to consume. This CUDA stream race caused intermittent
repeated forecast timesteps.

Synchronize the bound inputs before inference and outputs afterward, following
the ONNX Runtime I/O binding contract.

## Testing

- `uv run --extra fengwu pytest test/models/px/test_fengwu.py -q` (11 passed,
  1 package test skipped)
- `make lint`
- Real FengWu checkpoint: 12-step CUDA rollout advanced at every step; before
  the fix, the third forecast step exactly repeated the preceding field
