### PR TITLE
StormScope fixes/improvements

### DIFF
--- a/earth2studio/models/px/stormscope.py
+++ b/earth2studio/models/px/stormscope.py
@@ -1430,7 +1430,8 @@ class StormScopeBase(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         x, coords = self.prep_input(x, coords)
         ic_coords = coords.copy()
         ic_coords["lead_time"] = ic_coords["lead_time"][-1:]
-        yield torch.where(~self.valid_mask, torch.nan, x), ic_coords
+        ic_x = x[:, :, -1:, ...]
+        yield torch.where(~self.valid_mask, torch.nan, ic_x), ic_coords
 
         while True:
             x, coords = self.front_hook(x, coords)

--- a/examples/04_nowcasting/04_stormscope_meteosat_example.py
+++ b/examples/04_nowcasting/04_stormscope_meteosat_example.py
@@ -224,7 +224,9 @@ proj = ccrs.Geostationary(
 )
 extent = MeteosatFCI.projection_extent(resolution="2km", pixel_bbox=bbox_2km)
 
-fig = plt.figure(figsize=(8, 8))
+aspect = (extent[1] - extent[0]) / (extent[3] - extent[2])
+fig_height = 8
+fig = plt.figure(figsize=(fig_height * aspect, fig_height))
 ax = fig.add_subplot(1, 1, 1, projection=proj)
 ax.set_xlim(extent[0], extent[1])
 ax.set_ylim(extent[2], extent[3])

--- a/test/models/px/test_stormscope.py
+++ b/test/models/px/test_stormscope.py
@@ -271,7 +271,11 @@ def test_stormscope_iter(batch, device):
         time = [time]
 
     # Get generator
-    next(p_iter)  # Skip first which should return the input
+    ic_x, ic_coords = next(p_iter)  # First yield should return the initial condition
+    assert ic_x.shape == torch.Size([batch, len(time), 1, nvar, h, w])
+    assert ic_coords["lead_time"].shape == (1,)
+    assert ic_coords["lead_time"][0] == lead_time[-1]
+
     for i, (out, out_coords) in enumerate(p_iter):
         assert len(out.shape) == 6
         assert out.shape == torch.Size([batch, len(time), 1, nvar, h, w])


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
Makes the output image in the StormnScope-MTG example more square. Also fixes a bug where StormScope default generator was not slicing the returned initial condition tensor along lead time at step 0.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
