### PR TITLE
fix: use reshape instead of view in FengWu and FuXi

### DIFF
--- a/earth2studio/models/px/fengwu.py
+++ b/earth2studio/models/px/fengwu.py
@@ -304,7 +304,8 @@ class FengWu(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             return out
 
         x = (x - self.center) / self.scale  # Normalize
-        x = x.view(x.shape[0], -1, 721, 1440)  # Concat time-steps
+        # reshape, not view: x is the caller's tensor and may be non-contiguous
+        x = x.reshape(x.shape[0], -1, 721, 1440)  # Concat time-steps
         # Forward pass, fengwu onnx supports batched
         bind_input("input", x)
         output = bind_output("output", like=x)

--- a/earth2studio/models/px/fuxi.py
+++ b/earth2studio/models/px/fuxi.py
@@ -375,7 +375,7 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             np.tile(coords["time"] + coords["lead_time"][-1], x.shape[0])
         )
         # reshape, not view: x is the caller's tensor and may be non-contiguous
-        x = x.reshape(-1, *x.shape[2:])
+        x = x.reshape(-1, *x.shape[2:]).contiguous()
 
         # Not sure if FuXi supports batching atm
         output = torch.empty_like(x)

--- a/earth2studio/models/px/fuxi.py
+++ b/earth2studio/models/px/fuxi.py
@@ -374,7 +374,8 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         time_array = self._time_encoding(
             np.tile(coords["time"] + coords["lead_time"][-1], x.shape[0])
         )
-        x = x.view(-1, *x.shape[2:])
+        # reshape, not view: x is the caller's tensor and may be non-contiguous
+        x = x.reshape(-1, *x.shape[2:])
 
         # Not sure if FuXi supports batching atm
         output = torch.empty_like(x)
@@ -389,7 +390,7 @@ class FuXi(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             output[b : b + 1] = out
 
         # Reshape to batch and time dimension
-        output = output.view(-1, coords["time"].shape[0], *output.shape[1:])
+        output = output.reshape(-1, coords["time"].shape[0], *output.shape[1:])
 
         # Convert tp06 back to m
         output[..., tp06_index, :, :] = output[..., tp06_index, :, :] / 1000

--- a/test/models/px/test_fengwu.py
+++ b/test/models/px/test_fengwu.py
@@ -97,7 +97,14 @@ class TestFengWuMock:
         variable = p.input_coords()["variable"]
         x, coords = fetch_data(r, time, variable, lead_time, device=device)
 
+        # Same values, variable/lead_time permuted in memory: a data source that
+        # transposes on the way out yields a strided tensor and must not change
+        # the result.
+        x_strided = x.transpose(1, 2).contiguous().transpose(1, 2)
+        assert not x_strided.is_contiguous()
+
         out, out_coords = p(x, coords)
+        assert torch.allclose(out, p(x_strided, coords)[0])
 
         if not isinstance(time, Iterable):
             time = [time]

--- a/test/models/px/test_fuxi.py
+++ b/test/models/px/test_fuxi.py
@@ -107,7 +107,14 @@ class TestFuXiMock:
         variable = p.input_coords()["variable"]
         x, coords = fetch_data(r, time, variable, lead_time, device=device)
 
+        # Same values, variable/lead_time permuted in memory: a data source that
+        # transposes on the way out yields a strided tensor and must not change
+        # the result.
+        x_strided = x.transpose(1, 2).contiguous().transpose(1, 2)
+        assert not x_strided.is_contiguous()
+
         out, out_coords = p(x, coords)
+        assert torch.allclose(out, p(x_strided, coords)[0])
 
         if not isinstance(time, Iterable):
             time = [time]


### PR DESCRIPTION
view() only works when the requested shape fits the tensor's existing strides. Both models call it on the tensor the caller passed in, so a non-contiguous input raises - a data source that transposes the model input results in this error.

FengWu fails at any batch size. FuXi only fails at batch size 2 or more, because merging a leading dim of size 1 is always allowed.

reshape() does the same thing, and copies only when it has to.

The call tests now check that a strided input gives the same result as a contiguous one.

<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
