### PR TITLE
Fix StormScopeMeteosatEU default package pointing to stormcast-conus

### DIFF
--- a/earth2studio/models/px/stormscope_meteosat.py
+++ b/earth2studio/models/px/stormscope_meteosat.py
@@ -788,9 +788,9 @@ class StormScopeMeteosatEU(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     def load_default_package(cls) -> Package:
         """Load prognostic package"""
         package = Package(
-            "hf://nvidia/stormcast-conus@17148d712f7ef2c0b48355032dcad85173dd230e",
+            "hf://nvidia/stormscope-meteosat@17148d712f7ef2c0b48355032dcad85173dd230e",
             cache_options={
-                "cache_storage": Package.default_cache("stormcast-conus"),
+                "cache_storage": Package.default_cache("stormscope-meteosat"),
                 "same_names": True,
             },
         )


### PR DESCRIPTION
## Summary
- `StormScopeMeteosatEU.load_default_package()` (added in #981) referenced `hf://nvidia/stormcast-conus`, apparently copy-pasted from `stormcastconus.py`, instead of the actual EU Meteosat package.
- Points it at `hf://nvidia/stormscope-meteosat` instead. The pinned commit hash (`17148d712f7ef2c0b48355032dcad85173dd230e`) was already correct — it's the tip commit of `nvidia/stormscope-meteosat` and its tree contains `config.yaml`, both `.mdlus` checkpoints, and `metadata.nc`, matching what `load_model()` expects. Only the repo name and `cache_storage` label needed correcting.

## Test plan
- [x] Verified via the Hugging Face API/UI that `nvidia/stormscope-meteosat@17148d712f7ef2c0b48355032dcad85173dd230e` exists and contains the expected files.
- [ ] `load_default_package()` / `load_model()` successfully downloads and loads `StormScopeMeteosatEU` (not run here — no network/HF access in this environment).