### PR TITLE
fix package, example telemetry

### DIFF
--- a/earth2studio/data/meteosat_fci.py
+++ b/earth2studio/data/meteosat_fci.py
@@ -49,10 +49,12 @@ from earth2studio.utils.type import TimeArray, VariableArray
 try:
     import eumdac
     import netCDF4
+    import urllib3
 except ImportError:
     OptionalDependencyFailure("data")
     eumdac = None  # type: ignore[assignment]
     netCDF4 = None  # type: ignore[assignment]
+    urllib3 = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +546,13 @@ class MeteosatFCI:
                 collection,
                 retries=self._retries,
                 backoff=2.0,
-                exceptions=(OSError, IOError, TimeoutError, ConnectionError),
+                exceptions=(
+                    OSError,
+                    IOError,
+                    TimeoutError,
+                    ConnectionError,
+                    urllib3.exceptions.ProtocolError,
+                ),
             )
             for (t, collection) in downloads
         ]

--- a/earth2studio/models/px/stormscope_meteosat.py
+++ b/earth2studio/models/px/stormscope_meteosat.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
 from collections import OrderedDict
 from collections.abc import Callable, Generator
 from datetime import datetime
@@ -40,6 +41,7 @@ from earth2studio.utils.imports import (
 from earth2studio.utils.type import CoordSystem
 
 try:
+    import physicsnemo.nn.module.dit_layers as _dit_layers
     from omegaconf import OmegaConf
     from physicsnemo.diffusion.noise_schedulers import EDMNoiseScheduler
     from physicsnemo.diffusion.preconditioners import EDMPreconditioner
@@ -788,9 +790,9 @@ class StormScopeMeteosatEU(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
         package = Package(
-            "hf://nvidia/stormcast-conus@17148d712f7ef2c0b48355032dcad85173dd230e",
+            "hf://nvidia/stormscope-meteosat@17148d712f7ef2c0b48355032dcad85173dd230e",
             cache_options={
-                "cache_storage": Package.default_cache("stormcast-conus"),
+                "cache_storage": Package.default_cache("stormscope-meteosat"),
                 "same_names": True,
             },
         )
@@ -825,16 +827,35 @@ class StormScopeMeteosatEU(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # load model registry:
         config = OmegaConf.load(package.resolve("config.yaml"))
 
-        model_spec = [
-            {
-                "sigma_min": float(spec["sigma_min"]),
-                "sigma_max": float(spec["sigma_max"]),
-                "model": EDMPreconditioner.from_checkpoint(
-                    package.resolve(spec["path"])
-                ).eval(),
-            }
-            for spec in config["model_spec"]
-        ]
+        # Checkpoints embed layernorm_backend=apex in the model constructors, which will
+        # fail if apex is not installed. Here we patch APEX_AVAILABLE in physicsnemo
+        # dit_layers to avoid the import error. FusedLayerNorm uses elementwise_affine=False
+        # (no learned parameters), so torch.nn.LayerNorm is state-dict-compatible.
+        # TODO remove when upstream physicsnemo falls back to torch with a warning.
+        _apex_restore: tuple | None = None
+        if not _dit_layers.APEX_AVAILABLE:
+            _apex_restore = (_dit_layers.APEX_AVAILABLE, _dit_layers.apex_normalization)
+            _dit_layers.APEX_AVAILABLE = True
+            _dit_layers.apex_normalization = types.SimpleNamespace(
+                FusedLayerNorm=torch.nn.LayerNorm
+            )
+
+        try:
+            model_spec = [
+                {
+                    "sigma_min": float(spec["sigma_min"]),
+                    "sigma_max": float(spec["sigma_max"]),
+                    "model": EDMPreconditioner.from_checkpoint(
+                        package.resolve(spec["path"])
+                    ).eval(),
+                }
+                for spec in config["model_spec"]
+            ]
+        finally:
+            if _apex_restore is not None:
+                _dit_layers.APEX_AVAILABLE, _dit_layers.apex_normalization = (
+                    _apex_restore
+                )
 
         # Load metadata: means, stds, grid
         with xr.open_dataset(package.resolve("metadata.nc")) as metadata:

--- a/examples/04_nowcasting/04_stormscope_meteosat_example.py
+++ b/examples/04_nowcasting/04_stormscope_meteosat_example.py
@@ -92,7 +92,7 @@ from earth2studio.utils.coords import map_coords
 # ----------
 # Load StormScopeMeteosatEU from a package.
 
-# %%
+# %% tags=["e2sg-profile:setup"]
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 package = StormScopeMeteosatEU.load_default_package()
@@ -117,7 +117,7 @@ model.compile_model()
 # The 1 km grid is exactly 2 times the pixels of the 2 km grid, so we get
 # the 1 km bounding box by doubling the 2 km bounding box.
 
-# %%
+# %% tags=["e2sg-profile:setup"]
 bbox_2km = StormScopeMeteosatEU.Model_FCI_BBox
 FCI_BBox = {"2km": bbox_2km}
 FCI_BBox["1km"] = (
@@ -141,11 +141,11 @@ fci = {
 # ``StormScopeMeteosatEU.combine_1km_2km_inputs`` to resize the channels
 # retrieved from the 1 km data source.
 
-# %%
+# %% tags=["e2sg-profile:setup"]
 # Start time; replace with any time for which MTG-I1 FCI data is available.
 # StormScopeMeteosatEU was trained on November 2024 - May 2026 data; start times
 # should generally be outside that period.
-start_time = np.datetime64(datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc))
+start_time = np.datetime64(datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc))
 in_coords = model.input_coords()
 variables = in_coords["variable"]
 
@@ -180,7 +180,7 @@ with torch.no_grad():
 # Up to GPU memory limits, ``ensemble_size`` can be increased to produce multiple
 # independent ensemble members in a single forward pass.
 
-# %%
+# %% tags=["e2sg-profile:setup"]
 ensemble_size = 1
 x = x.expand(ensemble_size, -1, -1, -1, -1, -1)
 coords["ensemble"] = np.arange(ensemble_size)
@@ -193,7 +193,7 @@ coords.move_to_end("ensemble", last=False)
 # yielded value is the (unchanged) initial condition, and each subsequent
 # value advances the prediction by one 10-minute interval.
 
-# %%
+# %% tags=["e2sg-profile:inference"]
 n_steps = 12  # 2 hours of 10-minute forecast steps
 
 for step, (x_pred, coords_pred) in enumerate(
@@ -209,7 +209,7 @@ for step, (x_pred, coords_pred) in enumerate(
 # 0.5 / 0.4 µm) in geostationary projection. Off-Earth pixels are already set
 # to NaN by ``denormalize``.
 
-# %%
+# %% tags=["e2sg-profile:plotting"]
 rgb_channels = ["fci06vis", "fci05vis", "fci04vis"]
 ch_idx = [list(model.variables).index(ch) for ch in rgb_channels]
 

--- a/test/models/px/test_stormscope_meteosat.py
+++ b/test/models/px/test_stormscope_meteosat.py
@@ -669,7 +669,9 @@ def test_stormscope_meteosat_package():
 
     h, w = len(model.mtg_y), len(model.mtg_x)
     assert out.shape == torch.Size([1, len(time), 1, len(variable), h, w])
-    assert torch.isfinite(out).all()
+    # Off-Earth pixels are intentionally masked to NaN in denormalize(); only
+    # on-Earth pixels are expected to be finite.
+    assert torch.isfinite(out[..., model.earth_mask]).all()
     assert (out_coords["variable"] == model.output_coords(coords)["variable"]).all()
     assert np.all(out_coords["time"] == time)
     handshake_dim(out_coords, "x", 5)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Fixes StormScope-MTG package loading and adds telemetry to the example. Also 
<img width="1200" height="1200" alt="image" src="https://github.com/user-attachments/assets/ba8e8c87-4b7a-432f-9af2-f25940cb8dc7" />

Also a fix in the FCI data source for catching slow connections erroring out so they can retry.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
