### PR TITLE
Added regional split and new metrics to eval recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scoring.online.regions` takes named lat/lon boxes and adds a labeled
   `region` axis to `stats.zarr`/`scores.zarr`. New optional per-member
   metrics include MAE (`scoring.online.mae`) and log spectral distance
-  (`scoring.online.lsd`.
+  (`scoring.online.lsd`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   respectively.
 - Added `eager_sessions` option to Pangu6 and Pangu3 to build the extra
   ONNX sessions at construction instead of on first use in a rollout
+- Added regional splits to evaluation recipe online scoring:
+  `scoring.online.regions` takes named lat/lon boxes and adds a labeled
+  `region` axis to `stats.zarr`/`scores.zarr`. New optional per-member
+  metrics include MAE (`scoring.online.mae`) and log spectral distance
+  (`scoring.online.lsd`.
 
 ### Changed
 
@@ -37,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- Evaluation recipe: clearing resume markers no longer races between
+  ranks. Concurrent removal of the same progress directory retries until
+  the directory no longer exists
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source (`MeteosatLI`), providing per-flash, per-group and per-event
   detections from the LFL, LGR and LEF collections as a data frame
 - Added group- and flash-level variables to the `GOESGLM` data source
+- Added `eager_sessions` option to Pangu6 and Pangu3 to build the extra
+  ONNX sessions at construction instead of on first use in a rollout
+- Added regional splits to evaluation recipe scoring, in both the online
+  and store-then-score pathways: `scoring.regions` takes named coordinate
+  boxes and adds a labeled `region` axis to the score stores. New
+  optional per-member online metrics include MAE (`scoring.online.mae`)
+  and log spectral distance (`scoring.online.lsd`)
 
 ### Changed
 
@@ -24,16 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `lightning_flash_footprint_pixels`. `GOESGLM` variable ids `flashe` and
   `flashc` are renamed to `lightning_event_energy` and `lightning_event_count`
   respectively.
-- Added `eager_sessions` option to Pangu6 and Pangu3 to build the extra
-  ONNX sessions at construction instead of on first use in a rollout
-- Added regional splits to evaluation recipe online scoring:
-  `scoring.online.regions` takes named lat/lon boxes and adds a labeled
-  `region` axis to `stats.zarr`/`scores.zarr`. New optional per-member
-  metrics include MAE (`scoring.online.mae`) and log spectral distance
-  (`scoring.online.lsd`)
-
-### Changed
-
 - Pangu6 and Pangu3 build their extra ONNX sessions lazily and cache them
   on the model, instead of reconstructing them on every rollout call
 

--- a/recipes/eval/README.md
+++ b/recipes/eval/README.md
@@ -39,6 +39,7 @@ Key features:
   - [Model selection](#model-selection)
   - [Ensemble runs](#ensemble-runs)
   - [Scoring](#scoring)
+  - [Regional scoring](#regional-scoring)
   - [Online scoring](#online-scoring)
   - [Report](#report)
 - [Architecture](#architecture)
@@ -675,6 +676,40 @@ protocol can be specified via `_target_`.
 per-(time, lead_time) RMSE values.  To compute aggregate RMSE across
 all IC times, use `sqrt(mean(rmse²))` in post-processing (equivalent
 to `sqrt(mean(MSE))`).  The report step handles this automatically.
+
+### Regional scoring
+
+`scoring.regions` scores every configured region alongside the full
+grid and adds a labeled `region` axis to the score stores. Both
+pathways read the same block: the offline path masks each metric's
+weights per region, and the online path folds the masks into its
+accumulation weights.
+
+```yaml
+scoring:
+    regions:
+        global: null                                   # the whole grid
+        europe: {lat: [35, 75], lon: [-12.5, 42.5]}    # one box
+        extra_tropics:                                 # union of boxes
+            - {lat: [20, 90]}
+            - {lat: [-90, -20]}
+```
+
+A region is `null` for the whole grid, one box, or a list of boxes
+scored as their union. A box maps spatial dimension names to
+`[min, max]` coordinate ranges, so limited-area grids work the same way
+with their own dimension names, for example HRRR `y`/`x` coordinates.
+Dimensions left out of a box cover their full extent. Longitudes may
+be negative, meaning degrees west, and wrap the dateline where min
+exceeds max.
+
+The offline path applies regions at `score.py` time against the retained
+`forecast.zarr`, so re-scoring with new regions or metrics needs no new
+inference. The online path bakes the masks into the accumulated sums,
+so choose regions before the run. The offline path can only
+region-mask a metric that reduces over all spatial dimensions and takes
+a `weights` argument. Any other metric, such as a spectral one, scores
+the whole grid only.
 
 ### Online scoring
 

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -263,6 +263,9 @@ scoring:
         #   3. pairwise_comm_dtype / pairwise_variables — halve the bytes,
         #      or restrict CRPS to the variables you actually report on.
         crps: true
+        # Optional Mean Absolute Error and Log Spectral Distance per member.
+        mae: false
+        lsd: false
         pairwise_comm_dtype: bfloat16  # arithmetic upcasts to fp64 on arrival
         defer_pairwise_one_step: true  # overlap the exchange with the next step
         variable_chunk: 4              # variables per exchange + compute step
@@ -276,6 +279,8 @@ scoring:
         # point CONUS-scale run from ~1.5GB to well under 250MB, at some
         # throughput cost).
         pairwise_member_tile: 8
+        # Named regional splits.
+        regions: null
     output:
         store_name: scores.zarr
         overwrite: true

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -279,19 +279,23 @@ scoring:
         # point CONUS-scale run from ~1.5GB to well under 250MB, at some
         # throughput cost).
         pairwise_member_tile: 8
-        # Named regional splits: a mapping of region name to a lat/lon box
-        # (or a list of boxes, scored as their union). Adds a labeled
-        # "region" axis to stats.zarr/scores.zarr. A null box means the
-        # whole grid; longitudes may be negative (degrees west) and wrap
-        # the dateline where min > max.
-        #
-        # regions:
-        #     global: null
-        #     europe: {lat: [35, 75], lon: [-12.5, 42.5]}
-        #     extra_tropics:
-        #         - {lat: [20, 90], lon: [0, 360]}
-        #         - {lat: [-90, -20], lon: [0, 360]}
-        regions: null
+    # Named regional splits, used by BOTH scoring pathways (online and
+    # store-then-score): a mapping of region name to a box (or a list of
+    # boxes, scored as their union). A box maps spatial dimension names to
+    # [min, max] coordinate ranges — lat/lon degrees on a global grid, or
+    # the native grid coordinates of a limited-area model. Dimensions left
+    # out of a box cover their full extent; a null region means the whole
+    # grid. Longitudes may be negative (degrees west) and wrap the
+    # dateline where min > max. Adds a labeled "region" axis to the score
+    # stores.
+    #
+    # regions:
+    #     global: null
+    #     europe: {lat: [35, 75], lon: [-12.5, 42.5]}
+    #     extra_tropics:
+    #         - {lat: [20, 90]}
+    #         - {lat: [-90, -20]}
+    regions: null
     output:
         store_name: scores.zarr
         overwrite: true

--- a/recipes/eval/cfg/default.yaml
+++ b/recipes/eval/cfg/default.yaml
@@ -279,7 +279,18 @@ scoring:
         # point CONUS-scale run from ~1.5GB to well under 250MB, at some
         # throughput cost).
         pairwise_member_tile: 8
-        # Named regional splits.
+        # Named regional splits: a mapping of region name to a lat/lon box
+        # (or a list of boxes, scored as their union). Adds a labeled
+        # "region" axis to stats.zarr/scores.zarr. A null box means the
+        # whole grid; longitudes may be negative (degrees west) and wrap
+        # the dateline where min > max.
+        #
+        # regions:
+        #     global: null
+        #     europe: {lat: [35, 75], lon: [-12.5, 42.5]}
+        #     extra_tropics:
+        #         - {lat: [20, 90], lon: [0, 360]}
+        #         - {lat: [-90, -20], lon: [0, 360]}
         regions: null
     output:
         store_name: scores.zarr

--- a/recipes/eval/scorecard/README.md
+++ b/recipes/eval/scorecard/README.md
@@ -1,19 +1,31 @@
 # Scorecard
 
 Generates the source score JSON files behind the documentation's
-[Scorecards pages](../../../docs/scorecard). Each model is evaluated on the
-same campaign — 24 initial conditions (1st and 15th of each month of 2025,
-00 UTC), 14-day horizon, ERA5 verification via ARCO — using the eval recipe.
+[Scorecards pages](../../../docs/scorecard). Every model runs the same
+campaign: 48 initial conditions over a 14-day horizon, with ERA5
+verification through ARCO. The four monthly initial conditions rotate
+through the 00/06/12/18 UTC synoptic hours, so no lead time always
+verifies at the same local time.
+The campaigns use the evaluation recipe's **online scoring**: the inference
+loop reduces every forecast to a small set of statistics and never writes
+the raw forecast store.
+
+The scorecard computes every metric globally and for the regional splits in
+`cfg/regions/standard.yaml`. Any named lat/lon boxes work; that file is
+just the scorecard's choice. The exports also carry seasonal, monthly, and
+per-init-hour breakdowns, a per-initial-condition skill grid, and the
+persistence and climatology baseline campaigns.
 
 ## Layout
 
 ```text
 scorecard/
   cfg/campaign/<model>_2025_scorecard.yaml   self-contained evaluation campaigns
-  run_scorecard.py        predownload -> infer -> score -> prune
-  export_scores.py        scores.zarr -> exports/eval_scores_<model>.json
+  cfg/regions/standard.yaml     the regional splits every campaign shares
+  run_scorecard.py        predownload -> infer (scores online) -> score/prune
+  export_scores.py        scores.zarr -> exports/eval_scores_<model>*.json
   utils/pipelines.py      history / off-grid pipeline variants (see below)
-  models/<model>/outputs/ run data: forecast.zarr -> scores.zarr (not tracked)
+  models/<model>/outputs/ run data: stats.zarr + scores.zarr (not tracked)
   data/                   shared ERA5 stores (not tracked)
 ```
 
@@ -27,25 +39,47 @@ On a GPU node with the recipe environment:
 # 1. Run a campaign from cfg/campaign/
 python run_scorecard.py fcn3_2025_scorecard
 
-# 2. Export the scores JSON and copy it into the docs
+# 2. Export the scores JSONs and copy them into the docs
 python export_scores.py fcn3 --docs
 
 # 3. Regenerate the docs pages
 python ../../../docs/generate_scorecard.py
 ```
 
+The score JSONs are not stored in the git repository. The docs build
+fetches them from the `scorecard/` folder of the
+[Earth2Studio assets dataset](https://huggingface.co/datasets/nvidia/earth2studio-assets)
+on Hugging Face; files already present under `docs/_static/scorecard/`
+(for example, fresh local exports from step 2) take precedence, so the
+build works offline while iterating. To publish updated exports:
+
+```bash
+hf upload nvidia/earth2studio-assets docs/_static/scorecard scorecard \
+  --repo-type dataset --include "eval_scores_*.json"
+```
+
+Because the campaigns score online, the `infer` stage already derives
+`scores.zarr` from the accumulated `stats.zarr`. The `score` stage is a
+cheap idempotent re-derivation, and `prune` does nothing because no raw
+store exists.
+
 ## Scaling and portability
 
-Launches default to a single node (`torchrun --standalone`, all local GPUs);
-for multi-node runs set `TORCHRUN_ARGS` with your rendezvous flags, or invoke
-the recipe entry points (`predownload.py`, `main.py`, `score.py`) with your
-own launcher — the driver adds nothing they don't already support. All stages
-are resumable (`resume: true` in the campaigns), so large campaigns can be
-advanced incrementally across short queue allocations rather than needing one
-long job.
+Launches default to a single node (`torchrun --standalone`, all local
+GPUs). For multi-node runs, set `TORCHRUN_ARGS` with your rendezvous flags,
+or invoke the recipe entry points (`predownload.py`, `main.py`, `score.py`)
+with your own launcher; the driver adds nothing they do not already support.
+Every stage resumes (`resume: true` in the campaigns), so a large campaign
+can advance incrementally across short queue allocations rather than
+needing one long job.
 
-The JSON export carries everything a docs page needs — metric curves per variable
-and lead time (aggregated over initial conditions), units, and variable groups.
+The JSON exports carry everything a docs page needs: metric curves per
+variable and lead time aggregated over initial conditions, units, and
+variable groups. The exporter writes one file per regional split
+(`eval_scores_<model>_region_<name>.json`) plus monthly, hourly, and
+per-initial-condition grid files. The docs plot fetches these lazily when
+the matching selector is first used, so the initial page load only pays
+for the main file.
 
 Multiple campaigns per model are supported by construction: a campaign is just
 another self-contained config, and the docs plot selects its data file by URL

--- a/recipes/eval/src/online.py
+++ b/recipes/eval/src/online.py
@@ -2126,6 +2126,15 @@ def add_stats_arrays(
         :func:`finalize_stats` can reattach them as coordinate labels).
     """
     if region_names is not None:
+        existing = io.root.attrs.get("regions")
+        if existing is not None and list(existing) != list(region_names):
+            raise ValueError(
+                f"stats store already holds regions {list(existing)} but the "
+                f"current configuration defines {list(region_names)}. "
+                "Resuming would relabel previously accumulated statistics; "
+                "restore the original scoring.online.regions or clear the "
+                "run's output directory."
+            )
         io.root.attrs["regions"] = list(region_names)
     for coords, names in array_groups:
         shape = [len(io.coords[dim]) for dim in coords]

--- a/recipes/eval/src/online.py
+++ b/recipes/eval/src/online.py
@@ -45,9 +45,10 @@ properties follow:
 * Metrics derivable from the stored sums, and bootstrap CIs over ICs,
   remain possible after the fact without re-running inference. Spatial
   weighting (e.g. cosine-latitude weighting) is baked into the sums at
-  run time and applies to the whole grid; there is no per-region
-  weighting, so evaluating a different spatial region requires
-  re-running inference.
+  run time, so choose the set of spatial regions up front:
+  ``scoring.online.regions`` adds a ``region`` axis to every sum
+  (lat/lon boxes on the scored grid, masked into the weights), and
+  evaluating a region outside that set requires re-running inference.
 * Scope limited to a fixed set of metrics amenable to the above patterns.
   Users with custom metrics must still run offline.
 
@@ -64,6 +65,7 @@ Scope
 -----
 Per-member MSE, ensemble-mean MSE, ensemble variance / spread, rank
 histogram, bias / correlation / ACC, fair CRPS (via the member exchange),
+optional per-member MAE and log spectral distance, optional regional splits,
 and ``members_per_rank > 1`` on top of a member-batched rollout.
 """
 
@@ -121,6 +123,15 @@ _LAYOUT_DIMS: dict[str, tuple[str, ...]] = {
 }
 
 
+def _layout_dims(layout: str, n_regions: int) -> tuple[str, ...]:
+    """Store dims for *layout* — a ``region`` axis follows ``time`` when
+    the run configures regional splits, so per-IC slabs stay one chunk."""
+    dims = _LAYOUT_DIMS[layout]
+    if n_regions:
+        return (dims[0], "region", *dims[1:])
+    return dims
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -168,6 +179,19 @@ class OnlineSettings:
         needs field-sized member-to-member communication — everything else
         rides on spatially-reduced scalars — so it is the one knob that
         materially changes an online run's cost.
+    mae : bool
+        Accumulate per-member weighted absolute error (finalizes to
+        ``mae``, matching ``earth2studio.statistics.mae``).  Off by
+        default.
+    lsd : bool
+        Compute ``earth2studio.statistics.log_spectral_distance`` per
+        member and lead (finalizes to ``lsd``, in dB).  Configured as a
+        bool, or as ``{wavenumber_cutoff: N}`` to also set the cutoff.
+        Spectra are global by construction, so with ``regions`` configured
+        the values land only in whole-grid (``null``-box) regions; at
+        least one must exist.
+    lsd_wavenumber_cutoff : int | None
+        Optional radial-mode cutoff forwarded to the earth2studio metric.
     pairwise_comm_dtype : torch.dtype
         Wire dtype for the member exchange.  ``bfloat16`` halves the volume;
         the arithmetic upcasts to float64 immediately on arrival.  Safe
@@ -188,6 +212,13 @@ class OnlineSettings:
         all of them.  The moment-based statistics stay on the full set
         either way, so this trades CRPS coverage against the only expensive
         communication in the run.
+    regions : dict[str, list[dict] | None] | None
+        Named spatial splits.  ``None`` (the default) keeps the store
+        region-free.  Each entry is ``None`` (the whole grid), one
+        ``{lat: [min, max], lon: [min, max]}`` box on the scored grid, or
+        a list of boxes whose union defines the region; longitude boxes
+        may wrap (``min > max`` after normalizing to [0, 360)).
+        Every weighted sum gains a ``region`` axis.
     pairwise_member_tile : int
         Members per float64 abs-diff tile in :func:`_abs_diff_weighted_sum`
         — the scorer's own dominant memory term, and the one with no other
@@ -214,11 +245,15 @@ class OnlineSettings:
     validate_coords: bool
     nccl_timeout_s: int
     crps: bool
+    mae: bool
+    lsd: bool
+    lsd_wavenumber_cutoff: int | None
     pairwise_comm_dtype: torch.dtype
     defer_pairwise_one_step: bool
     variable_chunk: int
     pairwise_variables: list[str] | None
     pairwise_member_tile: int
+    regions: dict[str, list[dict] | None] | None
 
 
 def online_enabled(cfg: DictConfig) -> bool:
@@ -346,6 +381,34 @@ def parse_online_settings(cfg: DictConfig) -> OnlineSettings:
             f"{pairwise_member_tile}."
         )
 
+    regions = _parse_regions(block.get("regions", None))
+    lsd_cfg = block.get("lsd", False)
+    lsd_cutoff = None
+    if isinstance(lsd_cfg, (dict, DictConfig)):
+        lsd_opts = (
+            OmegaConf.to_container(lsd_cfg, resolve=True)
+            if isinstance(lsd_cfg, DictConfig)
+            else dict(lsd_cfg)
+        )
+        unknown = set(lsd_opts) - {"wavenumber_cutoff"}
+        if unknown:
+            raise ValueError(
+                f"Unknown scoring.online.lsd option(s) {sorted(unknown)}; "
+                "expected only 'wavenumber_cutoff'."
+            )
+        lsd = True
+        if lsd_opts.get("wavenumber_cutoff") is not None:
+            lsd_cutoff = int(lsd_opts["wavenumber_cutoff"])
+    else:
+        lsd = bool(lsd_cfg)
+    if lsd and regions is not None and not any(v is None for v in regions.values()):
+        raise ValueError(
+            "scoring.online.lsd needs a whole-grid region (an entry with a "
+            "null box) to land its values in — spectra cannot be computed "
+            "on a lat/lon sub-box.  Add e.g. 'global: null' to "
+            "scoring.online.regions."
+        )
+
     group_size = block.get("ensemble_group_size", None)
     return OnlineSettings(
         ensemble_group_size=None if group_size is None else int(group_size),
@@ -367,7 +430,65 @@ def parse_online_settings(cfg: DictConfig) -> OnlineSettings:
         variable_chunk=variable_chunk,
         pairwise_variables=pairwise_variables,
         pairwise_member_tile=pairwise_member_tile,
+        regions=regions,
+        mae=bool(block.get("mae", False)),
+        lsd=lsd,
+        lsd_wavenumber_cutoff=lsd_cutoff,
     )
+
+
+def _parse_regions(value: Any) -> dict[str, list[dict] | None] | None:
+    """Check and normalize the ``scoring.online.regions`` block.
+
+    Each region is ``null`` (whole grid), one ``{lat, lon}`` box, or a
+    LIST of boxes whose union defines the region (e.g. the extra-tropics
+    as both ``|lat| >= 20`` bands).  The parser turns single boxes into
+    one-element lists so the weight builder handles one shape.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DictConfig):
+        value = OmegaConf.to_container(value, resolve=True)
+    if not isinstance(value, dict) or not value:
+        raise ValueError(
+            "scoring.online.regions must be a non-empty mapping of "
+            "name -> null | {lat: [min, max], lon: [min, max]} | list of "
+            "such boxes (their union)."
+        )
+
+    def _one_box(name: str, spec: Any) -> dict:
+        if not isinstance(spec, dict) or set(spec) != {"lat", "lon"}:
+            raise ValueError(
+                f"Region '{name}' boxes need exactly 'lat' and 'lon' keys; "
+                f"got {spec!r}."
+            )
+        box: dict[str, list[float]] = {}
+        for key in ("lat", "lon"):
+            bounds = [float(b) for b in spec[key]]
+            if len(bounds) != 2:
+                raise ValueError(
+                    f"Region '{name}': '{key}' must be [min, max]; got {spec[key]!r}."
+                )
+            box[key] = bounds
+        lat_lo, lat_hi = box["lat"]
+        if not (-90.0 <= lat_lo < lat_hi <= 90.0):
+            raise ValueError(
+                f"Region '{name}': lat bounds must satisfy "
+                f"-90 <= min < max <= 90; got {box['lat']}."
+            )
+        return box
+
+    out: dict[str, list[dict] | None] = {}
+    for name, spec in value.items():
+        if spec is None:
+            out[str(name)] = None
+        elif isinstance(spec, list):
+            if not spec:
+                raise ValueError(f"Region '{name}': box list must be non-empty.")
+            out[str(name)] = [_one_box(str(name), b) for b in spec]
+        else:
+            out[str(name)] = [_one_box(str(name), spec)]
+    return out
 
 
 def _int_or(value: Any, default: int) -> int:
@@ -805,7 +926,13 @@ class StepContext:
     d_local : torch.Tensor
         ``f_local - y``, precomputed once (every statistic wants it).
     weights : torch.Tensor
-        Spatial weights broadcastable over the spatial dims.
+        Spatial weights.  Region-free runs: broadcastable over the spatial
+        dims.  With regions configured: ``[region, <spatial...>]``, the
+        latitude weights multiplied by each region's mask.
+    w_flat : torch.Tensor | None
+        ``None`` for region-free runs.  Otherwise the same weights
+        flattened to ``[n_spatial_points, region]`` so :meth:`wsum` is one
+        matmul; its output then carries a trailing ``region`` axis.
     valid : torch.Tensor
         Boolean ``[variable, <spatial...>]`` mask, ``True`` where every
         member's *original* (pre-``nan_policy``) forecast was finite.  A
@@ -843,9 +970,15 @@ class StepContext:
     ensemble_size: int
     member_ids: tuple[int, ...]
     comm: GroupComm
+    w_flat: torch.Tensor | None = None
     s1: torch.Tensor | None = None
     s2: torch.Tensor | None = None
     below: torch.Tensor | None = None
+
+    @property
+    def n_regions(self) -> int:
+        """Number of configured regions; 0 keeps the store region-free."""
+        return 0 if self.w_flat is None else self.w_flat.shape[-1]
 
     def wsum(self, t: torch.Tensor) -> torch.Tensor:
         """Weighted sum of *t* over its trailing spatial dimensions.
@@ -854,9 +987,15 @@ class StepContext:
         excluded — treated as absent, not zero — regardless of what *t*
         actually holds there (NaN under ``nan_policy=propagate``, or a
         finite but meaningless value under ``zero_fill``).
+
+        With regions configured the result carries a trailing ``region``
+        axis (one masked reduction per region, via a single matmul).
         """
-        axes = tuple(range(t.ndim - self.n_spatial, t.ndim))
         td = torch.where(self.valid, t.double(), 0.0)
+        if self.w_flat is not None:
+            lead = td.shape[: td.ndim - self.n_spatial]
+            return td.reshape(*lead, -1) @ self.w_flat
+        axes = tuple(range(t.ndim - self.n_spatial, t.ndim))
         return (td * self.weights).sum(dim=axes)
 
     def wsum_valid(self) -> torch.Tensor:
@@ -864,8 +1003,12 @@ class StepContext:
         weighted-mean normalizer for whatever :meth:`wsum` excluded.
         Equals the old constant ``sum(weights)`` wherever nothing is
         masked."""
+        vd = self.valid.double()
+        if self.w_flat is not None:
+            lead = vd.shape[: vd.ndim - self.n_spatial]
+            return vd.reshape(*lead, -1) @ self.w_flat
         axes = tuple(range(self.valid.ndim - self.n_spatial, self.valid.ndim))
-        return (self.valid.double() * self.weights).sum(dim=axes)
+        return (vd * self.weights).sum(dim=axes)
 
 
 class OnlineStatistic(Protocol):
@@ -894,8 +1037,13 @@ class OnlineStatistic(Protocol):
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        """Allocate per-IC buffers for a fresh initial condition."""
+        """Create per-IC buffers for a fresh initial condition.
+
+        ``n_regions > 0`` prepends a region axis to every buffer,
+        matching the trailing region axis :meth:`StepContext.wsum`
+        produces."""
         ...
 
     def update(self, ctx: StepContext) -> None:
@@ -930,6 +1078,12 @@ def _empty(*shape: int | torch.device) -> torch.Tensor:
     )
 
 
+def _region_first(value: torch.Tensor, n_regions: int) -> torch.Tensor:
+    """Move :meth:`StepContext.wsum`'s trailing region axis to the front,
+    matching the buffer layout; identity for region-free runs."""
+    return value.movedim(-1, 0) if n_regions else value
+
+
 class WeightSum:
     """The weighted-mean normalizer ``W = sum_s w``.
 
@@ -956,13 +1110,17 @@ class WeightSum:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._w = _empty(n_leads, n_variables, device)
+        self._nr = n_regions
+        self._w = _empty(
+            *((n_regions,) if n_regions else ()), n_leads, n_variables, device
+        )
 
     def update(self, ctx: StepContext) -> None:
         if not ctx.comm.is_root:
             return
-        self._w[ctx.lead_index, :] = ctx.wsum_valid()
+        self._w[..., ctx.lead_index, :] = _region_first(ctx.wsum_valid(), self._nr)
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"w_sum": self._w}
@@ -991,23 +1149,189 @@ class MemberSquaredError:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._sse = _empty(ensemble_size, n_leads, n_variables, device)
+        self._nr = n_regions
+        self._sse = _empty(
+            *((n_regions,) if n_regions else ()),
+            ensemble_size,
+            n_leads,
+            n_variables,
+            device,
+        )
 
     def update(self, ctx: StepContext) -> None:
         block = torch.zeros(
-            (ctx.ensemble_size, self._sse.shape[-1]),
+            (ctx.ensemble_size, self._sse.shape[-1])
+            + ((self._nr,) if self._nr else ()),
             dtype=torch.float64,
             device=self._sse.device,
         )
-        block[list(ctx.member_ids), :] = ctx.wsum(ctx.d_local**2)  # [K, variable]
+        block[list(ctx.member_ids)] = ctx.wsum(
+            ctx.d_local**2
+        )  # [K, variable(, region)]
         ctx.comm.reduce(block)
 
         if ctx.comm.is_root:
-            self._sse[:, ctx.lead_index, :] = block
+            # [M, var(, R)] -> buffer slice [(R,) M, var]
+            self._sse[..., ctx.lead_index, :] = _region_first(block, self._nr)
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"sse_member": self._sse}
+
+
+class MemberAbsError:
+    """Per-member weighted sum of absolute error (finalizes to ``mae``).
+
+    Same communication shape as :class:`MemberSquaredError`: entirely
+    local per member, one small zero-padded ``[M, variable]`` reduce.
+    Enabled by ``scoring.online.mae``.
+    """
+
+    name = "member_mae"
+
+    def requires(self) -> set[str]:
+        return set()
+
+    def fields(self) -> dict[str, str]:
+        return {"sae_member": _LAYOUT_MEMBER}
+
+    def reset(
+        self,
+        n_leads: int,
+        n_variables: int,
+        ensemble_size: int,
+        device: torch.device,
+        n_regions: int = 0,
+    ) -> None:
+        self._nr = n_regions
+        self._sae = _empty(
+            *((n_regions,) if n_regions else ()),
+            ensemble_size,
+            n_leads,
+            n_variables,
+            device,
+        )
+
+    def update(self, ctx: StepContext) -> None:
+        block = torch.zeros(
+            (ctx.ensemble_size, self._sae.shape[-1])
+            + ((self._nr,) if self._nr else ()),
+            dtype=torch.float64,
+            device=self._sae.device,
+        )
+        block[list(ctx.member_ids)] = ctx.wsum(ctx.d_local.abs())
+        ctx.comm.reduce(block)
+        if ctx.comm.is_root:
+            self._sae[..., ctx.lead_index, :] = _region_first(block, self._nr)
+
+    def state(self) -> dict[str, torch.Tensor]:
+        return {"sae_member": self._sae}
+
+
+class LogSpectralDistance:
+    """Per-member radially averaged 2D log spectral distance vs verification.
+
+    Delegates the whole computation — radial power spectra, optional
+    wavenumber cutoff, and the dB form — to
+    ``earth2studio.statistics.log_spectral_distance``; this class
+    reimplements nothing.  Unlike every other field in the store this is a
+    *final* per-(IC, member, lead) value rather than a mergeable sum — its
+    aggregation over ICs is a plain mean, so storing the value keeps it
+    exact.  Spectra are global by construction: with regions configured
+    the values land only in whole-grid (``null``-box) regions and stay NaN
+    elsewhere.  Enabled by ``scoring.online.lsd``.
+
+    Parameters
+    ----------
+    whole_grid_regions : Sequence[int] | None
+        Region indices with a ``null`` box, or ``None`` when the run is
+        region-free.
+    wavenumber_cutoff : int | None
+        Forwarded to the earth2studio metric: keep only the first N radial
+        modes (negative trims from the end; ``None`` uses all).
+    """
+
+    name = "lsd"
+
+    def __init__(
+        self,
+        whole_grid_regions: Sequence[int] | None = None,
+        wavenumber_cutoff: int | None = None,
+    ) -> None:
+        from earth2studio.statistics import log_spectral_distance
+
+        self._metric = log_spectral_distance(
+            reduction_dimensions=[],
+            ensemble_dimension="ensemble",
+            wavenumber_cutoff=wavenumber_cutoff,
+        )
+        self._whole_grid = (
+            None if whole_grid_regions is None else list(whole_grid_regions)
+        )
+
+    def requires(self) -> set[str]:
+        return set()
+
+    def fields(self) -> dict[str, str]:
+        return {"lsd": _LAYOUT_MEMBER}
+
+    def reset(
+        self,
+        n_leads: int,
+        n_variables: int,
+        ensemble_size: int,
+        device: torch.device,
+        n_regions: int = 0,
+    ) -> None:
+        self._nr = n_regions
+        self._lsd = _empty(
+            *((n_regions,) if n_regions else ()),
+            ensemble_size,
+            n_leads,
+            n_variables,
+            device,
+        )
+
+    def update(self, ctx: StepContext) -> None:
+        if ctx.n_spatial != 2:
+            raise ValueError(
+                "scoring.online.lsd needs a 2D (lat, lon) spatial grid; "
+                f"got {ctx.n_spatial} spatial dimensions."
+            )
+        # Entirely local per member.  The metric only uses the coordinate
+        # system to check x/y compatibility, so index coords suffice.
+        n_var = ctx.f_local.shape[1]
+        y_coords: CoordSystem = OrderedDict(
+            {
+                "variable": np.arange(n_var),
+                "ilat": np.arange(ctx.f_local.shape[-2]),
+                "ilon": np.arange(ctx.f_local.shape[-1]),
+            }
+        )
+        x_coords: CoordSystem = OrderedDict(
+            {"ensemble": np.array(ctx.member_ids), **y_coords}
+        )
+        values, _ = self._metric(ctx.f_local, x_coords, ctx.y, y_coords)
+        values = values.double()  # [K, variable]
+
+        block = torch.zeros(
+            (ctx.ensemble_size, self._lsd.shape[-1]),
+            dtype=torch.float64,
+            device=self._lsd.device,
+        )
+        block[list(ctx.member_ids), :] = values
+        ctx.comm.reduce(block)
+        if not ctx.comm.is_root:
+            return
+        if self._nr:
+            for r in self._whole_grid or []:
+                self._lsd[r, :, ctx.lead_index, :] = block
+        else:
+            self._lsd[:, ctx.lead_index, :] = block
+
+    def state(self) -> dict[str, torch.Tensor]:
+        return {"lsd": self._lsd}
 
 
 class EnsembleMeanSquaredError:
@@ -1032,8 +1356,12 @@ class EnsembleMeanSquaredError:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._sse = _empty(n_leads, n_variables, device)
+        self._nr = n_regions
+        self._sse = _empty(
+            *((n_regions,) if n_regions else ()), n_leads, n_variables, device
+        )
 
     def update(self, ctx: StepContext) -> None:
         if not ctx.comm.is_root:
@@ -1044,7 +1372,9 @@ class EnsembleMeanSquaredError:
                 "before this accumulator's update() runs."
             )
         mean_dev = ctx.s1 / ctx.ensemble_size
-        self._sse[ctx.lead_index, :] = ctx.wsum(mean_dev**2)
+        self._sse[..., ctx.lead_index, :] = _region_first(
+            ctx.wsum(mean_dev**2), self._nr
+        )
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"sse_ensmean": self._sse}
@@ -1074,8 +1404,12 @@ class EnsembleSpread:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._var = _empty(n_leads, n_variables, device)
+        self._nr = n_regions
+        self._var = _empty(
+            *((n_regions,) if n_regions else ()), n_leads, n_variables, device
+        )
 
     def update(self, ctx: StepContext) -> None:
         if not ctx.comm.is_root:
@@ -1087,7 +1421,7 @@ class EnsembleSpread:
             )
         m = ctx.ensemble_size
         var = (ctx.s2 - ctx.s1**2 / m) / (m - 1)
-        self._var[ctx.lead_index, :] = ctx.wsum(var)
+        self._var[..., ctx.lead_index, :] = _region_first(ctx.wsum(var), self._nr)
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"var_ens": self._var}
@@ -1119,8 +1453,16 @@ class RankHistogram:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._counts = _empty(ensemble_size + 1, n_leads, n_variables, device)
+        self._nr = n_regions
+        self._counts = _empty(
+            *((n_regions,) if n_regions else ()),
+            ensemble_size + 1,
+            n_leads,
+            n_variables,
+            device,
+        )
 
     def update(self, ctx: StepContext) -> None:
         if not ctx.comm.is_root:
@@ -1130,7 +1472,7 @@ class RankHistogram:
                 "StepContext.below is unset — 'rank_counts' must be "
                 "requested before this accumulator's update() runs."
             )
-        n_bins, _, n_variables = self._counts.shape
+        n_bins, _, n_variables = self._counts.shape[-3:]
         device = self._counts.device
 
         # `below` is meaningless at a masked gridpoint — NaN < y is always
@@ -1140,17 +1482,27 @@ class RankHistogram:
         # bin at all; `ctx.valid` was captured before nan_policy could
         # have replaced the NaN with something that compares "normally".
         ranks = ctx.below.reshape(n_variables, -1).long()
-        w_flat = (
-            ctx.weights.expand(ctx.y.shape[1:])
-            .reshape(1, -1)
-            .expand(n_variables, -1)
-            .contiguous()
-        )
         valid_flat = ctx.valid.reshape(n_variables, -1)
-        w_flat = torch.where(valid_flat, w_flat, 0.0)
-        hist = torch.zeros((n_variables, n_bins), dtype=torch.float64, device=device)
-        hist.scatter_add_(1, ranks, w_flat)
-        self._counts[:, ctx.lead_index, :] = hist.transpose(0, 1)
+        # One weight row per region (the region-free run is one region of
+        # everything); scatter_add per region keeps the kernel simple.
+        if self._nr:
+            region_weights = ctx.weights.reshape(self._nr, 1, -1)
+        else:
+            region_weights = (
+                ctx.weights.expand(ctx.y.shape[1:]).reshape(1, 1, -1).contiguous()
+            )
+        for r in range(region_weights.shape[0]):
+            w_flat = torch.where(
+                valid_flat, region_weights[r].expand(n_variables, -1), 0.0
+            )
+            hist = torch.zeros(
+                (n_variables, n_bins), dtype=torch.float64, device=device
+            )
+            hist.scatter_add_(1, ranks, w_flat)
+            if self._nr:
+                self._counts[r, :, ctx.lead_index, :] = hist.transpose(0, 1)
+            else:
+                self._counts[:, ctx.lead_index, :] = hist.transpose(0, 1)
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"rank_counts": self._counts}
@@ -1195,8 +1547,15 @@ class AnomalyMoments:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
-        self._buf = {name: _empty(n_leads, n_variables, device) for name in self._names}
+        self._nr = n_regions
+        self._buf = {
+            name: _empty(
+                *((n_regions,) if n_regions else ()), n_leads, n_variables, device
+            )
+            for name in self._names
+        }
 
     def update(self, ctx: StepContext) -> None:
         if not ctx.comm.is_root:
@@ -1217,11 +1576,14 @@ class AnomalyMoments:
 
         i = ctx.lead_index
         n = self._names
-        self._buf[n[0]][i, :] = ctx.wsum(fbar)
-        self._buf[n[1]][i, :] = ctx.wsum(obs)
-        self._buf[n[2]][i, :] = ctx.wsum(fbar**2)
-        self._buf[n[3]][i, :] = ctx.wsum(obs**2)
-        self._buf[n[4]][i, :] = ctx.wsum(fbar * obs)
+        for name, term in (
+            (n[0], fbar),
+            (n[1], obs),
+            (n[2], fbar**2),
+            (n[3], obs**2),
+            (n[4], fbar * obs),
+        ):
+            self._buf[name][..., i, :] = _region_first(ctx.wsum(term), self._nr)
 
     def state(self) -> dict[str, torch.Tensor]:
         return dict(self._buf)
@@ -1245,6 +1607,7 @@ def _abs_diff_weighted_sum(
     weights: torch.Tensor,
     n_spatial: int,
     member_tile: int = _PAIRWISE_MEMBER_TILE,
+    w_flat: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """``sum_{i in local} sum_{j in other} sum_s w_s |f_i(s) - f_j(s)|``.
 
@@ -1269,21 +1632,32 @@ def _abs_diff_weighted_sum(
         Members of *other* per tile — bounds the float64 working set.
         Defaults to :data:`_PAIRWISE_MEMBER_TILE`; runs pass
         ``settings.pairwise_member_tile`` explicitly.
+    w_flat : torch.Tensor | None
+        Regional weights ``[n_spatial_points, region]`` (see
+        :attr:`StepContext.w_flat`).  When set the spatial reduction is a
+        matmul against it and the result carries a region axis.
 
     Returns
     -------
     torch.Tensor
-        Float64 ``[variable]`` tensor.
+        Float64 ``[variable]`` tensor (``[variable, region]`` regional).
     """
     axes = tuple(range(local.ndim - n_spatial, local.ndim))
-    out = torch.zeros(local.shape[1], dtype=torch.float64, device=local.device)
+    out_shape: tuple[int, ...] = (local.shape[1],)
+    if w_flat is not None:
+        out_shape = (local.shape[1], w_flat.shape[-1])
+    out = torch.zeros(out_shape, dtype=torch.float64, device=local.device)
     for i in range(local.shape[0]):
         a = local[i].double()
         for j0 in range(0, other.shape[0], member_tile):
             tile = other[j0 : j0 + member_tile].double()
             diff = (a.unsqueeze(0) - tile).abs_()
-            diff.mul_(weights)
-            out += diff.sum(dim=axes).sum(dim=0)
+            if w_flat is not None:
+                flat = diff.reshape(diff.shape[0], diff.shape[1], -1)
+                out += (flat @ w_flat).sum(dim=0)
+            else:
+                diff.mul_(weights)
+                out += diff.sum(dim=axes).sum(dim=0)
     return out
 
 
@@ -1432,9 +1806,10 @@ class PairwiseExchange:
         if pending is None:
             return None
 
-        total = torch.zeros(
-            len(self._var_index), dtype=torch.float64, device=ctx.d_local.device
-        )
+        out_shape: tuple[int, ...] = (len(self._var_index),)
+        if ctx.w_flat is not None:
+            out_shape = (len(self._var_index), ctx.n_regions)
+        total = torch.zeros(out_shape, dtype=torch.float64, device=ctx.d_local.device)
         offset = 0
         for local, buffers, handle in zip(
             pending.local_chunks, pending.gathered, pending.work
@@ -1449,6 +1824,7 @@ class PairwiseExchange:
                 ctx.weights,
                 ctx.n_spatial,
                 member_tile=self._settings.pairwise_member_tile,
+                w_flat=ctx.w_flat,
             )
             offset += width
 
@@ -1514,10 +1890,13 @@ class FairCRPS:
         n_variables: int,
         ensemble_size: int,
         device: torch.device,
+        n_regions: int = 0,
     ) -> None:
+        self._nr = n_regions
         n = len(self._variables)
-        self._t1 = _empty(n_leads, n, device)
-        self._t2 = _empty(n_leads, n, device)
+        dims = (n_regions,) if n_regions else ()
+        self._t1 = _empty(*dims, n_leads, n, device)
+        self._t2 = _empty(*dims, n_leads, n, device)
 
     def update(self, ctx: StepContext) -> None:
         index = torch.tensor(
@@ -1529,12 +1908,18 @@ class FairCRPS:
         # narrower) pairwise `self._variables` subset, so masking must
         # happen before index_select — same order PairwiseExchange._submit
         # uses for term 2 — rather than after, via ctx.wsum.
-        d_local = torch.where(ctx.valid, ctx.d_local, 0.0).index_select(1, index).abs()
-        axes = tuple(range(d_local.ndim - ctx.n_spatial, d_local.ndim))
-        t1 = (d_local.double() * ctx.weights).sum(dim=axes).sum(dim=0)
+        d_local = (
+            torch.where(ctx.valid, ctx.d_local, 0.0).index_select(1, index).abs()
+        ).double()
+        if ctx.w_flat is not None:
+            flat = d_local.reshape(d_local.shape[0], d_local.shape[1], -1)
+            t1 = (flat @ ctx.w_flat).sum(dim=0)  # [var_sub, region]
+        else:
+            axes = tuple(range(d_local.ndim - ctx.n_spatial, d_local.ndim))
+            t1 = (d_local * ctx.weights).sum(dim=axes).sum(dim=0)
         ctx.comm.reduce(t1)
         if ctx.comm.is_root:
-            self._t1[ctx.lead_index, :] = t1
+            self._t1[..., ctx.lead_index, :] = _region_first(t1, self._nr)
 
         # Term 2: the member exchange, possibly resolving an earlier step.
         self._store_pairwise(ctx, self._exchange.step(ctx))
@@ -1549,7 +1934,7 @@ class FairCRPS:
         if result is None or not ctx.comm.is_root:
             return
         lead_index, values = result
-        self._t2[lead_index, :] = values
+        self._t2[..., lead_index, :] = _region_first(values, self._nr)
 
     def state(self) -> dict[str, torch.Tensor]:
         return {"crps_t1": self._t1, "crps_t2": self._t2}
@@ -1604,6 +1989,20 @@ def build_statistics(
         stats.extend([MemberSquaredError(), EnsembleSpread(), RankHistogram()])
     stats.append(AnomalyMoments(anomaly=has_climatology))
 
+    if settings is not None and settings.mae:
+        stats.append(MemberAbsError())
+    if settings is not None and settings.lsd:
+        whole_grid = None
+        if settings.regions is not None:
+            whole_grid = [
+                i for i, spec in enumerate(settings.regions.values()) if spec is None
+            ]
+        stats.append(
+            LogSpectralDistance(
+                whole_grid, wavenumber_cutoff=settings.lsd_wavenumber_cutoff
+            )
+        )
+
     if ensemble_size > 1 and settings is not None and settings.crps:
         if variables is None:
             raise ValueError(
@@ -1624,6 +2023,7 @@ def stats_array_groups(
     times: np.ndarray,
     lead_times: np.ndarray,
     ensemble_size: int,
+    region_names: Sequence[str] | None = None,
 ) -> tuple[CoordSystem, list[tuple[CoordSystem, list[str]]]]:
     """Build the ``stats.zarr`` schema for the configured statistics.
 
@@ -1645,14 +2045,21 @@ def stats_array_groups(
         All lead times in the forecast.
     ensemble_size : int
         Ensemble size ``M`` (sets the ``ensemble`` and ``rank_bin`` axes).
+    region_names : Sequence[str] | None
+        Names of the configured regional splits; every array gains a
+        ``region`` axis, whose integer indices map to names kept in the
+        store's attributes (:func:`finalize_stats` reattaches them).
+        ``None`` keeps the store region-free.
 
     Returns
     -------
     tuple[CoordSystem, list[tuple[CoordSystem, list[str]]]]
         ``(superset_coords, array_groups)``.
     """
+    n_regions = 0 if region_names is None else len(region_names)
     axes: dict[str, np.ndarray] = {
         "time": times,
+        "region": np.arange(n_regions),
         "ensemble": np.arange(ensemble_size),
         "rank_bin": np.arange(ensemble_size + 1),
         "lead_time": lead_times,
@@ -1670,8 +2077,11 @@ def stats_array_groups(
             )
 
     superset: CoordSystem = OrderedDict()
-    for dim in ("time", "ensemble", "rank_bin", "lead_time"):
-        if dim in ("time", "lead_time") or any(
+    for dim in ("time", "region", "ensemble", "rank_bin", "lead_time"):
+        if dim == "region":
+            if n_regions:
+                superset[dim] = axes[dim]
+        elif dim in ("time", "lead_time") or any(
             dim in _LAYOUT_DIMS[layout] for layout in used_layouts
         ):
             superset[dim] = axes[dim]
@@ -1682,7 +2092,7 @@ def stats_array_groups(
         if not names:
             continue
         coords: CoordSystem = OrderedDict(
-            (dim, axes[dim]) for dim in _LAYOUT_DIMS[layout]
+            (dim, axes[dim]) for dim in _layout_dims(layout, n_regions)
         )
         groups.append((coords, names))
     return superset, groups
@@ -1691,6 +2101,7 @@ def stats_array_groups(
 def add_stats_arrays(
     io: Any,
     array_groups: list[tuple[CoordSystem, list[str]]],
+    region_names: Sequence[str] | None = None,
 ) -> None:
     """Create the ``stats.zarr`` data arrays, skipping any that exist.
 
@@ -1709,7 +2120,13 @@ def add_stats_arrays(
         Backend from ``OutputManager.io``.
     array_groups : list[tuple[CoordSystem, list[str]]]
         Groups from :func:`stats_array_groups`.
+    region_names : Sequence[str] | None
+        Regional split names, recorded in the store's attributes so the
+        integer ``region`` axis stays interpretable (and so
+        :func:`finalize_stats` can reattach them as coordinate labels).
     """
+    if region_names is not None:
+        io.root.attrs["regions"] = list(region_names)
     for coords, names in array_groups:
         shape = [len(io.coords[dim]) for dim in coords]
         chunks = [io.chunks.get(dim, len(io.coords[dim])) for dim in coords]
@@ -1764,14 +2181,15 @@ def open_stats_store(
     all groups have finished writing.
     """
     settings = parse_online_settings(cfg)
+    region_names = None if settings.regions is None else list(settings.regions)
     superset, groups = stats_array_groups(
-        statistics, variables, times, lead_times, ensemble_size
+        statistics, variables, times, lead_times, ensemble_size, region_names
     )
     mgr = OutputManager(
         cfg, store_name=settings.stats_store, chunks={"time": 1}, io_backend="zarr"
     )
     mgr.validate_output_store(superset, [])
-    run_on_rank0_first(add_stats_arrays, mgr.io, groups)
+    run_on_rank0_first(add_stats_arrays, mgr.io, groups, region_names)
     return mgr
 
 
@@ -1857,6 +2275,15 @@ class OnlineScorer:
         )
         self._spatial_dims = tuple(d for d in spatial_coords if d not in _NON_SPATIAL)
         self._weights = weights.to(device=device, dtype=torch.float64)
+        # Regional runs carry the weights twice: full-shaped for the rank
+        # histogram, and flattened [n_points, region] for the matmul path
+        # every other reduction takes (see StepContext.w_flat).
+        self._n_regions = 0 if settings.regions is None else len(settings.regions)
+        self._w_flat = (
+            self._weights.reshape(self._n_regions, -1).T.contiguous()
+            if self._n_regions
+            else None
+        )
         self._stats_mgr = stats_mgr
         self._device = device
 
@@ -1907,6 +2334,7 @@ class OnlineScorer:
                 len(self._variables),
                 self._ensemble_size,
                 self._device,
+                n_regions=self._n_regions,
             )
 
     def update(self, x: torch.Tensor, coords: CoordSystem) -> None:
@@ -1994,6 +2422,7 @@ class OnlineScorer:
             ensemble_size=self._ensemble_size,
             member_ids=self._comm.group.member_ids,
             comm=self._comm,
+            w_flat=self._w_flat,
         )
 
     # ------------------------------------------------------------------
@@ -2163,6 +2592,7 @@ class OnlineScorer:
             ensemble_size=self._ensemble_size,
             member_ids=self._comm.group.member_ids,
             comm=self._comm,
+            w_flat=self._w_flat,
         )
         self._materialize(ctx)
         for stat in self._statistics:
@@ -2197,6 +2627,8 @@ class OnlineScorer:
 
     def _axis_values(self, dim: str) -> np.ndarray:
         """Coordinate values of a statistics-store axis."""
+        if dim == "region":
+            return np.arange(self._n_regions)
         if dim == "ensemble":
             return np.arange(self._ensemble_size)
         if dim == "rank_bin":
@@ -2232,12 +2664,13 @@ class OnlineScorer:
                 parts.append(tensor)
 
             # (lead, var) -> (1, lead, n_names); (extra, lead, var) ->
-            # (1, extra, lead, n_names).
+            # (1, extra, lead, n_names); a leading region axis on the
+            # buffers slots in the same way.
             data = torch.cat(parts, dim=-1).unsqueeze(0).cpu()
 
             write_coords: CoordSystem = OrderedDict()
             write_coords["time"] = np.array([time])
-            for dim in _LAYOUT_DIMS[layout][1:]:
+            for dim in _layout_dims(layout, self._n_regions)[1:]:
                 write_coords[dim] = self._axis_values(dim)
             write_coords["variable"] = np.array(names)
             self._stats_mgr.write(data, write_coords)
@@ -2246,14 +2679,18 @@ class OnlineScorer:
 def build_spatial_weights(
     spatial_coords: CoordSystem,
     lat_weights: bool,
+    regions: dict[str, list[dict] | None] | None = None,
 ) -> torch.Tensor:
     """Build the spatial weight tensor for online reductions.
 
     Mirrors the offline scorer's weighting: cosine-latitude weights when
     ``scoring.lat_weights`` is set and the grid has a ``lat`` dimension,
-    uniform weights otherwise.  The returned tensor has one axis per
-    spatial dimension so it broadcasts against ``[..., <spatial...>]``
-    tensors.
+    uniform weights otherwise.  Region-free, the returned tensor has one
+    axis per spatial dimension so it broadcasts against
+    ``[..., <spatial...>]`` tensors.  With ``regions`` configured the
+    tensor becomes ``[region, <spatial...>]``: the same weights multiplied
+    by each region's {0, 1} mask, evaluated on the actual scored grid so
+    box edges land exactly on gridpoints.
 
     Parameters
     ----------
@@ -2261,22 +2698,83 @@ def build_spatial_weights(
         Spatial coordinate arrays of the scored grid.
     lat_weights : bool
         Whether to apply cosine-latitude weighting.
+    regions : dict[str, list[dict] | None] | None
+        Parsed ``scoring.online.regions`` (see :func:`_parse_regions`).
 
     Returns
     -------
     torch.Tensor
-        Float64 weights broadcastable over the spatial dims.
+        Float64 weights (broadcastable, or full-shaped per region).
     """
     dims = [d for d in spatial_coords if d not in _NON_SPATIAL]
     shape = [1] * len(dims)
 
-    if not lat_weights or "lat" not in dims:
-        return torch.ones(shape, dtype=torch.float64)
+    if lat_weights and "lat" in dims:
+        lat_vals = np.asarray(spatial_coords["lat"])
+        w = lat_weight(torch.tensor(lat_vals, dtype=torch.float64))
+        shape[dims.index("lat")] = len(lat_vals)
+        base = w.reshape(shape)
+    else:
+        base = torch.ones(shape, dtype=torch.float64)
 
-    lat_vals = np.asarray(spatial_coords["lat"])
-    w = lat_weight(torch.tensor(lat_vals, dtype=torch.float64))
-    shape[dims.index("lat")] = len(lat_vals)
-    return w.reshape(shape)
+    if regions is None:
+        return base
+
+    if "lat" not in dims or "lon" not in dims:
+        raise ValueError(
+            "scoring.online.regions needs 'lat' and 'lon' spatial "
+            f"dimensions on the scored grid; got {dims}."
+        )
+    full_shape = [len(np.asarray(spatial_coords[d])) for d in dims]
+    lat = torch.tensor(np.asarray(spatial_coords["lat"]), dtype=torch.float64)
+    lon = torch.tensor(np.asarray(spatial_coords["lon"]), dtype=torch.float64)
+
+    def _box_mask(spec: dict) -> torch.Tensor:
+        lat_lo, lat_hi = spec["lat"]
+        lat_mask = (lat >= lat_lo) & (lat <= lat_hi)
+        # Longitudes compare on [0, 360); a box whose normalized min
+        # exceeds its max wraps across the dateline/meridian, and a
+        # span of >= 360 degrees means every longitude (a [0, 360]
+        # bound must not normalize into an empty span).
+        lon_n = lon % 360.0
+        if spec["lon"][1] - spec["lon"][0] >= 360.0:
+            lon_mask = torch.ones_like(lon_n, dtype=torch.bool)
+        else:
+            lon_lo, lon_hi = (b % 360.0 for b in spec["lon"])
+            if lon_lo <= lon_hi:
+                lon_mask = (lon_n >= lon_lo) & (lon_n <= lon_hi)
+            else:
+                lon_mask = (lon_n >= lon_lo) | (lon_n <= lon_hi)
+        mask = torch.ones(full_shape, dtype=torch.float64)
+        for axis, axis_mask in (
+            (dims.index("lat"), lat_mask),
+            (dims.index("lon"), lon_mask),
+        ):
+            view = [1] * len(dims)
+            view[axis] = -1
+            mask = mask * axis_mask.double().reshape(view)
+        return mask
+
+    stacked = []
+    for name, spec in regions.items():
+        if spec is None:
+            mask = torch.ones(full_shape, dtype=torch.float64)
+        else:
+            # A region is the union of its boxes (e.g. the extra-tropics
+            # as both |lat| >= 20 bands).  _parse_regions normalizes single
+            # boxes to one-element lists; accept a bare box here too so
+            # direct callers keep working.
+            boxes = spec if isinstance(spec, (list, tuple)) else [spec]
+            mask = torch.zeros(full_shape, dtype=torch.float64)
+            for box in boxes:
+                mask = torch.maximum(mask, _box_mask(box))
+        if spec is not None and not mask.any():
+            raise ValueError(
+                f"Region '{name}' selects no gridpoints on the scored "
+                "grid — check its lat/lon boxes."
+            )
+        stacked.append(base.expand(full_shape) * mask)
+    return torch.stack(stacked, dim=0)
 
 
 # ---------------------------------------------------------------------------
@@ -2304,6 +2802,14 @@ def _finalize_variable(
 
     if f"var_ens__{var}" in ds:
         out[f"ensemble_variance__{var}"] = ds[f"var_ens__{var}"] / w
+
+    # Optional per-member additions (scoring.online.mae / .lsd).  The
+    # store keeps LSD as a final per-(IC, member, lead) value rather than
+    # a sum — its IC aggregation is a plain mean, so nothing normalizes it.
+    if f"sae_member__{var}" in ds:
+        out[f"mae__{var}"] = ds[f"sae_member__{var}"] / w
+    if f"lsd__{var}" in ds:
+        out[f"lsd__{var}"] = ds[f"lsd__{var}"]
 
     # Fair CRPS.  t1 and t2 are stored as raw weighted sums over members
     # and pairs respectively, so the normalization lives here:
@@ -2397,7 +2903,13 @@ def finalize_stats(cfg: DictConfig) -> str:
     ``bias__{v}``               mean forecast minus mean verification
     ``corr__{v}``               centered spatial Pearson correlation
     ``acc__{v}``                anomaly correlation (climatology only)
+    ``mae__{v}``                per-member MAE (``scoring.online.mae``)
+    ``lsd__{v}``                per-member log spectral distance, dB
+                                (``scoring.online.lsd``)
     ==========================  =========================================
+
+    With ``scoring.online.regions`` configured every array carries a
+    ``region`` axis, labeled with the configured region names.
 
     Spread and SSR are not written: the report derives them from
     ``ensemble_mean_mse`` and ``ensemble_variance`` with the correct
@@ -2430,6 +2942,11 @@ def finalize_stats(cfg: DictConfig) -> str:
 
     ds = xr.open_zarr(stats_path)
     ensemble_size = int(ds.sizes.get("ensemble", 1))
+    # Regional runs store the region axis as integer indices; the names
+    # live in the store attributes and become coordinate labels here.
+    region_names = ds.attrs.get("regions")
+    if region_names is not None and "region" in ds.dims:
+        ds = ds.assign_coords(region=np.array([str(r) for r in region_names]))
     variables = sorted(
         {str(name).split("__", 1)[1] for name in ds.data_vars if "__" in str(name)}
     )
@@ -2441,6 +2958,8 @@ def finalize_stats(cfg: DictConfig) -> str:
     # Statistics for ICs that were never run stay NaN rather than being
     # silently dropped, matching the offline scorer's partial-run behavior.
     scores = xr.Dataset(arrays).compute()
+    if region_names is not None:
+        scores.attrs["regions"] = list(region_names)
     # Rebuild from scratch: the derived metric set depends on what is in
     # stats.zarr (member breakdown, rank counts, climatology), so an
     # in-place overwrite could leave stale arrays from an earlier config.
@@ -2539,7 +3058,9 @@ def build_online_scorer(
         )
 
     weights = build_spatial_weights(
-        spatial_coords, bool(cfg.scoring.get("lat_weights", False))
+        spatial_coords,
+        bool(cfg.scoring.get("lat_weights", False)),
+        regions=settings.regions,
     )
 
     return OnlineScorer(

--- a/recipes/eval/src/online.py
+++ b/recipes/eval/src/online.py
@@ -46,9 +46,10 @@ properties follow:
   remain possible after the fact without re-running inference. Spatial
   weighting (e.g. cosine-latitude weighting) is baked into the sums at
   run time, so choose the set of spatial regions up front:
-  ``scoring.online.regions`` adds a ``region`` axis to every sum
-  (lat/lon boxes on the scored grid, masked into the weights), and
-  evaluating a region outside that set requires re-running inference.
+  ``scoring.regions`` adds a ``region`` axis to every sum (boxes on the
+  scored grid, masked into the weights), and evaluating a region outside
+  that set requires re-running inference (or offline scoring against a
+  retained forecast store).
 * Scope limited to a fixed set of metrics amenable to the above patterns.
   Users with custom metrics must still run offline.
 
@@ -88,11 +89,15 @@ from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
 from earth2studio.data import DataSource
-from earth2studio.statistics.weights import lat_weight
 from earth2studio.utils.coords import CoordSystem
 
 from .distributed import run_on_rank0_first
 from .output import OutputManager
+from .regions import (
+    NON_SPATIAL,
+    build_spatial_weights,
+    parse_regions,
+)
 from .scoring import _apply_valid_ranges
 from .work import (
     EnsembleGroup,
@@ -103,7 +108,7 @@ from .work import (
 )
 
 # Dimensions that never take part in the spatial reduction.
-_NON_SPATIAL = frozenset({"batch", "time", "lead_time", "variable", "ensemble"})
+_NON_SPATIAL = NON_SPATIAL  # shared spatial-dim filter (src.regions)
 
 # Group products materialized once per lead step, in this fixed order, for
 # the union of every configured statistic's `requires()`.  Ordering matters:
@@ -381,7 +386,8 @@ def parse_online_settings(cfg: DictConfig) -> OnlineSettings:
             f"{pairwise_member_tile}."
         )
 
-    regions = _parse_regions(block.get("regions", None))
+    # Regions live at scoring.regions — shared with the offline pathway.
+    regions = parse_regions(cfg.scoring.get("regions", None))
     lsd_cfg = block.get("lsd", False)
     lsd_cutoff = None
     if isinstance(lsd_cfg, (dict, DictConfig)):
@@ -405,8 +411,8 @@ def parse_online_settings(cfg: DictConfig) -> OnlineSettings:
         raise ValueError(
             "scoring.online.lsd needs a whole-grid region (an entry with a "
             "null box) to land its values in — spectra cannot be computed "
-            "on a lat/lon sub-box.  Add e.g. 'global: null' to "
-            "scoring.online.regions."
+            "on a spatial sub-box.  Add e.g. 'global: null' to "
+            "scoring.regions."
         )
 
     group_size = block.get("ensemble_group_size", None)
@@ -435,60 +441,6 @@ def parse_online_settings(cfg: DictConfig) -> OnlineSettings:
         lsd=lsd,
         lsd_wavenumber_cutoff=lsd_cutoff,
     )
-
-
-def _parse_regions(value: Any) -> dict[str, list[dict] | None] | None:
-    """Check and normalize the ``scoring.online.regions`` block.
-
-    Each region is ``null`` (whole grid), one ``{lat, lon}`` box, or a
-    LIST of boxes whose union defines the region (e.g. the extra-tropics
-    as both ``|lat| >= 20`` bands).  The parser turns single boxes into
-    one-element lists so the weight builder handles one shape.
-    """
-    if value is None:
-        return None
-    if isinstance(value, DictConfig):
-        value = OmegaConf.to_container(value, resolve=True)
-    if not isinstance(value, dict) or not value:
-        raise ValueError(
-            "scoring.online.regions must be a non-empty mapping of "
-            "name -> null | {lat: [min, max], lon: [min, max]} | list of "
-            "such boxes (their union)."
-        )
-
-    def _one_box(name: str, spec: Any) -> dict:
-        if not isinstance(spec, dict) or set(spec) != {"lat", "lon"}:
-            raise ValueError(
-                f"Region '{name}' boxes need exactly 'lat' and 'lon' keys; "
-                f"got {spec!r}."
-            )
-        box: dict[str, list[float]] = {}
-        for key in ("lat", "lon"):
-            bounds = [float(b) for b in spec[key]]
-            if len(bounds) != 2:
-                raise ValueError(
-                    f"Region '{name}': '{key}' must be [min, max]; got {spec[key]!r}."
-                )
-            box[key] = bounds
-        lat_lo, lat_hi = box["lat"]
-        if not (-90.0 <= lat_lo < lat_hi <= 90.0):
-            raise ValueError(
-                f"Region '{name}': lat bounds must satisfy "
-                f"-90 <= min < max <= 90; got {box['lat']}."
-            )
-        return box
-
-    out: dict[str, list[dict] | None] = {}
-    for name, spec in value.items():
-        if spec is None:
-            out[str(name)] = None
-        elif isinstance(spec, list):
-            if not spec:
-                raise ValueError(f"Region '{name}': box list must be non-empty.")
-            out[str(name)] = [_one_box(str(name), b) for b in spec]
-        else:
-            out[str(name)] = [_one_box(str(name), spec)]
-    return out
 
 
 def _int_or(value: Any, default: int) -> int:
@@ -2132,7 +2084,7 @@ def add_stats_arrays(
                 f"stats store already holds regions {list(existing)} but the "
                 f"current configuration defines {list(region_names)}. "
                 "Resuming would relabel previously accumulated statistics; "
-                "restore the original scoring.online.regions or clear the "
+                "restore the original scoring.regions or clear the "
                 "run's output directory."
             )
         io.root.attrs["regions"] = list(region_names)
@@ -2685,107 +2637,6 @@ class OnlineScorer:
             self._stats_mgr.write(data, write_coords)
 
 
-def build_spatial_weights(
-    spatial_coords: CoordSystem,
-    lat_weights: bool,
-    regions: dict[str, list[dict] | None] | None = None,
-) -> torch.Tensor:
-    """Build the spatial weight tensor for online reductions.
-
-    Mirrors the offline scorer's weighting: cosine-latitude weights when
-    ``scoring.lat_weights`` is set and the grid has a ``lat`` dimension,
-    uniform weights otherwise.  Region-free, the returned tensor has one
-    axis per spatial dimension so it broadcasts against
-    ``[..., <spatial...>]`` tensors.  With ``regions`` configured the
-    tensor becomes ``[region, <spatial...>]``: the same weights multiplied
-    by each region's {0, 1} mask, evaluated on the actual scored grid so
-    box edges land exactly on gridpoints.
-
-    Parameters
-    ----------
-    spatial_coords : CoordSystem
-        Spatial coordinate arrays of the scored grid.
-    lat_weights : bool
-        Whether to apply cosine-latitude weighting.
-    regions : dict[str, list[dict] | None] | None
-        Parsed ``scoring.online.regions`` (see :func:`_parse_regions`).
-
-    Returns
-    -------
-    torch.Tensor
-        Float64 weights (broadcastable, or full-shaped per region).
-    """
-    dims = [d for d in spatial_coords if d not in _NON_SPATIAL]
-    shape = [1] * len(dims)
-
-    if lat_weights and "lat" in dims:
-        lat_vals = np.asarray(spatial_coords["lat"])
-        w = lat_weight(torch.tensor(lat_vals, dtype=torch.float64))
-        shape[dims.index("lat")] = len(lat_vals)
-        base = w.reshape(shape)
-    else:
-        base = torch.ones(shape, dtype=torch.float64)
-
-    if regions is None:
-        return base
-
-    if "lat" not in dims or "lon" not in dims:
-        raise ValueError(
-            "scoring.online.regions needs 'lat' and 'lon' spatial "
-            f"dimensions on the scored grid; got {dims}."
-        )
-    full_shape = [len(np.asarray(spatial_coords[d])) for d in dims]
-    lat = torch.tensor(np.asarray(spatial_coords["lat"]), dtype=torch.float64)
-    lon = torch.tensor(np.asarray(spatial_coords["lon"]), dtype=torch.float64)
-
-    def _box_mask(spec: dict) -> torch.Tensor:
-        lat_lo, lat_hi = spec["lat"]
-        lat_mask = (lat >= lat_lo) & (lat <= lat_hi)
-        # Longitudes compare on [0, 360); a box whose normalized min
-        # exceeds its max wraps across the dateline/meridian, and a
-        # span of >= 360 degrees means every longitude (a [0, 360]
-        # bound must not normalize into an empty span).
-        lon_n = lon % 360.0
-        if spec["lon"][1] - spec["lon"][0] >= 360.0:
-            lon_mask = torch.ones_like(lon_n, dtype=torch.bool)
-        else:
-            lon_lo, lon_hi = (b % 360.0 for b in spec["lon"])
-            if lon_lo <= lon_hi:
-                lon_mask = (lon_n >= lon_lo) & (lon_n <= lon_hi)
-            else:
-                lon_mask = (lon_n >= lon_lo) | (lon_n <= lon_hi)
-        mask = torch.ones(full_shape, dtype=torch.float64)
-        for axis, axis_mask in (
-            (dims.index("lat"), lat_mask),
-            (dims.index("lon"), lon_mask),
-        ):
-            view = [1] * len(dims)
-            view[axis] = -1
-            mask = mask * axis_mask.double().reshape(view)
-        return mask
-
-    stacked = []
-    for name, spec in regions.items():
-        if spec is None:
-            mask = torch.ones(full_shape, dtype=torch.float64)
-        else:
-            # A region is the union of its boxes (e.g. the extra-tropics
-            # as both |lat| >= 20 bands).  _parse_regions normalizes single
-            # boxes to one-element lists; accept a bare box here too so
-            # direct callers keep working.
-            boxes = spec if isinstance(spec, (list, tuple)) else [spec]
-            mask = torch.zeros(full_shape, dtype=torch.float64)
-            for box in boxes:
-                mask = torch.maximum(mask, _box_mask(box))
-        if spec is not None and not mask.any():
-            raise ValueError(
-                f"Region '{name}' selects no gridpoints on the scored "
-                "grid — check its lat/lon boxes."
-            )
-        stacked.append(base.expand(full_shape) * mask)
-    return torch.stack(stacked, dim=0)
-
-
 # ---------------------------------------------------------------------------
 # Finalize: stats.zarr -> scores.zarr
 # ---------------------------------------------------------------------------
@@ -2917,7 +2768,7 @@ def finalize_stats(cfg: DictConfig) -> str:
                                 (``scoring.online.lsd``)
     ==========================  =========================================
 
-    With ``scoring.online.regions`` configured every array carries a
+    With ``scoring.regions`` configured every array carries a
     ``region`` axis, labeled with the configured region names.
 
     Spread and SSR are not written: the report derives them from

--- a/recipes/eval/src/regions.py
+++ b/recipes/eval/src/regions.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Named regional splits, shared by both scoring pathways.
+
+The ``scoring.regions`` config block maps region names to rectangular
+boxes on the scored grid.  A box maps spatial dimension names to
+``[min, max]`` ranges in that dimension's coordinate values — ``lat``/
+``lon`` degrees on a global grid, or projection/index coordinates on a
+limited-area grid.  Dimensions left out of a box cover their full
+extent.  A region may also be ``null`` (the whole grid) or a LIST of
+boxes scored as their union (e.g. the extra-tropics as both
+``|lat| >= 20`` bands).
+
+Two special cases apply to geographic dimension names:
+
+* ``lon`` compares on the [0, 360) circle — negative bounds mean degrees
+  west, a box whose normalized min exceeds its max wraps across the
+  dateline, and a span of 360 degrees or more means every longitude.
+* ``lat`` bounds must lie in [-90, 90].
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any
+
+import numpy as np
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from earth2studio.statistics.weights import lat_weight
+from earth2studio.utils.type import CoordSystem
+
+# Dimensions that never count as spatial when scanning a grid's
+# coordinate system for its spatial axes.
+NON_SPATIAL = frozenset({"batch", "time", "lead_time", "variable", "ensemble"})
+
+
+def spatial_dims(spatial_coords: CoordSystem) -> list[str]:
+    """Return the spatial dimension names of a coordinate system."""
+    return [d for d in spatial_coords if d not in NON_SPATIAL]
+
+
+def parse_regions(value: Any) -> dict[str, list[dict] | None] | None:
+    """Check and normalize the ``scoring.regions`` block.
+
+    Each region is ``null`` (whole grid), one box, or a LIST of boxes
+    whose union defines the region.  A box maps spatial dimension names
+    to ``[min, max]`` coordinate ranges; dimensions left out cover their
+    full extent.  The parser turns single boxes into one-element lists so
+    the mask builder handles one shape.  :func:`region_masks` checks box
+    dimensions against the scored grid later, once the grid exists.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DictConfig):
+        value = OmegaConf.to_container(value, resolve=True)
+    if not isinstance(value, dict) or not value:
+        raise ValueError(
+            "scoring.regions must be a non-empty mapping of "
+            "name -> null | {<dim>: [min, max], ...} | list of such boxes "
+            "(their union)."
+        )
+
+    def _one_box(name: str, spec: Any) -> dict:
+        if not isinstance(spec, dict) or not spec:
+            raise ValueError(
+                f"Region '{name}' boxes must map spatial dimension names to "
+                f"[min, max] ranges; got {spec!r}."
+            )
+        box: dict[str, list[float]] = {}
+        for key, bounds_in in spec.items():
+            try:
+                bounds = [float(b) for b in bounds_in]
+            except (TypeError, ValueError) as err:
+                raise ValueError(
+                    f"Region '{name}': '{key}' must be [min, max]; "
+                    f"got {bounds_in!r}."
+                ) from err
+            if len(bounds) != 2:
+                raise ValueError(
+                    f"Region '{name}': '{key}' must be [min, max]; "
+                    f"got {bounds_in!r}."
+                )
+            box[str(key)] = bounds
+        if "lat" in box:
+            lat_lo, lat_hi = box["lat"]
+            if not (-90.0 <= lat_lo < lat_hi <= 90.0):
+                raise ValueError(
+                    f"Region '{name}': lat bounds must satisfy "
+                    f"-90 <= min < max <= 90; got {box['lat']}."
+                )
+        for key, (lo, hi) in box.items():
+            # lon may wrap (min > max means crossing the dateline); every
+            # other dimension is an ordinary interval.
+            if key != "lon" and lo >= hi:
+                raise ValueError(
+                    f"Region '{name}': '{key}' must satisfy min < max; "
+                    f"got [{lo}, {hi}]."
+                )
+        return box
+
+    out: dict[str, list[dict] | None] = {}
+    for name, spec in value.items():
+        if spec is None:
+            out[str(name)] = None
+        elif isinstance(spec, list):
+            if not spec:
+                raise ValueError(f"Region '{name}': box list must be non-empty.")
+            out[str(name)] = [_one_box(str(name), b) for b in spec]
+        else:
+            out[str(name)] = [_one_box(str(name), spec)]
+    return out
+
+
+def region_masks(
+    spatial_coords: CoordSystem,
+    regions: dict[str, list[dict] | None],
+) -> "OrderedDict[str, torch.Tensor]":
+    """Compute each region's {0, 1} mask on the scored grid.
+
+    Parameters
+    ----------
+    spatial_coords : CoordSystem
+        Spatial coordinate arrays of the scored grid (1D per dimension).
+    regions : dict[str, list[dict] | None]
+        Parsed ``scoring.regions`` (see :func:`parse_regions`).
+
+    Returns
+    -------
+    OrderedDict[str, torch.Tensor]
+        Float64 mask of the full spatial shape per region, in config
+        order.
+
+    Raises
+    ------
+    ValueError
+        If a box names a dimension the grid does not have, or a region
+        selects no gridpoints.
+    """
+    dims = spatial_dims(spatial_coords)
+    full_shape = [len(np.asarray(spatial_coords[d])) for d in dims]
+    axes = {
+        d: torch.tensor(np.asarray(spatial_coords[d]), dtype=torch.float64)
+        for d in dims
+    }
+
+    def _box_mask(name: str, spec: dict) -> torch.Tensor:
+        unknown = sorted(set(spec) - set(dims))
+        if unknown:
+            raise ValueError(
+                f"Region '{name}' uses dimensions {unknown} that are not "
+                f"spatial dimensions of the scored grid; got {dims}."
+            )
+        mask = torch.ones(full_shape, dtype=torch.float64)
+        for key, (lo, hi) in spec.items():
+            vals = axes[key]
+            if key == "lon":
+                # Longitudes compare on [0, 360); a box whose normalized
+                # min exceeds its max wraps across the dateline/meridian,
+                # and a span of >= 360 degrees means every longitude (a
+                # [0, 360] bound must not normalize into an empty span).
+                vals_n = vals % 360.0
+                if hi - lo >= 360.0:
+                    axis_mask = torch.ones_like(vals_n, dtype=torch.bool)
+                else:
+                    lon_lo, lon_hi = lo % 360.0, hi % 360.0
+                    if lon_lo <= lon_hi:
+                        axis_mask = (vals_n >= lon_lo) & (vals_n <= lon_hi)
+                    else:
+                        axis_mask = (vals_n >= lon_lo) | (vals_n <= lon_hi)
+            else:
+                axis_mask = (vals >= lo) & (vals <= hi)
+            view = [1] * len(dims)
+            view[dims.index(key)] = -1
+            mask = mask * axis_mask.double().reshape(view)
+        return mask
+
+    out: "OrderedDict[str, torch.Tensor]" = OrderedDict()
+    for name, spec in regions.items():
+        if spec is None:
+            mask = torch.ones(full_shape, dtype=torch.float64)
+        else:
+            # A region is the union of its boxes.  parse_regions
+            # normalizes single boxes to one-element lists; accept a bare
+            # box here too so direct callers keep working.
+            boxes = spec if isinstance(spec, (list, tuple)) else [spec]
+            mask = torch.zeros(full_shape, dtype=torch.float64)
+            for box in boxes:
+                mask = torch.maximum(mask, _box_mask(name, box))
+        if spec is not None and not mask.any():
+            raise ValueError(
+                f"Region '{name}' selects no gridpoints on the scored "
+                "grid — check its boxes."
+            )
+        out[name] = mask
+    return out
+
+
+def build_spatial_weights(
+    spatial_coords: CoordSystem,
+    lat_weights: bool,
+    regions: dict[str, list[dict] | None] | None = None,
+) -> torch.Tensor:
+    """Build the spatial weight tensor for online reductions.
+
+    Mirrors the offline scorer's weighting: cosine-latitude weights when
+    ``scoring.lat_weights`` is true and the grid has a ``lat`` dimension,
+    uniform weights otherwise.  Region-free, the returned tensor has one
+    axis per spatial dimension so it broadcasts against
+    ``[..., <spatial...>]`` tensors.  With ``regions`` configured the
+    tensor becomes ``[region, <spatial...>]``: the same weights multiplied
+    by each region's {0, 1} mask, evaluated on the actual scored grid so
+    box edges land exactly on gridpoints.
+
+    Parameters
+    ----------
+    spatial_coords : CoordSystem
+        Spatial coordinate arrays of the scored grid.
+    lat_weights : bool
+        Whether to apply cosine-latitude weighting.
+    regions : dict[str, list[dict] | None] | None
+        Parsed ``scoring.regions`` (see :func:`parse_regions`).
+
+    Returns
+    -------
+    torch.Tensor
+        Float64 weights (broadcastable, or full-shaped per region).
+    """
+    dims = spatial_dims(spatial_coords)
+    shape = [1] * len(dims)
+
+    if lat_weights and "lat" in dims:
+        lat_vals = np.asarray(spatial_coords["lat"])
+        w = lat_weight(torch.tensor(lat_vals, dtype=torch.float64))
+        shape[dims.index("lat")] = len(lat_vals)
+        base = w.reshape(shape)
+    else:
+        base = torch.ones(shape, dtype=torch.float64)
+
+    if regions is None:
+        return base
+
+    full_shape = [len(np.asarray(spatial_coords[d])) for d in dims]
+    masks = region_masks(spatial_coords, regions)
+    return torch.stack(
+        [base.expand(full_shape) * mask for mask in masks.values()], dim=0
+    )

--- a/recipes/eval/src/regions.py
+++ b/recipes/eval/src/regions.py
@@ -130,7 +130,7 @@ def parse_regions(value: Any) -> dict[str, list[dict] | None] | None:
 def region_masks(
     spatial_coords: CoordSystem,
     regions: dict[str, list[dict] | None],
-) -> "OrderedDict[str, torch.Tensor]":
+) -> OrderedDict[str, torch.Tensor]:
     """Compute each region's {0, 1} mask on the scored grid.
 
     Parameters
@@ -190,7 +190,7 @@ def region_masks(
             mask = mask * axis_mask.double().reshape(view)
         return mask
 
-    out: "OrderedDict[str, torch.Tensor]" = OrderedDict()
+    out: OrderedDict[str, torch.Tensor] = OrderedDict()
     for name, spec in regions.items():
         if spec is None:
             mask = torch.ones(full_shape, dtype=torch.float64)

--- a/recipes/eval/src/report/aggregation.py
+++ b/recipes/eval/src/report/aggregation.py
@@ -111,7 +111,21 @@ def load_scores(cfg: DictConfig) -> xr.Dataset:
             "Run scoring (score.py) before generating a report."
         )
     logger.info(f"Opened score store: {store_path}")
-    return xr.open_zarr(store_path)
+    ds = xr.open_zarr(store_path)
+    if "region" in ds.dims:
+        labels = [str(r) for r in ds.region.values]
+        pick = str(
+            cfg.get("report", {}).get(
+                "region", "global" if "global" in labels else labels[0]
+            )
+        )
+        if pick not in labels:
+            raise ValueError(
+                f"report.region '{pick}' is not in the store's regions {labels}."
+            )
+        logger.info(f"Score store has regional splits {labels}; using '{pick}'.")
+        ds = ds.sel(region=pick)
+    return ds
 
 
 def parse_score_arrays(

--- a/recipes/eval/src/scoring.py
+++ b/recipes/eval/src/scoring.py
@@ -101,7 +101,7 @@ class RegionalMetric:
         Metric instances keyed by region name, in config order.
     """
 
-    def __init__(self, per_region: "OrderedDict[str, Any]") -> None:
+    def __init__(self, per_region: OrderedDict[str, Any]) -> None:
         self._per_region = per_region
         first = next(iter(per_region.values()))
         self.reduction_dimensions = first.reduction_dimensions

--- a/recipes/eval/src/scoring.py
+++ b/recipes/eval/src/scoring.py
@@ -45,6 +45,7 @@ from earth2studio.utils.coords import CoordSystem
 
 from .distributed import get_rank
 from .output import OutputManager
+from .regions import parse_regions, region_masks, spatial_dims
 from .work import write_scoring_marker
 
 # Dimensions that are never spatial.
@@ -85,6 +86,78 @@ def _is_statistic(obj: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+class RegionalMetric:
+    """One metric applied per named region, stacked on a ``region`` axis.
+
+    Wraps per-region instances of the same underlying metric (each built
+    with region-masked weights) behind the Metric protocol, so the store
+    schema, chunking validation, and write path treat it as any other
+    metric — its output simply carries a leading string-labeled ``region``
+    dimension.
+
+    Parameters
+    ----------
+    per_region : OrderedDict[str, Any]
+        Metric instances keyed by region name, in config order.
+    """
+
+    def __init__(self, per_region: "OrderedDict[str, Any]") -> None:
+        self._per_region = per_region
+        first = next(iter(per_region.values()))
+        self.reduction_dimensions = first.reduction_dimensions
+        self._inner_is_statistic = _is_statistic(first)
+
+    def _region_coords(self, inner: CoordSystem) -> CoordSystem:
+        coords: CoordSystem = OrderedDict()
+        coords["region"] = np.array(list(self._per_region))
+        coords.update(inner)
+        return coords
+
+    def output_coords(self, input_coords: CoordSystem) -> CoordSystem:
+        """Inner metric's output coords behind a leading ``region`` axis."""
+        first = next(iter(self._per_region.values()))
+        return self._region_coords(first.output_coords(input_coords))
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        x_coords: CoordSystem,
+        y: torch.Tensor | None = None,
+        y_coords: CoordSystem | None = None,
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """Apply every region's instance and stack the results."""
+        values = []
+        inner_coords: CoordSystem = OrderedDict()
+        for metric in self._per_region.values():
+            if self._inner_is_statistic:
+                value, inner_coords = metric(x, x_coords)
+            else:
+                value, inner_coords = metric(x, x_coords, y, y_coords)
+            values.append(value)
+        return torch.stack(values, dim=0), self._region_coords(inner_coords)
+
+
+def _embed_mask(
+    mask: torch.Tensor,
+    red_dims: list[str],
+    spatial_coords: CoordSystem,
+) -> torch.Tensor:
+    """Reshape a spatial-shaped region mask onto a metric's reduction dims.
+
+    The mask carries one axis per spatial dimension (grid order, and not
+    separable for union regions); the metric wants weights with exactly one
+    axis per reduction dimension.  Permute the mask's axes into reduction
+    order and insert size-1 axes for non-spatial reduction dims.
+    """
+    dims = spatial_dims(spatial_coords)
+    perm = [dims.index(d) for d in red_dims if d in dims]
+    out = mask.permute(perm)
+    for i, d in enumerate(red_dims):
+        if d not in dims:
+            out = out.unsqueeze(i)
+    return out
+
+
 def instantiate_metrics(
     cfg: DictConfig,
     spatial_coords: CoordSystem,
@@ -96,14 +169,18 @@ def instantiate_metrics(
     metric's ``reduction_dimensions``, cosine latitude weights are injected
     automatically.
 
+    With ``scoring.regions``, every metric that reduces over all spatial
+    dimensions and accepts a ``weights`` argument becomes a
+    :class:`RegionalMetric` - adding a labeled ``region`` axis to its scores.
+
     Parameters
     ----------
     cfg : DictConfig
-        Full Hydra config (reads ``cfg.scoring.metrics`` and
-        ``cfg.scoring.lat_weights``).
+        Full Hydra config (reads ``cfg.scoring.metrics``,
+        ``cfg.scoring.lat_weights`` and ``cfg.scoring.regions``).
     spatial_coords : CoordSystem
         Spatial coordinate arrays from the prediction store (used to
-        compute latitude weights).
+        compute latitude weights and region masks).
 
     Returns
     -------
@@ -111,12 +188,16 @@ def instantiate_metrics(
         Metric instances keyed by their config name.
     """
     use_lat_weights = cfg.scoring.get("lat_weights", False)
+    regions = parse_regions(cfg.scoring.get("regions", None))
+    masks = region_masks(spatial_coords, regions) if regions is not None else None
+    grid_dims = spatial_dims(spatial_coords)
     metrics: OrderedDict = OrderedDict()
 
     for name, metric_cfg in cfg.scoring.metrics.items():
         cfg_dict: dict = OmegaConf.to_container(metric_cfg, resolve=True)
         target = cfg_dict.pop("_target_")
         cls = hydra.utils.get_class(target)
+        red_dims = list(cfg_dict.get("reduction_dimensions", []))
 
         # Inject cosine latitude weights when appropriate.
         # Weights must have exactly len(reduction_dimensions) dims with
@@ -124,12 +205,11 @@ def instantiate_metrics(
         if (
             use_lat_weights
             and "lat" in spatial_coords
-            and "lat" in cfg_dict.get("reduction_dimensions", [])
+            and "lat" in red_dims
             and "weights" not in cfg_dict
         ):
             lat_vals = spatial_coords["lat"]
             weights_1d = lat_weight(torch.tensor(lat_vals, dtype=torch.float32))
-            red_dims = cfg_dict["reduction_dimensions"]
             shape = [
                 len(spatial_coords[d]) if d in spatial_coords else 1 for d in red_dims
             ]
@@ -141,8 +221,43 @@ def instantiate_metrics(
             weights = weights * weights_1d.reshape(view_shape)
             cfg_dict["weights"] = weights
 
-        metrics[name] = cls(**cfg_dict)
-        logger.info(f"Instantiated metric '{name}': {target}")
+        # Region-mask the metric when it can carry the masking: it must
+        # reduce over every spatial dimension (a partial spatial reduction
+        # would leave masked-out gridpoints in the output) and take a
+        # weights argument to fold the mask into.
+        regional = (
+            masks is not None
+            and set(grid_dims) <= set(red_dims)
+            and "weights" in inspect.signature(cls.__init__).parameters
+        )
+        if masks is not None and not regional:
+            logger.warning(
+                f"Metric '{name}' cannot be region-masked (needs a 'weights' "
+                "argument and a full spatial reduction) — scored on the "
+                "whole grid only."
+            )
+
+        if regional:
+            base = cfg_dict.pop("weights", None)
+            if base is None:
+                base = torch.ones(
+                    [
+                        len(spatial_coords[d]) if d in spatial_coords else 1
+                        for d in red_dims
+                    ]
+                )
+            per_region: OrderedDict = OrderedDict()
+            for region_name, mask in masks.items():
+                embedded = _embed_mask(mask, red_dims, spatial_coords).to(base.dtype)
+                per_region[region_name] = cls(**cfg_dict, weights=base * embedded)
+            metrics[name] = RegionalMetric(per_region)
+            logger.info(
+                f"Instantiated metric '{name}': {target} "
+                f"({len(per_region)} regions)"
+            )
+        else:
+            metrics[name] = cls(**cfg_dict)
+            logger.info(f"Instantiated metric '{name}': {target}")
 
     return metrics
 

--- a/recipes/eval/src/scoring.py
+++ b/recipes/eval/src/scoring.py
@@ -225,19 +225,18 @@ def instantiate_metrics(
         # reduce over every spatial dimension (a partial spatial reduction
         # would leave masked-out gridpoints in the output) and take a
         # weights argument to fold the mask into.
-        regional = (
-            masks is not None
-            and set(grid_dims) <= set(red_dims)
+        maskable = (
+            set(grid_dims) <= set(red_dims)
             and "weights" in inspect.signature(cls.__init__).parameters
         )
-        if masks is not None and not regional:
+        if masks is not None and not maskable:
             logger.warning(
                 f"Metric '{name}' cannot be region-masked (needs a 'weights' "
                 "argument and a full spatial reduction) — scored on the "
                 "whole grid only."
             )
 
-        if regional:
+        if masks is not None and maskable:
             base = cfg_dict.pop("weights", None)
             if base is None:
                 base = torch.ones(

--- a/recipes/eval/src/work.py
+++ b/recipes/eval/src/work.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+import errno
 import shutil
 import struct
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
@@ -359,10 +361,10 @@ def _remove_progress_dir(directory: Path) -> None:
     entries disappear underneath it — ``shutil.rmtree`` then raises
     ``FileNotFoundError`` partway through and may leave the rest behind.
 
-    A missing entry is the desired end state, so retry until the directory
-    is actually gone.  This converges immediately in practice: nothing
-    writes markers while a clear is in flight (markers are only written
-    during the run, after the store-creation barriers).
+    A missing entry is the desired end state, so retry with a short
+    backoff until the directory no longer exists. The backoff gives the winning
+    peer time to finish its in-flight ``rmtree``, and since nothing
+    writes markers while a clear is running, waiting always converges.
 
     Parameters
     ----------
@@ -372,16 +374,20 @@ def _remove_progress_dir(directory: Path) -> None:
     Raises
     ------
     RuntimeError
-        If the directory survives several attempts, which would mean
-        something other than a peer rank is holding it.
+        If the directory survives a few seconds of attempts, which
+        would mean something other than a peer rank is holding it.
     """
-    for _ in range(5):
+    for _ in range(50):
         if not directory.exists():
             return
         try:
             shutil.rmtree(directory)
         except FileNotFoundError:
-            continue  # a peer got there first; re-check and retry the rest
+            pass  # a peer got there first; re-check and retry the rest
+        except OSError as exc:
+            if exc.errno not in (errno.ENOTEMPTY, errno.ENOENT):
+                raise
+        time.sleep(0.05)
     if not directory.exists():
         return
     raise RuntimeError(

--- a/recipes/eval/test/test_online.py
+++ b/recipes/eval/test/test_online.py
@@ -1766,9 +1766,7 @@ class TestEndToEndRegional:
         from src.data import PredownloadedSource
 
         cfg = _base_cfg(tmp_path, ensemble_size=1)
-        cfg.scoring.regions = OmegaConf.create(
-            {k: v for k, v in REGIONS.items()}
-        )
+        cfg.scoring.regions = OmegaConf.create({k: v for k, v in REGIONS.items()})
         cfg.scoring.online.mae = True
         os.makedirs(cfg.output.path, exist_ok=True)
 

--- a/recipes/eval/test/test_online.py
+++ b/recipes/eval/test/test_online.py
@@ -135,10 +135,17 @@ def _base_cfg(tmp_path, ensemble_size: int = 1, mode: str = "online"):
 
 
 def _settings(tmp_path, **overrides):
-    """Parse online settings from the base cfg with ``scoring.online`` tweaks."""
+    """Parse online settings from the base cfg with ``scoring.online`` tweaks.
+
+    ``regions`` is the exception: it lives at ``scoring.regions`` (shared
+    with the offline pathway), not under ``scoring.online``.
+    """
     cfg = _base_cfg(tmp_path)
     for key, value in overrides.items():
-        cfg.scoring.online[key] = value
+        if key == "regions":
+            cfg.scoring[key] = value
+        else:
+            cfg.scoring.online[key] = value
     return parse_online_settings(cfg)
 
 
@@ -1515,10 +1522,13 @@ class TestRegionalWeights:
         settings = _settings(tmp_path, regions=REGIONS)
         assert list(settings.regions) == ["global", "midlat", "wrap"]
         assert settings.regions["global"] is None
-        with pytest.raises(ValueError, match="exactly 'lat' and 'lon'"):
-            _settings(tmp_path, regions={"bad": {"lat": [0, 10]}})
+        # A box may name any subset of spatial dims; the rest span fully.
+        partial = _settings(tmp_path, regions={"band": {"lat": [0, 10]}})
+        assert partial.regions["band"] == [{"lat": [0.0, 10.0]}]
         with pytest.raises(ValueError, match="lat bounds"):
             _settings(tmp_path, regions={"bad": {"lat": [50, 10], "lon": [0, 10]}})
+        with pytest.raises(ValueError, match="min < max"):
+            _settings(tmp_path, regions={"bad": {"level": [500, 200]}})
 
     def test_lsd_requires_a_whole_grid_region(self, tmp_path):
         with pytest.raises(ValueError, match="whole-grid region"):
@@ -1756,7 +1766,7 @@ class TestEndToEndRegional:
         from src.data import PredownloadedSource
 
         cfg = _base_cfg(tmp_path, ensemble_size=1)
-        cfg.scoring.online.regions = OmegaConf.create(
+        cfg.scoring.regions = OmegaConf.create(
             {k: v for k, v in REGIONS.items()}
         )
         cfg.scoring.online.mae = True

--- a/recipes/eval/test/test_online.py
+++ b/recipes/eval/test/test_online.py
@@ -1465,3 +1465,471 @@ class TestEndToEnd:
         finalize_stats(cfg)
         second = xr.open_zarr(os.path.join(cfg.output.path, "scores.zarr")).load()
         xr.testing.assert_allclose(first, second)
+
+
+# ---------------------------------------------------------------------------
+# Regional splits and optional statistics (mae / lsd)
+# ---------------------------------------------------------------------------
+
+# SMALL_LAT is [90, 30, -30, -90]; SMALL_LON is 0..315 step 45.
+REGIONS = {
+    "global": None,
+    "midlat": {"lat": [-40.0, 40.0], "lon": [0.0, 360.0]},
+    "wrap": {"lat": [-90.0, 90.0], "lon": [315.0, 45.0]},
+}
+
+
+def _region_masks() -> torch.Tensor:
+    """The {0,1} masks REGIONS describes on the small test grid."""
+    lat = torch.tensor(SMALL_LAT, dtype=torch.float64)
+    lon = torch.tensor(SMALL_LON, dtype=torch.float64)
+    masks = torch.ones(3, len(SMALL_LAT), len(SMALL_LON), dtype=torch.float64)
+    masks[1] *= ((lat >= -40) & (lat <= 40)).double().reshape(-1, 1)
+    masks[2] *= ((lon >= 315) | (lon <= 45)).double().reshape(1, -1)
+    return masks
+
+
+class TestRegionalWeights:
+    def test_shapes_and_global_slice(self):
+        coords = OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON})
+        w = build_spatial_weights(coords, lat_weights=True, regions=REGIONS)
+        assert w.shape == (3, len(SMALL_LAT), len(SMALL_LON))
+        base = build_spatial_weights(coords, lat_weights=True)
+        assert torch.allclose(w[0], base.expand(len(SMALL_LAT), len(SMALL_LON)))
+
+    def test_masks_match_expected_boxes(self):
+        coords = OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON})
+        w = build_spatial_weights(coords, lat_weights=False, regions=REGIONS)
+        assert torch.equal(w, _region_masks())
+
+    def test_empty_box_raises(self):
+        coords = OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON})
+        with pytest.raises(ValueError, match="selects no gridpoints"):
+            build_spatial_weights(
+                coords,
+                lat_weights=False,
+                regions={"nowhere": {"lat": [-5.0, 5.0], "lon": [0.0, 360.0]}},
+            )
+
+    def test_parse_roundtrip_and_validation(self, tmp_path):
+        settings = _settings(tmp_path, regions=REGIONS)
+        assert list(settings.regions) == ["global", "midlat", "wrap"]
+        assert settings.regions["global"] is None
+        with pytest.raises(ValueError, match="exactly 'lat' and 'lon'"):
+            _settings(tmp_path, regions={"bad": {"lat": [0, 10]}})
+        with pytest.raises(ValueError, match="lat bounds"):
+            _settings(tmp_path, regions={"bad": {"lat": [50, 10], "lon": [0, 10]}})
+
+    def test_lsd_requires_a_whole_grid_region(self, tmp_path):
+        with pytest.raises(ValueError, match="whole-grid region"):
+            _settings(
+                tmp_path,
+                lsd=True,
+                regions={"midlat": {"lat": [-40.0, 40.0], "lon": [0.0, 360.0]}},
+            )
+        settings = _settings(tmp_path, lsd=True, regions=REGIONS)
+        assert settings.lsd
+
+
+def _run_statistics_regional(
+    f: torch.Tensor,
+    y: torch.Tensor,
+    ensemble_size: int,
+    tmp_path,
+):
+    """Drive one lead step with REGIONS configured; returns the states."""
+    comm = _single_rank_comm(ensemble_size)
+    spatial = OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON})
+    weights = build_spatial_weights(spatial, lat_weights=True, regions=REGIONS)
+    w_flat = weights.reshape(3, -1).T.contiguous()
+    n_variables = y.shape[0]
+
+    settings = _settings(tmp_path, regions=REGIONS, mae=True, crps=False)
+    statistics = build_statistics(ensemble_size, settings=settings)
+    for stat in statistics:
+        stat.reset(1, n_variables, ensemble_size, torch.device("cpu"), n_regions=3)
+
+    ctx = StepContext(
+        lead_index=0,
+        valid_time=np.datetime64("2024-01-01T06", "ns"),
+        y=y,
+        clim=None,
+        f_local=f,
+        d_local=f - y,
+        weights=weights,
+        valid=torch.ones_like(y, dtype=torch.bool),
+        n_spatial=2,
+        ensemble_size=ensemble_size,
+        member_ids=tuple(range(ensemble_size)),
+        comm=comm,
+        w_flat=w_flat,
+    )
+    d = ctx.d_local.double()
+    ctx.s1 = d.sum(dim=0)
+    ctx.s2 = (d**2).sum(dim=0)
+    ctx.below = (ctx.f_local < ctx.y).sum(dim=0, dtype=torch.int32)
+
+    for stat in statistics:
+        stat.update(ctx)
+    state: dict = {}
+    for stat in statistics:
+        state.update(stat.state())
+    return state
+
+
+class TestRegionalAccumulation:
+    """Region 0 (whole grid) must reproduce the region-free run exactly, and
+    a boxed region must equal the region-free math on pre-masked weights."""
+
+    def test_global_region_matches_region_free_run(self, tmp_path):
+        torch.manual_seed(20)
+        m = 4
+        f = torch.randn(m, len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+        y = torch.randn(len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+
+        regional = _run_statistics_regional(f, y, m, tmp_path)
+        reference, _ = _run_statistics(f, y, ensemble_size=m)
+
+        for name, ref in reference.items():
+            got = regional[name][0]  # region axis leads the buffers
+            assert torch.allclose(got, ref, rtol=1e-12, atol=1e-12), name
+
+    def test_boxed_region_matches_masked_weights(self, tmp_path):
+        torch.manual_seed(21)
+        m = 3
+        f = torch.randn(m, len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+        y = torch.randn(len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+
+        regional = _run_statistics_regional(f, y, m, tmp_path)
+
+        base = build_spatial_weights(
+            OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON}), lat_weights=True
+        ).expand(len(SMALL_LAT), len(SMALL_LON))
+        for r in (1, 2):
+            masked = (base * _region_masks()[r]).double()
+            # Square/abs in float32 first — the accumulators upcast to
+            # float64 only for the weighted reduction, like the offline
+            # scorer does.
+            d = f - y
+            expected_sse = float(((d[0, 0] ** 2).double() * masked).sum())
+            assert regional["sse_member"][r, 0, 0, 0] == pytest.approx(
+                expected_sse, rel=1e-10
+            )
+            expected_w = float(masked.sum())
+            assert regional["w_sum"][r, 0, 0] == pytest.approx(expected_w, rel=1e-10)
+            expected_sae = float((d[0, 0].abs().double() * masked).sum())
+            assert regional["sae_member"][r, 0, 0, 0] == pytest.approx(
+                expected_sae, rel=1e-10
+            )
+            # Rank histogram: per-region counts total the masked weight sum.
+            counts = regional["rank_counts"][r, :, 0, :]
+            assert torch.allclose(
+                counts.sum(dim=0),
+                torch.full((len(VARIABLES),), expected_w, dtype=torch.float64),
+            )
+
+    def test_pairwise_matmul_matches_elementwise(self):
+        torch.manual_seed(22)
+        from src.online import _abs_diff_weighted_sum
+
+        local = torch.randn(2, len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+        other = torch.randn(5, len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+        base = build_spatial_weights(
+            OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON}), lat_weights=True
+        )
+        regional_w = build_spatial_weights(
+            OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON}),
+            lat_weights=True,
+            regions=REGIONS,
+        )
+        w_flat = regional_w.reshape(3, -1).T.contiguous()
+        got = _abs_diff_weighted_sum(local, other, base, 2, w_flat=w_flat)
+        assert got.shape == (len(VARIABLES), 3)
+        for r in range(3):
+            ref = _abs_diff_weighted_sum(local, other, regional_w[r], 2)
+            assert torch.allclose(got[:, r], ref, rtol=1e-12)
+
+
+class TestExtraStatistics:
+    def test_mae_matches_manual_weighted_mean(self, tmp_path):
+        torch.manual_seed(23)
+        m = 3
+        f = torch.randn(m, len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+        y = torch.randn(len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+
+        settings = _settings(tmp_path, mae=True, crps=False)
+        statistics = build_statistics(m, settings=settings)
+        names = [type(s).__name__ for s in statistics]
+        assert "MemberAbsError" in names
+
+        comm = _single_rank_comm(m)
+        weights = build_spatial_weights(
+            OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON}), lat_weights=True
+        )
+        w_sum = float(weights.expand(len(SMALL_LAT), len(SMALL_LON)).sum())
+        for stat in statistics:
+            stat.reset(1, len(VARIABLES), m, torch.device("cpu"))
+        ctx = StepContext(
+            lead_index=0,
+            valid_time=np.datetime64("2024-01-01T06", "ns"),
+            y=y,
+            clim=None,
+            f_local=f,
+            d_local=f - y,
+            weights=weights,
+            valid=torch.ones_like(y, dtype=torch.bool),
+            n_spatial=2,
+            ensemble_size=m,
+            member_ids=tuple(range(m)),
+            comm=comm,
+        )
+        d = ctx.d_local.double()
+        ctx.s1 = d.sum(dim=0)
+        ctx.s2 = (d**2).sum(dim=0)
+        ctx.below = (ctx.f_local < ctx.y).sum(dim=0, dtype=torch.int32)
+        for stat in statistics:
+            stat.update(ctx)
+        state: dict = {}
+        for stat in statistics:
+            state.update(stat.state())
+
+        expected = ((f - y).abs().double() * weights).sum(dim=(2, 3)) / w_sum
+        assert torch.allclose(state["sae_member"][:, 0, :] / w_sum, expected, atol=1e-9)
+
+    def test_lsd_matches_earth2studio(self, tmp_path):
+        pytest.importorskip("physicsnemo.metrics.general.power_spectrum")
+        from earth2studio.statistics import log_spectral_distance
+
+        torch.manual_seed(24)
+        m = 2
+        # A larger grid so the radial binning is non-trivial.
+        lat = np.linspace(90, -90, 16)
+        lon = np.linspace(0, 360, 32, endpoint=False)
+        f = torch.randn(m, len(VARIABLES), len(lat), len(lon))
+        y = torch.randn(len(VARIABLES), len(lat), len(lon))
+
+        settings = _settings(tmp_path, lsd=True, crps=False)
+        statistics = build_statistics(m, settings=settings)
+        lsd_stat = next(
+            s for s in statistics if type(s).__name__ == "LogSpectralDistance"
+        )
+        lsd_stat.reset(1, len(VARIABLES), m, torch.device("cpu"))
+        ctx = StepContext(
+            lead_index=0,
+            valid_time=np.datetime64("2024-01-01T06", "ns"),
+            y=y,
+            clim=None,
+            f_local=f,
+            d_local=f - y,
+            weights=torch.ones(1, 1, dtype=torch.float64),
+            valid=torch.ones_like(y, dtype=torch.bool),
+            n_spatial=2,
+            ensemble_size=m,
+            member_ids=tuple(range(m)),
+            comm=_single_rank_comm(m),
+        )
+        lsd_stat.update(ctx)
+        got = lsd_stat.state()["lsd"][:, 0, :]  # [ensemble, variable]
+
+        metric = log_spectral_distance(
+            reduction_dimensions=[], ensemble_dimension="ensemble"
+        )
+        x_coords = OrderedDict(
+            {
+                "ensemble": np.arange(m),
+                "variable": np.array(VARIABLES),
+                "lat": lat,
+                "lon": lon,
+            }
+        )
+        y_coords = OrderedDict(
+            {"variable": np.array(VARIABLES), "lat": lat, "lon": lon}
+        )
+        ref, _ = metric(f, x_coords, y, y_coords)
+        assert torch.allclose(got.float(), ref, rtol=1e-4)
+
+
+class TestEndToEndRegional:
+    """Regional + mae/lsd plumbing: store schema, labels, final scores."""
+
+    def _run(self, tmp_path):
+        from src.data import PredownloadedSource
+
+        cfg = _base_cfg(tmp_path, ensemble_size=1)
+        cfg.scoring.online.regions = OmegaConf.create(
+            {k: v for k, v in REGIONS.items()}
+        )
+        cfg.scoring.online.mae = True
+        os.makedirs(cfg.output.path, exist_ok=True)
+
+        valid_times = np.unique(
+            np.array(
+                [t + lt for t in IC_TIMES for lt in LEAD_TIMES],
+                dtype="datetime64[ns]",
+            )
+        )
+        verif_path = _verification_zarr(tmp_path / "verif.zarr", valid_times)
+        source = PredownloadedSource(verif_path)
+
+        settings = parse_online_settings(cfg)
+        comm = _single_rank_comm(1)
+        statistics = build_statistics(1, settings=settings)
+        spatial = OrderedDict({"lat": SMALL_LAT, "lon": SMALL_LON})
+
+        rng = np.random.default_rng(31)
+        forecasts = {
+            (str(t), int(lt.astype("int64"))): rng.standard_normal(
+                (len(VARIABLES), len(SMALL_LAT), len(SMALL_LON))
+            ).astype("float32")
+            for t in IC_TIMES
+            for lt in LEAD_TIMES
+        }
+
+        with (
+            patch("src.output.DistributedManager", return_value=_fake_dist()),
+            patch("src.distributed.DistributedManager", return_value=_fake_dist()),
+        ):
+            stats_mgr = open_stats_store(
+                cfg, statistics, VARIABLES, IC_TIMES, LEAD_TIMES, 1
+            )
+            with stats_mgr:
+                scorer = OnlineScorer(
+                    cfg=cfg,
+                    settings=settings,
+                    comm=comm,
+                    verification=FieldCache(
+                        source, VARIABLES, ("lat", "lon"), torch.device("cpu")
+                    ),
+                    climatology=None,
+                    variables=list(VARIABLES),
+                    lead_times=LEAD_TIMES,
+                    spatial_coords=spatial,
+                    weights=build_spatial_weights(
+                        spatial, True, regions=settings.regions
+                    ),
+                    stats_mgr=stats_mgr,
+                    device=torch.device("cpu"),
+                )
+                for item in build_group_work_items(list(IC_TIMES), comm.group, cfg):
+                    scorer.begin_item(item)
+                    for lt in LEAD_TIMES:
+                        x = torch.from_numpy(
+                            forecasts[(str(item.time), int(lt.astype("int64")))]
+                        )
+                        coords = OrderedDict(
+                            {
+                                "time": np.array([item.time]),
+                                "lead_time": np.array([lt]),
+                                "variable": np.array(VARIABLES),
+                                "lat": SMALL_LAT,
+                                "lon": SMALL_LON,
+                            }
+                        )
+                        scorer.update(x[None, None], coords)
+                    scorer.finish_item(item)
+
+            finalize_stats(cfg)
+        return cfg, forecasts, source
+
+    def test_store_schema_and_labels(self, tmp_path):
+        cfg, _, _ = self._run(tmp_path)
+        stats = xr.open_zarr(os.path.join(cfg.output.path, "stats.zarr"))
+        assert stats["sse_ensmean__t2m"].dims == ("time", "region", "lead_time")
+        assert stats.attrs["regions"] == ["global", "midlat", "wrap"]
+
+        scores = xr.open_zarr(os.path.join(cfg.output.path, "scores.zarr"))
+        assert list(scores.region.values) == ["global", "midlat", "wrap"]
+        assert "mae__t2m" in scores
+        assert not np.isnan(scores["mse__t2m"].values).any()
+
+    def test_global_region_matches_region_free_scores(self, tmp_path):
+        cfg, forecasts, source = self._run(tmp_path)
+        scores = xr.open_zarr(os.path.join(cfg.output.path, "scores.zarr"))
+
+        metric = mse(reduction_dimensions=["lat", "lon"], weights=_weights_2d())
+        y_coords = OrderedDict(
+            {"variable": np.array(VARIABLES), "lat": SMALL_LAT, "lon": SMALL_LON}
+        )
+        for t in IC_TIMES:
+            for lt in LEAD_TIMES:
+                x = torch.from_numpy(forecasts[(str(t), int(lt.astype("int64")))])
+                y = torch.from_numpy(
+                    source([t + lt], VARIABLES)
+                    .transpose("time", "variable", "lat", "lon")
+                    .values[0]
+                    .copy()
+                )
+                ref, _ = metric(x, y_coords, y, y_coords)
+                for j, var in enumerate(VARIABLES):
+                    got = float(
+                        scores[f"mse__{var}"]
+                        .sel(time=t, lead_time=lt, region="global")
+                        .values
+                    )
+                    assert got == pytest.approx(float(ref[j]), rel=1e-5)
+
+
+class TestUnionRegions:
+    """A region may be a list of boxes; the mask is their union."""
+
+    def test_parse_normalizes_to_box_lists(self, tmp_path):
+        settings = _settings(
+            tmp_path,
+            regions={
+                "global": None,
+                "extra_tropics": [
+                    {"lat": [20, 90], "lon": [0, 360]},
+                    {"lat": [-90, -20], "lon": [0, 360]},
+                ],
+                "tropics": {"lat": [-20, 20], "lon": [0, 360]},
+            },
+        )
+        assert settings.regions["global"] is None
+        assert len(settings.regions["extra_tropics"]) == 2
+        assert len(settings.regions["tropics"]) == 1
+
+    def test_union_mask_is_complement_of_tropics(self, tmp_path):
+        lat = np.linspace(90, -90, 19)
+        lon = np.linspace(0, 360, 12, endpoint=False)
+        coords = OrderedDict({"lat": lat, "lon": lon})
+        w = build_spatial_weights(
+            coords,
+            lat_weights=True,
+            regions={
+                "global": None,
+                "tropics": [{"lat": [-20, 20], "lon": [0, 360]}],
+                "extra_tropics": [
+                    {"lat": [20, 90], "lon": [0, 360]},
+                    {"lat": [-90, -20], "lon": [0, 360]},
+                ],
+            },
+        )
+        assert w.shape == (3, len(lat), len(lon))
+        # Band-edge points (|lat| = 20) sit in BOTH splits, WB2-style
+        # inclusive slices; away from the edges the two are complementary
+        # and together tile the globe.
+        interior = np.abs(lat) != 20
+        both = (w[1] > 0) & (w[2] > 0)
+        assert not both[interior].any()
+        assert torch.allclose(torch.maximum(w[1], w[2])[interior], w[0][interior])
+
+    def test_overlapping_boxes_do_not_double_count(self, tmp_path):
+        lat = np.linspace(90, -90, 19)
+        lon = np.linspace(0, 360, 12, endpoint=False)
+        coords = OrderedDict({"lat": lat, "lon": lon})
+        w = build_spatial_weights(
+            coords,
+            lat_weights=True,
+            regions={
+                "a": [
+                    {"lat": [0, 90], "lon": [0, 360]},
+                    {"lat": [-30, 45], "lon": [0, 360]},  # overlaps the first
+                ]
+            },
+        )
+        ref = build_spatial_weights(
+            coords,
+            lat_weights=True,
+            regions={"b": {"lat": [-30, 90], "lon": [0, 360]}},
+        )
+        assert torch.allclose(w[0], ref[0])

--- a/recipes/eval/test/test_scoring.py
+++ b/recipes/eval/test/test_scoring.py
@@ -635,6 +635,63 @@ class TestInstantiateMetrics:
         assert metrics["rmse"].weights is None
 
 
+class TestRegionalMetrics:
+    """scoring.regions in the store-then-score pathway."""
+
+    def _cfg(self, reduction, regions):
+        return OmegaConf.create(
+            {
+                "scoring": {
+                    "lat_weights": False,
+                    "regions": regions,
+                    "metrics": {
+                        "rmse": {
+                            "_target_": "earth2studio.statistics.rmse",
+                            "reduction_dimensions": reduction,
+                        }
+                    },
+                }
+            }
+        )
+
+    def test_region_axis_and_values(self, spatial_coords):
+        cfg = self._cfg(
+            ["lat", "lon"], {"global": None, "north": {"lat": [0, 90]}}
+        )
+        metrics = instantiate_metrics(cfg, spatial_coords)
+        metric = metrics["rmse"]
+
+        lat = np.asarray(spatial_coords["lat"])
+        lon = np.asarray(spatial_coords["lon"])
+        torch.manual_seed(7)
+        x = torch.randn(2, len(lat), len(lon))
+        y = torch.randn(2, len(lat), len(lon))
+        coords = OrderedDict(
+            {"variable": np.array(["a", "b"]), "lat": lat, "lon": lon}
+        )
+
+        value, out = metric(x, coords, y, coords.copy())
+        assert list(out)[0] == "region"
+        assert list(out["region"]) == ["global", "north"]
+
+        # The global region is a plain unweighted RMSE; the boxed region
+        # equals the same RMSE restricted to its rows (uniform weights, so
+        # the masked weighted mean is the sub-grid mean).
+        expected_global = torch.sqrt(((x - y) ** 2).mean(dim=(-2, -1)))
+        assert torch.allclose(value[0], expected_global, rtol=1e-5, atol=1e-6)
+        rows = torch.from_numpy(lat >= 0)
+        expected_north = torch.sqrt(
+            ((x[:, rows] - y[:, rows]) ** 2).mean(dim=(-2, -1))
+        )
+        assert torch.allclose(value[1], expected_north, rtol=1e-5, atol=1e-6)
+
+    def test_partial_spatial_reduction_stays_global(self, spatial_coords):
+        cfg = self._cfg(["lat"], {"global": None, "north": {"lat": [0, 90]}})
+        metrics = instantiate_metrics(cfg, spatial_coords)
+        # Not wrapped: reducing only lat cannot carry a lat/lon mask.
+        assert not hasattr(metrics["rmse"], "_per_region")
+
+
 # ---------------------------------------------------------------------------
 # Scoring progress tracking (work.py)
 # ---------------------------------------------------------------------------

--- a/recipes/eval/test/test_scoring.py
+++ b/recipes/eval/test/test_scoring.py
@@ -655,9 +655,7 @@ class TestRegionalMetrics:
         )
 
     def test_region_axis_and_values(self, spatial_coords):
-        cfg = self._cfg(
-            ["lat", "lon"], {"global": None, "north": {"lat": [0, 90]}}
-        )
+        cfg = self._cfg(["lat", "lon"], {"global": None, "north": {"lat": [0, 90]}})
         metrics = instantiate_metrics(cfg, spatial_coords)
         metric = metrics["rmse"]
 
@@ -666,9 +664,7 @@ class TestRegionalMetrics:
         torch.manual_seed(7)
         x = torch.randn(2, len(lat), len(lon))
         y = torch.randn(2, len(lat), len(lon))
-        coords = OrderedDict(
-            {"variable": np.array(["a", "b"]), "lat": lat, "lon": lon}
-        )
+        coords = OrderedDict({"variable": np.array(["a", "b"]), "lat": lat, "lon": lon})
 
         value, out = metric(x, coords, y, coords.copy())
         assert list(out)[0] == "region"
@@ -680,9 +676,7 @@ class TestRegionalMetrics:
         expected_global = torch.sqrt(((x - y) ** 2).mean(dim=(-2, -1)))
         assert torch.allclose(value[0], expected_global, rtol=1e-5, atol=1e-6)
         rows = torch.from_numpy(lat >= 0)
-        expected_north = torch.sqrt(
-            ((x[:, rows] - y[:, rows]) ** 2).mean(dim=(-2, -1))
-        )
+        expected_north = torch.sqrt(((x[:, rows] - y[:, rows]) ** 2).mean(dim=(-2, -1)))
         assert torch.allclose(value[1], expected_north, rtol=1e-5, atol=1e-6)
 
     def test_partial_spatial_reduction_stays_global(self, spatial_coords):


### PR DESCRIPTION
### Description

- **Regional scoring**: `scoring.online.regions` accepts named latitude/longitude boxes (or lists of boxes, scored as their union) and adds a labeled `region` axis to `stats.zarr`/`scores.zarr`. Regions are applied as masked cosine-latitude weights inside the existing accumulation step, so regional scores cost one matrix product — no extra passes over the forecast. A null box means global.
- **New online metrics**: opt-in per-member MAE (`scoring.online.mae`) and log spectral distance (`scoring.online.lsd`, reusing `earth2studio.statistics.log_spectral_distance`), accumulated online alongside the existing RMSE/CRPS/spread statistics.
- **Fix**: clearing resume markers no longer races between ranks; concurrent removal of the same progress directory retries with backoff until it no longer exists.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

