### PR TITLE
Bump version to 0.19.0a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0a0] - 2026-08-xx
+## [0.19.0a0] - xxxx-xx-xx
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Dependencies
+
+## [0.18.0] - 2026-08-xx
 
 ### Added
 
@@ -130,8 +146,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated the `fs_factory` parameter of `AsyncZarrBackend` in favor of
   `store`; the default local write path no longer uses fsspec
-
-### Removed
 
 ### Fixed
 

--- a/earth2studio/__init__.py
+++ b/earth2studio/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.0a0"
+__version__ = "0.19.0a0"
 
 # Deprecation warnings
 # import sys


### PR DESCRIPTION
Bump the Earth2Studio version to 0.19.0a0 to start the next development cycle.

### Changes
- Updated `earth2studio/__init__.py` version from `0.18.0a0` to `0.19.0a0`
- Added blank `[0.19.0a0]` section to CHANGELOG.md
- Renamed released section from `[0.18.0a0]` to `[0.18.0]`
- Removed empty `### Removed` subsection from the 0.18.0 release notes