### PR TITLE
fix: link getting-started workflow docs

### DIFF
--- a/examples/01_getting_started/01_deterministic_workflow.py
+++ b/examples/01_getting_started/01_deterministic_workflow.py
@@ -44,16 +44,8 @@ In this example you will learn:
 # Set Up
 # ------
 # All workflows inside Earth2Studio require constructed components to be
-# handed to them. In this example, let's take a look at the most basic:
-# [`earth2studio.run.deterministic`][earth2studio.run.deterministic].
-
-# %%
-# .. literalinclude:: ../../earth2studio/run.py
-#    :language: python
-#    :start-after: # sphinx - deterministic start
-#    :end-before: # sphinx - deterministic end
-
-# %%
+# handed to them. In this example, let's take a look at the most basic: [`earth2studio.run.deterministic`](https://nvidia.github.io/earth2studio/main/modules/generated/workflows/deterministic/#earth2studio.run.deterministic).
+#
 # Thus, we need the following:
 #
 # - Prognostic Model: Use the built in FourCastNet Model [`earth2studio.models.px.FCN`][earth2studio.models.px.FCN].

--- a/examples/01_getting_started/02_diagnostic_workflow.py
+++ b/examples/01_getting_started/02_diagnostic_workflow.py
@@ -44,17 +44,10 @@ In this example you will learn:
 # %%
 # Set Up
 # ------
-# For this example, the built in diagnostic workflow [`earth2studio.run.diagnostic`][earth2studio.run.diagnostic]
-# will be used.
-
-# %%
-# .. literalinclude:: ../../earth2studio/run.py
-#    :language: python
-#    :start-after: # sphinx - diagnostic start
-#    :end-before: # sphinx - diagnostic end
-
-
-# %%
+# All workflows inside Earth2Studio require constructed components to be handed to
+# them. In this example, let's take a look at the diagnostic workflow:
+# [`earth2studio.run.diagnostic`](https://nvidia.github.io/earth2studio/main/modules/generated/workflows/diagnostic/#earth2studio.run.diagnostic).
+#
 # Thus, we need the following:
 #
 # - Prognostic Model: Use the built in FourCastNet Model [`earth2studio.models.px.FCN`][earth2studio.models.px.FCN].

--- a/examples/01_getting_started/03_ensemble_workflow.py
+++ b/examples/01_getting_started/03_ensemble_workflow.py
@@ -49,18 +49,11 @@ In this example you will learn:
 # %%
 # Set Up
 # ------
-# All workflows inside Earth2Studio require constructed components to be
-# handed to them. In this example, we will use the built in ensemble workflow
-# [`earth2studio.run.ensemble`][earth2studio.run.ensemble].
-
-# %%
-# .. literalinclude:: ../../earth2studio/run.py
-#    :language: python
-#    :start-after: # sphinx - ensemble start
-#    :end-before: # sphinx - ensemble end
-
-# %%
-# We need the following:
+# All workflows inside Earth2Studio require constructed components to be handed to
+# them. In this example, let's take a look at the ensemble workflow:
+# [`earth2studio.run.ensemble`](https://nvidia.github.io/earth2studio/main/modules/generated/workflows/ensemble/#earth2studio.run.ensemble).
+#
+# Thus, we need the following:
 #
 # - Prognostic Model: Use the built in FourCastNet model [`earth2studio.models.px.FCN`][earth2studio.models.px.FCN].
 # - Perturbation Method: Use the Spherical Gaussian Method [`earth2studio.perturbation.SphericalGaussian`][earth2studio.perturbation.SphericalGaussian].


### PR DESCRIPTION
## Description

- Remove broken literal includes of earth2studio/run.py from the first three getting-started examples.
- Link directly to the rendered deterministic, diagnostic, and ensemble API pages.
- Keep each setup introduction immediately followed by the required component list.

## Validation

- Black and Ruff pass for all three examples.
- All three documentation pages and workflow anchors resolve.