### PR TITLE
StormScope: Return only lead_time=0 from ICs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed StormScope default generator returning all input lead times for ICs.
 - Fixed intermittent repeated FengWu forecast timesteps by synchronizing ONNX
   Runtime I/O buffers with PyTorch.
 - Fixed HRRR GRIB index lookups for total precipitation at lead zero and for

--- a/earth2studio/models/px/stormscope.py
+++ b/earth2studio/models/px/stormscope.py
@@ -1430,7 +1430,10 @@ class StormScopeBase(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         x, coords = self.prep_input(x, coords)
         ic_coords = coords.copy()
         ic_coords["lead_time"] = ic_coords["lead_time"][-1:]
-        yield torch.where(~self.valid_mask, torch.nan, x), ic_coords
+        lt_idx = list(ic_coords).index("lead_time")
+        yield torch.where(
+            self.valid_mask, x.narrow(lt_idx, -1, 1), torch.nan
+        ), ic_coords
 
         while True:
             x, coords = self.front_hook(x, coords)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description
The StormScope default generator previously returned all 6 lead times from the IC tensor. This did not match the returned coords (sliced to lead time 0) or the tensor/coords returned during forecast steps (only latest lead time)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
