### PR TITLE
Add HRRR lsm and z variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added HRRR land-sea mask and surface geopotential variables.
 - Added EUMETSAT MTG-I Lightning Imager (LI) Level-2 pointed lightning data
   source (`MeteosatLI`), providing per-flash, per-group and per-event
   detections from the LFL, LGR and LEF collections as a data frame

--- a/earth2studio/lexicon/hrrr.py
+++ b/earth2studio/lexicon/hrrr.py
@@ -67,6 +67,8 @@ class HRRRLexicon(metaclass=LexiconType):
             "crain": "wrfsfc::CRAIN::surface::anl",
             "aerot": "wrfsfc::AOTK::entire atmosphere (considered as a single layer)",  # will be zero
             "rsds": "wrfsfc::DSWRF::surface",
+            "lsm": "wrfsfc::LAND::surface",
+            "z": "wrfsfc::HGT::surface",
         }
         prs_levels = [
             50,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

## Description

HRRR land-sea mask and surface geopotential (converted from orography in m through the already existing mod function).

<img width="989" height="303" alt="image" src="https://github.com/user-attachments/assets/58ca4977-3fa7-48ec-abf1-849313ac3986" />


```
from datetime import datetime
from earth2studio.data import HRRR
import matplotlib.pyplot as plt

hrrr = HRRR()
da = hrrr(datetime(2026, 8, 1), ["lsm", "z"])

fig, ax = plt.subplots(ncols=2, figsize=(12, 3.5))
lsm = da.sel(variable="lsm").values.squeeze()
im0 = ax[0].imshow(lsm)
fig.colorbar(im0, ax=ax[0])
ax[0].set_title(f"lsm {lsm.mean()=:.3f}")
orog = da.sel(variable="z").values.squeeze() / 9.81
im1 = ax[1].imshow(orog)
ax[1].set_title(f"orog {orog.mean()=:.3f}")
fig.colorbar(im1, ax=ax[1])
fig.savefig("test.png", bbox_inches="tight")
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
