### PR TITLE
Add swvl2 to Earthmover ERA5 lexicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source (`MeteosatLI`), providing per-flash, per-group and per-event
   detections from the LFL, LGR and LEF collections as a data frame
 - Added group- and flash-level variables to the `GOESGLM` data source
+- Added `swvl2` to the Earthmover ERA5 lexicon / `EarthMoverERA5` variables,
+  matching the variable now published in the Marketplace dataset
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added regional splits to evaluation recipe scoring, in both the online
   and store-then-score pathways: `scoring.regions` takes named coordinate
   boxes and adds a labeled `region` axis to the score stores.
-- New eval recipt optional per-member online metrics include MAE
+- New eval recipe optional per-member online metrics include MAE
   (`scoring.online.mae`) and log spectral distance (`scoring.online.lsd`)
 
 ### Changed

--- a/earth2studio/lexicon/earthmover.py
+++ b/earth2studio/lexicon/earthmover.py
@@ -448,6 +448,7 @@ class EarthMoverERA5Lexicon(_EarthMoverLexiconBase):
         "stl3": "stl3::sfc::",
         "stl4": "stl4::sfc::",
         "swvl1": "swvl1::sfc::",
+        "swvl2": "swvl2::sfc::",
         "t2m": "t2m::sfc::",
         "tcc": "tcc::sfc::",
         "tcw": "tcw::sfc::",

--- a/test/data/test_earthmover.py
+++ b/test/data/test_earthmover.py
@@ -65,6 +65,7 @@ ERA5_SINGLE_VARIABLES = (
     "stl3",
     "stl4",
     "swvl1",
+    "swvl2",
     "t2m",
     "tcc",
     "tcw",

--- a/test/lexicon/test_earthmover_lexicon.py
+++ b/test/lexicon/test_earthmover_lexicon.py
@@ -102,6 +102,7 @@ ERA5_SURFACE_VOCAB = {
     "stl3": "stl3::sfc::",
     "stl4": "stl4::sfc::",
     "swvl1": "swvl1::sfc::",
+    "swvl2": "swvl2::sfc::",
     "t2m": "t2m::sfc::",
     "tcc": "tcc::sfc::",
     "tcw": "tcw::sfc::",


### PR DESCRIPTION
## Earth2Studio Pull Request

### Description

The Earthmover ERA5 Marketplace dataset now publishes `swvl2` (volumetric soil
water layer 2), but the Earth2Studio lexicon only exposed `swvl1`. This adds
`swvl2` to `EarthMoverERA5Lexicon.SURFACE_VARIABLES`, which also adds it to
`EarthMoverERA5.VARIABLES` (derived from the vocab).

No other changes were required: the shared Earthmover metadata tables already
carry `swvl2` (`_PARAM_IDS` 40, `_CANONICAL_UNITS_BY_SHORT_NAME` `m3 m-3`), so
the spec and unit-conversion paths work as-is. The other lexicons that support
ERA5 soil moisture (ARCO, CDS, NCAR, ECMWF, Earthmover IFS initial conditions)
already had `swvl2`.

- `earth2studio/lexicon/earthmover.py`: add `"swvl2": "swvl2::sfc::"`
- `test/lexicon/test_earthmover_lexicon.py`, `test/data/test_earthmover.py`:
  add `swvl2` to the expected ERA5 vocab / variable listings
- `CHANGELOG.md`: entry under Added

### Verify new var
```python
from arraylake import Client
import xarray as xr
client = Client()
repo = client.get_repo("earthmover-public/era5")
session = repo.readonly_session(branch="main")
ds = xr.open_zarr(session.store, zarr_format=3, group="single/spatial")
ds.swvl2.attrs
{...
'GRIB_missingValue': 3.4028234663852886e+38,
 'GRIB_name': 'Volumetric soil water layer 2',
...
 'GRIB_units': 'm**3 m**-3',
 'long_name': 'Volumetric soil water layer 2',
 'units': 'm**3 m**-3'
...
}
```

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.

### Testing

`pytest test/lexicon/test_earthmover_lexicon.py` — 15 passed.
`pytest test/data/test_earthmover.py -m "not slow"` — the variable-listing tests
pass; 4 pre-existing failures remain in my local env from the missing
`arraylake` optional dependency (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)