### PR TITLE
Support batched deterministic inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed deterministic workflows with data sources that provide leading batch
+  dimensions such as ensemble.
+
 - Fixed intermittent repeated FengWu forecast timesteps by synchronizing ONNX
   Runtime I/O buffers with PyTorch.
 - Fixed HRRR GRIB index lookups for total precipitation at lead zero and for

--- a/earth2studio/data/base.py
+++ b/earth2studio/data/base.py
@@ -47,7 +47,8 @@ class DataSource(Protocol):
         Returns
         -------
         xr.DataArray
-            An xarray data-array with the dimensions [time, variable, ....]. The coords
+            An xarray data-array with the dimensions
+            [optional leading batch dimensions, time, variable, ...]. The coords
             should be provided. Time coordinate should be a datetime array and the
             variable coordinate should be array of strings with Earth2Studio variable
             ids.
@@ -72,7 +73,8 @@ class DataSource(Protocol):
         Returns
         -------
         xr.DataArray
-            An xarray data-array with the dimensions [time, variable, ....]. The coords
+            An xarray data-array with the dimensions
+            [optional leading batch dimensions, time, variable, ...]. The coords
             should be provided. Time coordinate should be a datetime array and the
             variable coordinate should be array of strings with Earth2Studio variable
             ids.
@@ -109,7 +111,8 @@ class ForecastSource(Protocol):
         Returns
         -------
         xr.DataArray
-            An xarray data-array with the dimensions [time, variable, lead_time, ...].
+            An xarray data-array with the dimensions
+            [optional leading batch dimensions, time, lead_time, variable, ...].
             The coords should be provided. Time coordinate should be a TimeArray,
             lead time coordinate a LeadTimeArray and the variable coordinate should be
             an array of strings with Earth2Studio variable ids.
@@ -138,7 +141,8 @@ class ForecastSource(Protocol):
         Returns
         -------
         xr.DataArray
-            An xarray data-array with the dimensions [time, variable, lead_time, ...].
+            An xarray data-array with the dimensions
+            [optional leading batch dimensions, time, lead_time, variable, ...].
             The coords should be provided. Time coordinate should be a TimeArray,
             lead time coordinate a LeadTimeArray and the variable coordinate should be
             an array of strings with Earth2Studio variable ids.

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -153,7 +153,9 @@ def fetch_data(
         for lead in lead_time:
             adjust_times = _offset_times(time, lead)
             da0 = source(adjust_times, variable)  # type: ignore
-            da0 = da0.expand_dims(dim={"lead_time": 1}, axis=1)
+            da0 = da0.expand_dims(
+                dim={"lead_time": 1}, axis=da0.get_axis_num("time") + 1
+            )
             da0 = da0.assign_coords(lead_time=np.array([lead], dtype="timedelta64[ns]"))
             da0 = da0.assign_coords(time=time)
             da.append(da0)

--- a/earth2studio/run.py
+++ b/earth2studio/run.py
@@ -94,28 +94,6 @@ def deterministic(
     prognostic_ic = prognostic.input_coords()
     time = to_time_array(time)
 
-    # Set up IO backend
-    total_coords = prognostic.output_coords(prognostic.input_coords()).copy()
-    for key, value in prognostic.output_coords(
-        prognostic.input_coords()
-    ).items():  # Scrub batch dims
-        if value.shape == (0,):
-            del total_coords[key]
-    total_coords["time"] = time
-    total_coords["lead_time"] = np.asarray(
-        [
-            prognostic.output_coords(prognostic.input_coords())["lead_time"] * i
-            for i in range(nsteps + 1)
-        ]
-    ).flatten()
-    total_coords.move_to_end("lead_time", last=False)
-    total_coords.move_to_end("time", last=False)
-
-    for key, value in total_coords.items():
-        total_coords[key] = output_coords.get(key, value)
-    var_names = total_coords.pop("variable")
-    io.add_array(total_coords, var_names)
-
     with checkpoint as ckpt:
         restart_step = None
         if ckpt.exists and ckpt.write_count > 0:
@@ -156,6 +134,24 @@ def deterministic(
 
         # Map lat and lon if needed
         x, coords = map_coords(x, coords, prognostic.input_coords())
+
+        # Set up IO backend, preserving dimensions batched by the model wrapper
+        prognostic_oc = prognostic.output_coords(prognostic_ic)
+        total_coords = OrderedDict(
+            (key, value) for key, value in prognostic_oc.items() if value.shape != (0,)
+        )
+        leading_dim_count = len(coords) - len(prognostic_ic) + 1
+        leading_coords = OrderedDict(list(coords.items())[:leading_dim_count])
+        total_coords = leading_coords | total_coords
+        total_coords["lead_time"] = np.asarray(
+            [prognostic_oc["lead_time"] * i for i in range(nsteps + 1)]
+        ).flatten()
+
+        for key, value in total_coords.items():
+            total_coords[key] = output_coords.get(key, value)
+        var_names = total_coords.pop("variable")
+        io.add_array(total_coords, var_names)
+
         # Create prognostic iterator
         model = prognostic.create_iterator(x, coords)
 

--- a/test/run/test_deterministic.py
+++ b/test/run/test_deterministic.py
@@ -72,6 +72,26 @@ def test_run_deterministic(coords, variable, nsteps, time, device):
             assert io[var].shape[i + 2] == value.shape[0]
 
 
+def test_run_deterministic_batched_data():
+    class BatchedRandom(Random):
+        def __call__(self, time, variable):
+            return super().__call__(time, variable).expand_dims(ensemble=np.arange(2))
+
+    coords = OrderedDict([("lat", np.arange(2)), ("lon", np.arange(3))])
+    io = run.deterministic(
+        ["2024-01-01"],
+        1,
+        Persistence(["t2m"], coords),
+        BatchedRandom(coords),
+        ZarrBackend(),
+        device=torch.device("cpu"),
+        verbose=False,
+    )
+    assert io["t2m"].shape == (2, 1, 2, 2, 3)
+    assert np.array_equal(io["ensemble"][:], np.arange(2))
+    assert not np.isnan(io["t2m"][:]).any()
+
+
 @pytest.mark.parametrize(
     "output_coords",
     [


### PR DESCRIPTION
## Description

Allow `run.deterministic` to consume data sources with optional leading batch dimensions, such as precomputed ensemble members.

- insert synthesized `lead_time` immediately after the source's actual `time` dimension
- initialize the IO backend after fetching data so source-provided leading coordinates are included
- document the supported source dimension ordering
- add a compact end-to-end regression test that preserves the ensemble coordinate and writes finite output

Closes #659.

## Testing

- `uv run pytest -q test/run/test_deterministic.py` (43 passed)
- `uv run pytest -q test/data/test_data_utils.py test/utils/test_checkpoint.py` (92 passed, 5 skipped)
- manually reproduced both a batched `DataSource` and `ForecastSource` workflow
- `make format`
- `make lint`
