### PR TITLE
fix: backport serve Docker build fix to 0.18

### DIFF
--- a/serve/Dockerfile
+++ b/serve/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.01-py3
+FROM nvcr.io/nvidia/pytorch:26.02-py3
 
 RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
 
@@ -37,10 +37,6 @@ RUN apt-get update && apt-get install -y redis-server && rm -rf /var/lib/apt/lis
     cd /workspace/earth2studio-project && \
     uv pip install --system --break-system-packages ".[dlwp,dlesym,pangu,sfno,stormcast,fcn3,serve,cbottle,corrdiff,cyclone,data,perturbation,statistics]" && \
     rm -rf /workspace/earth2studio-project/earth2studio /workspace/earth2studio-project/pyproject.toml /workspace/earth2studio-project/README.md
-
-# Pin warp-lang below 1.12.0 — physicsnemo uses wp.context.Device which was
-# removed/changed in 1.12.0+, causing import failures at runtime.
-RUN uv pip install --system --break-system-packages "warp-lang<1.12.0"
 
 # Critical CVEs
 # Libtasn1: CVEs


### PR DESCRIPTION
## Description

Backports the two commits from #1115 to the 0.18.0 release branch.

- Update the NVIDIA PyTorch base image from 26.01 to 26.02.
- Remove the obsolete warp-lang<1.12.0 runtime pin.
- Preserve the source PR merge commit without importing unrelated main changes.

## Validation

- Verified the backport diff contains only serve/Dockerfile.
- Docker build validation resolved the NVIDIA 26.02 base image; the local check could not access ghcr.io/astral-sh/uv because the host lacks GHCR credentials.