### PR TITLE
Add Earthmover Marketplace user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`scoring.online.mae`) and log spectral distance (`scoring.online.lsd`)
 - Scorecards gain regional, seasonal, monthly, per-init-hour and per-IC
   views with baseline overlays; GraphCast and Atlas CRPS added
+- Added user guide documentation for the Earthmover Marketplace data sources
+  (`EarthMoverERA5`, `EarthMoverBrightBandIFS`, `EarthMoverBrightBandIFS_FX`),
+  covering subscribing, authentication, usage, data hosting, writing output to
+  Arraylake and publishing a listing
 
 ### Changed
 

--- a/docs/userguide/components/datasources.md
+++ b/docs/userguide/components/datasources.md
@@ -121,6 +121,14 @@ We recommend that you review the [extension examples](../../examples/index.md#ex
 examples, which will step you through the basic process of implementing your own
 data source.
 
+## Earthmover Marketplace
+
+Earth2Studio includes data sources that read directly from the
+[Earthmover Marketplace](https://app.earthmover.io/marketplace), a catalog of
+analysis-ready weather/climate datasets stored as Arraylake/Icechunk Zarr
+repositories. See [Earthmover Marketplace](earthmover_marketplace.md) for subscription,
+authentication and usage details.
+
 ## Contributing a Datasource
 
 We are always looking for new remote data stores that our users may be interested in for

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -183,6 +183,33 @@ session.commit(message="Add data")
 See [Earthmover's version control guide](https://docs.earthmover.io/guide/version-control)
 for the full writable-session and commit workflow.
 
+### Publishing your own Marketplace listing
+
+Writing to your own repo is enough to use it as a `repo="org/repo"` data source (see
+[Custom or private Arraylake repositories](#custom-or-private-arraylake-repositories)
+below), but publishing it as a Marketplace listing so others can subscribe is a
+separate, Earthmover-account-level process, per
+[Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers):
+
+1. Create an organization at
+   [app.earthmover.io/orgs/new](https://app.earthmover.io/orgs/new) - "the public face
+   for your data."
+2. Upgrade to the Professional tier by emailing `support@earthmover.io`; this is
+   required to become a provider.
+3. "Configure a storage bucket using Credential Vending in your cloud provider of
+   choice" (bring-your-own-bucket), or request Earthmover-managed storage from
+   support.
+4. Prepare the data: "create a new Icechunk repo," import existing Icechunk data, or
+   write it with Xarray, using the `writable_session` / `commit` pattern above.
+5. In your org settings, open the **Marketplace** tab and click **"+ Create
+   Listing"**, then fill in the repository, listing name and description, thumbnail
+   URL, README, license terms, and pricing model.
+6. Choose a pricing model: for free listings, "subscribers get access to everything in
+   the repo"; for paid listings, you "select exactly which variables and groups are
+   available to subscribers."
+7. Set the listing status to **Published** (requires a repository attached) - it can
+   otherwise be left **Unpublished** or **Coming Soon**.
+
 ## Variable resolution
 
 [Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by Earth2Studio, so each Earthmover data

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -17,14 +17,15 @@ verification data without writing any custom download or parsing code.
 
 ## Available Marketplace Data Sources
 
-| Data source | Type | Dataset |
-| --- | --- | --- |
-| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | ERA5 0.25° reanalysis |
-| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | Brightband ECMWF IFS 0.25° initial conditions |
-| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | Brightband ECMWF IFS 0.1° (10 km) 15-day forecast |
+| Data source | Type | Dataset | Marketplace listing (hosted repo) |
+| --- | --- | --- | --- |
+| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | ERA5 0.25° reanalysis | [app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) |
+| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | Brightband ECMWF IFS 0.25° initial conditions | [app.earthmover.io/marketplace/697162921880507a6587c31b](https://app.earthmover.io/marketplace/697162921880507a6587c31b) |
+| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | Brightband ECMWF IFS 0.1° (10 km) 15-day forecast | [app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
 
-Each class' docstring links to its Marketplace listing page, where dataset coverage,
-license and the subscription button live.
+Each listing page is where the dataset's Arraylake repository is hosted and subscribed
+to — dataset coverage, license and the **Subscribe** button all live there. Each data
+source class' docstring links to the same page.
 
 ## 1. Subscribe to a dataset
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -49,7 +49,9 @@ same page. Per the listing pages themselves:
 
 ## How the data is hosted
 
-Marketplace data is **not copied into Earthmover's or your own storage**. Per
+The underlying chunk data is **never copied into Earthmover's or your own storage**
+(a paid subscription's own bucket holds only metadata about which chunks you can
+access, not the data itself - see below). Per
 [Earthmover's storage docs](https://docs.earthmover.io/concepts/storage), "Arraylake
 works with a wide range of commercial and open-source object storage services,
 including any S3-compatible object store as well as Google Cloud Storage and Microsoft

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -58,23 +58,33 @@ maintain a local on-disk cache; every call re-reads from the provider's object s
 Marketplace datasets require an active subscription before they can be read, even for
 open/free listings:
 
-1. Open the dataset's listing page (linked from the data source docstring above, or
-   browse [app.earthmover.io/marketplace](https://app.earthmover.io/marketplace)).
-2. Click **Subscribe**, and choose which [Arraylake](https://docs.earthmover.io/) organization should house the
-   resulting repository (you'll be prompted to create one if you don't have one yet).
-   This creates a read-only repository under your organization, typically named
-   `<org>/<dataset>-subscription`.
-3. Note your **organization name**, used to derive the repository path below.
+Per [Earthmover's own docs](https://docs.earthmover.io/marketplace/data-users):
 
-Free listings subscribe instantly and give a complete mirror of the provider's
-repository, including full commit history. Paid listings require a
-[Professional Arraylake plan](https://docs.earthmover.io/marketplace/faq) and a
-request-access step before the subscription repository is created; they may also be
-scoped ("filtered subscriptions") to specific variables, time ranges, or regions rather
-than mirroring the full dataset.
+1. "Browse the Marketplace - Find a dataset you're interested in at
+   app.earthmover.io/marketplace" (or follow the link from the data source docstring
+   above).
+2. "Subscribe - Click the subscribe button on the listing page."
+3. "Select an Organization - Choose which Arraylake organization should house the
+   resulting repo" (you'll be prompted to create one if you don't have one yet). Note
+   this **organization name**, used to derive the repository path below.
+
+"When you subscribe to a dataset, a read-only repo appears in your Arraylake
+organization," typically named `<org>/<dataset>-subscription`.
+
+"Many datasets on the Marketplace are freely available. Anyone with an Arraylake
+account can subscribe to free listings instantly." Free listings "use direct
+subscriptions" - "your repo is a complete mirror of the provider's repo," including
+full commit history. Paid listings are premium offerings that "use filtered
+subscriptions": "instead of mirroring the provider's entire repo, you receive a repo
+scoped to specific variables, time ranges, or spatial regions," and require a
+[Professional Arraylake plan](https://docs.earthmover.io/marketplace/faq).
 
 Attempting to read a repository without an active subscription raises a
 `PermissionError` pointing back to the listing page.
+
+!!! note
+    "Subscriptions are not anonymous. When you subscribe to a dataset, the data
+    provider can see your organization name and contact email."
 
 !!! note "License & cost"
     Each listing page states its own license and, for paid data, its pricing, set by

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -33,9 +33,18 @@ open/free listings:
 
 1. Open the dataset's listing page (linked from the data source docstring above, or
    browse [app.earthmover.io/marketplace](https://app.earthmover.io/marketplace)).
-2. Click **Subscribe**. This creates a repository under your organization, typically
-   named `<org>/<dataset>-subscription`.
+2. Click **Subscribe**, and choose which Arraylake organization should house the
+   resulting repository (you'll be prompted to create one if you don't have one yet).
+   This creates a read-only repository under your organization, typically named
+   `<org>/<dataset>-subscription`.
 3. Note your **organization name** — it's used to derive the repository path below.
+
+Free listings subscribe instantly and give a complete mirror of the provider's
+repository, including full commit history. Paid listings require a
+[Professional Arraylake plan](https://docs.earthmover.io/marketplace/faq) and a
+request-access step before the subscription repository is created; they may also be
+scoped ("filtered subscriptions") to specific variables, time ranges, or regions rather
+than mirroring the full dataset.
 
 Attempting to read a repository without an active subscription raises a
 `PermissionError` pointing back to the listing page.
@@ -119,3 +128,10 @@ as shown above.
 | `PermissionError: Access to Arraylake repo '...' was denied` | No active subscription | Subscribe on the dataset's Marketplace listing page |
 | `ValueError: Arraylake repo '...' was not found` | Wrong repo name, or subscription not yet active | Double check the `org/repo` name and subscription status |
 | `ValueError: Could not resolve Earth2Studio variable '...' ` | Repository lacks GRIB/CF metadata for that variable | Check the error's list of available repository variables |
+
+## Further reading
+
+- [Earthmover Marketplace](https://app.earthmover.io/marketplace) — browse listings
+- [Marketplace docs: Data Users](https://docs.earthmover.io/marketplace/data-users) — subscription mechanics
+- [Marketplace docs: FAQ](https://docs.earthmover.io/marketplace/faq) — pricing and plan requirements
+- [Arraylake client installation](https://docs.earthmover.io/setup/installation) — `arraylake` package setup

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -17,15 +17,16 @@ verification data without writing any custom download or parsing code.
 
 ## Available Marketplace Data Sources
 
-| Data source | Type | Dataset | Marketplace listing (hosted repo) |
-| --- | --- | --- | --- |
-| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | ERA5 0.25° reanalysis | [app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) |
-| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | Brightband ECMWF IFS 0.25° initial conditions | [app.earthmover.io/marketplace/697162921880507a6587c31b](https://app.earthmover.io/marketplace/697162921880507a6587c31b) |
-| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | Brightband ECMWF IFS 0.1° (10 km) 15-day forecast | [app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
+| Data source | Type | Dataset (hosted repo listing) |
+| --- | --- | --- |
+| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | [ERA5 0.25° reanalysis](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) |
+| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | [Brightband ECMWF IFS 0.25° initial conditions](https://app.earthmover.io/marketplace/697162921880507a6587c31b) |
+| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | [Brightband ECMWF IFS 0.1° (10 km) 15-day forecast](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
 
-Each listing page is where the dataset's Arraylake repository is hosted and subscribed
-to — dataset coverage, license and the **Subscribe** button all live there. Each data
-source class' docstring links to the same page.
+Each dataset name links to its Marketplace listing page, which is where the Arraylake
+repository is hosted and subscribed to — dataset coverage, license and the
+**Subscribe** button all live there. Each data source class' docstring links to the
+same page.
 
 ## 1. Subscribe to a dataset
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -49,11 +49,14 @@ same page. Per the listing pages themselves:
 
 ## How the data is hosted
 
-Marketplace data is **not copied into Earthmover's or your own storage**. Each dataset
-provider hosts their data in their own cloud object store (any S3-compatible store, GCS,
-or Azure Blob), and [Icechunk](https://icechunk.io/) (the versioned storage format
-Arraylake is built on) tracks it with cryptographically-addressed manifests.
-Subscribing does not trigger a download:
+Marketplace data is **not copied into Earthmover's or your own storage**. Per
+[Earthmover's storage docs](https://docs.earthmover.io/concepts/storage), "Arraylake
+works with a wide range of commercial and open-source object storage services,
+including any S3-compatible object store as well as Google Cloud Storage and Microsoft
+Azure Blob Storage," and providers typically use "BYOB - Bring your own bucket": "all
+the data live in your cloud in your own object storage bucket." [Icechunk](https://icechunk.io/)
+(the versioned storage format Arraylake is built on) tracks it with
+cryptographically-addressed manifests. Subscribing does not trigger a download:
 
 - **Free listings** are a direct subscription. Per
   [Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers),
@@ -105,17 +108,26 @@ Attempting to read a repository without an active subscription raises a
     provider can see your organization name and contact email."
 
 !!! note "License & cost"
-    Each listing page states its own license and, for paid data, its pricing, set by
-    the provider, not Earth2Studio. Storage for a subscription repo lives in the
-    provider's bucket (free listings) or your own organization's bucket for the
-    subscription metadata (paid listings); either way you are not billed for storing a
-    copy of the underlying dataset. Check the listing page before subscribing to a
-    paid dataset for the applicable terms.
+    Per [Earthmover's FAQ](https://docs.earthmover.io/marketplace/faq): "The
+    Marketplace supports both free/open data and paid subscriptions." For free
+    listings, "no payment needed to access the data"; "many datasets on the
+    Marketplace are completely free" and "anyone with an Arraylake account can
+    subscribe to free listings instantly and start querying data right away." For
+    paid listings, "custom pricing [is] negotiated between provider and the user," and
+    "paid datasets require a Professional plan." Each listing page states its own
+    license terms, set by the provider, not Earth2Studio - check it before
+    subscribing.
 
 ## 2. Authenticate
 
-Set an [Arraylake](https://docs.earthmover.io/) API key (create one at
-[app.earthmover.io](https://app.earthmover.io) under account settings):
+Set an [Arraylake](https://docs.earthmover.io/) API key. Per
+[Earthmover's org-access docs](https://docs.earthmover.io/setup/org-access), "to create
+a new API key, click on the big purple 'New API Client' button" in your organization's
+settings on [app.earthmover.io](https://app.earthmover.io), "enter a name for the API
+key, then select the appropriate permissions (read/write), and the key's lifetime."
+The resulting "secret tokens are a single string, prefixed with the `ema_` identifier"
+(e.g. `ema_123456789123456789_123456789123456789123456789`) and "expire after 1 year by
+default." Tokens "should be considered secret, and should not be shared publicly":
 
 ```bash
 export EARTHMOVER_API_KEY="<your-arraylake-api-key>"

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -35,7 +35,7 @@ open/free listings:
 
 1. Open the dataset's listing page (linked from the data source docstring above, or
    browse [app.earthmover.io/marketplace](https://app.earthmover.io/marketplace)).
-2. Click **Subscribe**, and choose which Arraylake organization should house the
+2. Click **Subscribe**, and choose which [Arraylake](https://docs.earthmover.io/) organization should house the
    resulting repository (you'll be prompted to create one if you don't have one yet).
    This creates a read-only repository under your organization, typically named
    `<org>/<dataset>-subscription`.
@@ -53,7 +53,7 @@ Attempting to read a repository without an active subscription raises a
 
 ## 2. Authenticate
 
-Set an Arraylake API key (create one at
+Set an [Arraylake](https://docs.earthmover.io/) API key (create one at
 [app.earthmover.io](https://app.earthmover.io) under account settings):
 
 ```bash
@@ -63,8 +63,8 @@ export EARTHMOVER_ORGANIZATION="<your-org-name>"
 
 `EARTHMOVER_ORGANIZATION` is only needed if you want the data source to derive the
 subscription repository name automatically (see below). Alternatively, pass a
-pre-authenticated `arraylake.AsyncClient` directly to the data source via the `client`
-argument.
+pre-authenticated [`arraylake.AsyncClient`](https://docs.earthmover.io/reference/client)
+directly to the data source via the `client` argument.
 
 ## 3. Use the data source
 
@@ -106,7 +106,7 @@ initial state.
 
 ## Variable resolution
 
-Marketplace repositories are not curated by Earth2Studio, so each Earthmover data
+[Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by Earth2Studio, so each Earthmover data
 source resolves Earth2Studio variable ids (e.g. `t2m`, `z500`) against the repository's
 native variable metadata at read time — matching on GRIB `paramId`, GRIB `shortName` /
 `cfVarName`, or CF `standard_name`, in that priority order.
@@ -116,8 +116,9 @@ returning the wrong field.
 
 ## Custom or private Arraylake repositories
 
-The Earthmover data sources are not limited to catalog listings from the Marketplace.
-Any Arraylake repository with a compatible CF/GRIB-annotated Zarr layout — including
+The Earthmover data sources are not limited to catalog listings from the
+[Marketplace](https://app.earthmover.io/marketplace).
+Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF/GRIB-annotated Zarr layout — including
 your own private repositories — can be read by passing `repo="org/repo"` explicitly,
 as shown above.
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD033 MD046 -->
+
 # Earthmover Marketplace { #earthmover_marketplace_userguide }
 
 The [Earthmover Marketplace](https://app.earthmover.io/marketplace) is Earthmover's
@@ -282,7 +284,7 @@ as shown above.
 | `ValueError: Set EARTHMOVER_API_KEY ...` | No credentials found | Set `EARTHMOVER_API_KEY` or pass an authenticated `client=` |
 | `PermissionError: Access to Arraylake repo '...' was denied` | No active subscription | Subscribe on the dataset's Marketplace listing page |
 | `ValueError: Arraylake repo '...' was not found` | Wrong repo name, or subscription not yet active | Double check the `org/repo` name and subscription status |
-| `ValueError: Could not resolve Earth2Studio variable '...' ` | Repository lacks GRIB/CF metadata for that variable | Check the error's list of available repository variables |
+| `ValueError: Could not resolve Earth2Studio variable '...'` | Repository lacks GRIB/CF metadata for that variable | Check the error's list of available repository variables |
 
 ## Further reading
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -24,7 +24,7 @@ verification data without writing any custom download or parsing code.
 | [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | [Brightband ECMWF IFS 0.1° (10 km) 15-day forecast](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
 
 Each dataset name links to its Marketplace listing page, which is where the Arraylake
-repository is hosted and subscribed to — dataset coverage, license and the
+repository is hosted and subscribed to. Dataset coverage, license and the
 **Subscribe** button all live there. Each data source class' docstring links to the
 same page.
 
@@ -32,8 +32,8 @@ same page.
 
 Marketplace data is **not copied into Earthmover's or your own storage**. Each dataset
 provider hosts their data in their own cloud object store (any S3-compatible store, GCS,
-or Azure Blob), and [Icechunk](https://icechunk.io/) — the versioned storage format
-Arraylake is built on — tracks it with cryptographically-addressed manifests.
+or Azure Blob), and [Icechunk](https://icechunk.io/) (the versioned storage format
+Arraylake is built on) tracks it with cryptographically-addressed manifests.
 Subscribing does not trigger a download:
 
 - **Free listings** give you a direct read-only view: your repo points at the
@@ -46,7 +46,7 @@ Subscribing does not trigger a download:
 In both cases, Icechunk's manifests prevent a subscriber from discovering or reading
 chunks outside their subscription. Arraylake reads lazily rather than downloading whole
 datasets, but (unlike Earth2Studio's other remote data sources) these classes do not
-maintain a local on-disk cache — every call re-reads from the provider's object store.
+maintain a local on-disk cache; every call re-reads from the provider's object store.
 
 ## 1. Subscribe to a dataset
 
@@ -59,7 +59,7 @@ open/free listings:
    resulting repository (you'll be prompted to create one if you don't have one yet).
    This creates a read-only repository under your organization, typically named
    `<org>/<dataset>-subscription`.
-3. Note your **organization name** — it's used to derive the repository path below.
+3. Note your **organization name**, used to derive the repository path below.
 
 Free listings subscribe instantly and give a complete mirror of the provider's
 repository, including full commit history. Paid listings require a
@@ -72,7 +72,7 @@ Attempting to read a repository without an active subscription raises a
 `PermissionError` pointing back to the listing page.
 
 !!! note "License & cost"
-    Each listing page states its own license and, for paid data, its pricing — set by
+    Each listing page states its own license and, for paid data, its pricing, set by
     the provider, not Earth2Studio. Storage for a subscription repo lives in the
     provider's bucket (free listings) or your own organization's bucket for the
     subscription metadata (paid listings); either way you are not billed for storing a
@@ -136,7 +136,7 @@ initial state.
 
 [Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by Earth2Studio, so each Earthmover data
 source resolves Earth2Studio variable ids (e.g. `t2m`, `z500`) against the repository's
-native variable metadata at read time — matching on GRIB `paramId`, GRIB `shortName` /
+native variable metadata at read time, matching on GRIB `paramId`, GRIB `shortName` /
 `cfVarName`, or CF `standard_name`, in that priority order.
 If a variable cannot be unambiguously resolved, the data source raises a `ValueError`
 listing which variables are available in the repository, rather than silently
@@ -146,8 +146,8 @@ returning the wrong field.
 
 The Earthmover data sources are not limited to catalog listings from the
 [Marketplace](https://app.earthmover.io/marketplace).
-Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF/GRIB-annotated Zarr layout — including
-your own private repositories — can be read by passing `repo="org/repo"` explicitly,
+Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF/GRIB-annotated Zarr layout,
+including your own private repositories, can be read by passing `repo="org/repo"` explicitly,
 as shown above.
 
 ## Troubleshooting
@@ -162,7 +162,7 @@ as shown above.
 
 ## Further reading
 
-- [Earthmover Marketplace](https://app.earthmover.io/marketplace) — browse listings
-- [Marketplace docs: Data Users](https://docs.earthmover.io/marketplace/data-users) — subscription mechanics
-- [Marketplace docs: FAQ](https://docs.earthmover.io/marketplace/faq) — pricing and plan requirements
-- [Arraylake client installation](https://docs.earthmover.io/setup/installation) — `arraylake` package setup
+- [Earthmover Marketplace](https://app.earthmover.io/marketplace): browse listings
+- [Marketplace docs: Data Users](https://docs.earthmover.io/marketplace/data-users): subscription mechanics
+- [Marketplace docs: FAQ](https://docs.earthmover.io/marketplace/faq): pricing and plan requirements
+- [Arraylake client installation](https://docs.earthmover.io/setup/installation): `arraylake` package setup

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -39,7 +39,7 @@ same page. Per the listing pages themselves:
 - [![ECMWF IFS Initial Conditions (open) listing](https://app.earthmover.io/marketplace/697162921880507a6587c31b/opengraph-image-9dzfy2?b1f408a208b63cfd)](https://app.earthmover.io/marketplace/697162921880507a6587c31b)
 
     "Dataset containing variables from the ECMWF IFS atmospheric models necessary for
-    initializing MLWP models."
+    initializing MLWP models, available 4x daily."
 
 - [![ECMWF IFS 15-day Forecast (open) listing](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04/opengraph-image-9dzfy2?b1f408a208b63cfd)](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04)
 
@@ -60,9 +60,9 @@ cryptographically-addressed manifests. Subscribing does not trigger a download:
 
 - **Free listings** are a direct subscription. Per
   [Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers),
-  "subscribers read data directly from your object store" and "see your full commit
-  history and can access any version" - no data is copied, your repo just points at
-  the provider's storage.
+  "subscribers read data directly from [the provider's] object store" and "see your
+  full commit history and can access any version" - no data is copied, your repo just
+  points at the provider's storage.
 - **Paid listings** are "filtered subscriptions": your repo stores only metadata (which
   chunks you're entitled to) in your own organization's bucket, while "the actual chunk
   data is read from [the provider's] object store" - scoped to what your subscription
@@ -70,9 +70,11 @@ cryptographically-addressed manifests. Subscribing does not trigger a download:
 
 Either way, "due to Icechunk's cryptographically random keys, it is not possible for
 the subscriber to discover any data not explicitly included in their manifests."
-Arraylake reads lazily rather than downloading whole
-datasets, but (unlike Earth2Studio's other remote data sources) these classes do not
-maintain a local on-disk cache; every call re-reads from the provider's object store.
+Arraylake reads lazily rather than downloading whole datasets. Unlike Earth2Studio's
+other remote data sources, these classes do not use Earth2Studio's own on-disk cache
+(the `cache` constructor argument is accepted for API compatibility but unused); any
+caching beyond that is internal to the `arraylake`/Icechunk client and not something
+Earth2Studio controls or has verified.
 
 ## 1. Subscribe to a dataset
 
@@ -90,7 +92,11 @@ Per [Earthmover's own docs](https://docs.earthmover.io/marketplace/data-users):
    this **organization name**, used to derive the repository path below.
 
 "When you subscribe to a dataset, a read-only repo appears in your Arraylake
-organization," typically named `<org>/<dataset>-subscription`.
+organization." The repo name is set by the provider and varies per listing - e.g.
+`<org>/era5-subscription` for ERA5, or
+`<org>/ecmwf-ifs-initial-conditions-open-subscription` for Brightband's IFS initial
+conditions - so check the listing page or the data source's docstring for the exact
+name.
 
 "Many datasets on the Marketplace are freely available. Anyone with an Arraylake
 account can subscribe to free listings instantly." Free listings "use direct
@@ -257,6 +263,14 @@ The Earthmover data sources are not limited to catalog listings from the
 Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF/GRIB-annotated Zarr layout,
 including your own private repositories, can be read by passing `repo="org/repo"` explicitly,
 as shown above.
+
+!!! warning
+    Each class also fixes which Zarr group(s) it opens, so a custom repo must match
+    that layout: `EarthMoverERA5` always opens the `single/spatial` and
+    `pressure/spatial` groups, while `EarthMoverBrightBandIFS` and
+    `EarthMoverBrightBandIFS_FX` open the repository's root group. A custom repo with a
+    different group layout will fail to connect even if its variable metadata is
+    otherwise compatible.
 
 ## Troubleshooting
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -1,0 +1,121 @@
+# Earthmover Marketplace { #earthmover_marketplace_userguide }
+
+The [Earthmover Marketplace](https://app.earthmover.io/marketplace) hosts analysis-ready
+weather and climate datasets stored as [Arraylake](https://docs.earthmover.io/) /
+[Icechunk](https://icechunk.io/) Zarr repositories.
+Earth2Studio ships a set of data sources under `earth2studio.data` that read directly
+from Marketplace repositories, so datasets can be used as initial conditions or
+verification data without writing any custom download or parsing code.
+
+!!! note
+    Arraylake-backed Earthmover data sources require **Python 3.12 or newer** and the
+    optional `arraylake` dependency, installed with:
+
+    ```bash
+    pip install earth2studio[data]
+    ```
+
+## Available Marketplace Data Sources
+
+| Data source | Type | Dataset |
+| --- | --- | --- |
+| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | ERA5 0.25° reanalysis |
+| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | Brightband ECMWF IFS 0.25° initial conditions |
+| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | Brightband ECMWF IFS 0.1° (10 km) 15-day forecast |
+
+Each class' docstring links to its Marketplace listing page, where dataset coverage,
+license and the subscription button live.
+
+## 1. Subscribe to a dataset
+
+Marketplace datasets require an active subscription before they can be read, even for
+open/free listings:
+
+1. Open the dataset's listing page (linked from the data source docstring above, or
+   browse [app.earthmover.io/marketplace](https://app.earthmover.io/marketplace)).
+2. Click **Subscribe**. This creates a repository under your organization, typically
+   named `<org>/<dataset>-subscription`.
+3. Note your **organization name** — it's used to derive the repository path below.
+
+Attempting to read a repository without an active subscription raises a
+`PermissionError` pointing back to the listing page.
+
+## 2. Authenticate
+
+Set an Arraylake API key (create one at
+[app.earthmover.io](https://app.earthmover.io) under account settings):
+
+```bash
+export EARTHMOVER_API_KEY="<your-arraylake-api-key>"
+export EARTHMOVER_ORGANIZATION="<your-org-name>"
+```
+
+`EARTHMOVER_ORGANIZATION` is only needed if you want the data source to derive the
+subscription repository name automatically (see below). Alternatively, pass a
+pre-authenticated `arraylake.AsyncClient` directly to the data source via the `client`
+argument.
+
+## 3. Use the data source
+
+With the repo name derived from `EARTHMOVER_ORGANIZATION`:
+
+```python
+from earth2studio.data import EarthMoverERA5
+
+ds = EarthMoverERA5()
+da = ds(time="2021-06-01T00:00:00", variable=["t2m", "u10m", "z500"])
+```
+
+Or pass an explicit `org/repo` to read a specific repository:
+
+```python
+from earth2studio.data import EarthMoverBrightBandIFS
+
+ds = EarthMoverBrightBandIFS(repo="my-org/ecmwf-ifs-initial-conditions-open-subscription")
+da = ds(time="2024-01-01T00:00:00", variable=["t2m", "z500", "u850"])
+```
+
+Forecast sources additionally take a `lead_time`:
+
+```python
+import numpy as np
+from earth2studio.data import EarthMoverBrightBandIFS_FX
+
+ds = EarthMoverBrightBandIFS_FX()
+da = ds(
+    time="2024-01-01T00:00:00",
+    lead_time=np.array([np.timedelta64(h, "h") for h in [0, 6, 12]]),
+    variable=["t2m", "u10m"],
+)
+```
+
+As with any [data source](datasources.md#datasources_userguide), the returned
+`xr.DataArray` can be used directly for postprocessing or moved to the GPU as a model
+initial state.
+
+## Variable resolution
+
+Marketplace repositories are not curated by Earth2Studio, so each Earthmover data
+source resolves Earth2Studio variable ids (e.g. `t2m`, `z500`) against the repository's
+native variable metadata at read time — matching on GRIB `paramId`, GRIB `shortName` /
+`cfVarName`, or CF `standard_name`, in that priority order.
+If a variable cannot be unambiguously resolved, the data source raises a `ValueError`
+listing which variables are available in the repository, rather than silently
+returning the wrong field.
+
+## Custom or private Arraylake repositories
+
+The Earthmover data sources are not limited to catalog listings from the Marketplace.
+Any Arraylake repository with a compatible CF/GRIB-annotated Zarr layout — including
+your own private repositories — can be read by passing `repo="org/repo"` explicitly,
+as shown above.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| `ValueError: Pass repo='org/repo' or set EARTHMOVER_ORGANIZATION ...` | No repo could be derived | Set `EARTHMOVER_ORGANIZATION` or pass `repo=` explicitly |
+| `ValueError: Set EARTHMOVER_API_KEY ...` | No credentials found | Set `EARTHMOVER_API_KEY` or pass an authenticated `client=` |
+| `PermissionError: Access to Arraylake repo '...' was denied` | No active subscription | Subscribe on the dataset's Marketplace listing page |
+| `ValueError: Arraylake repo '...' was not found` | Wrong repo name, or subscription not yet active | Double check the `org/repo` name and subscription status |
+| `ValueError: Could not resolve Earth2Studio variable '...' ` | Repository lacks GRIB/CF metadata for that variable | Check the error's list of available repository variables |

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -1,11 +1,12 @@
 # Earthmover Marketplace { #earthmover_marketplace_userguide }
 
-The [Earthmover Marketplace](https://app.earthmover.io/marketplace) hosts analysis-ready
-weather and climate datasets stored as [Arraylake](https://docs.earthmover.io/) /
-[Icechunk](https://icechunk.io/) Zarr repositories.
-Earth2Studio ships a set of data sources under `earth2studio.data` that read directly
-from Marketplace repositories, so datasets can be used as initial conditions or
-verification data without writing any custom download or parsing code.
+The [Earthmover Marketplace](https://app.earthmover.io/marketplace) is Earthmover's
+["modern, cloud-native data sharing experience for high-velocity gridded weather,
+climate, and geospatial datasets"](https://docs.earthmover.io/marketplace/data-users),
+stored as [Arraylake](https://docs.earthmover.io/) / [Icechunk](https://icechunk.io/)
+Zarr repositories. Earth2Studio ships a set of data sources under `earth2studio.data`
+that read directly from Marketplace repositories, so datasets can be used as initial
+conditions or verification data without writing any custom download or parsing code.
 
 !!! note
     Arraylake-backed Earthmover data sources require **Python 3.12 or newer** and the
@@ -36,15 +37,19 @@ or Azure Blob), and [Icechunk](https://icechunk.io/) (the versioned storage form
 Arraylake is built on) tracks it with cryptographically-addressed manifests.
 Subscribing does not trigger a download:
 
-- **Free listings** give you a direct read-only view: your repo points at the
-  provider's object store and reads chunks straight from it, including full commit
-  history.
-- **Paid ("filtered") listings** store only metadata (which chunks you're entitled to)
-  in your own organization's bucket; the chunk data itself is still read live from the
-  provider's store, scoped to what your subscription covers.
+- **Free listings** are a direct subscription. Per
+  [Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers),
+  "subscribers read data directly from your object store" and "see your full commit
+  history and can access any version" - no data is copied, your repo just points at
+  the provider's storage.
+- **Paid listings** are "filtered subscriptions": your repo stores only metadata (which
+  chunks you're entitled to) in your own organization's bucket, while "the actual chunk
+  data is read from [the provider's] object store" - scoped to what your subscription
+  covers.
 
-In both cases, Icechunk's manifests prevent a subscriber from discovering or reading
-chunks outside their subscription. Arraylake reads lazily rather than downloading whole
+Either way, "due to Icechunk's cryptographically random keys, it is not possible for
+the subscriber to discover any data not explicitly included in their manifests."
+Arraylake reads lazily rather than downloading whole
 datasets, but (unlike Earth2Studio's other remote data sources) these classes do not
 maintain a local on-disk cache; every call re-reads from the provider's object store.
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -157,6 +157,32 @@ As with any [data source](datasources.md#datasources_userguide), the returned
 `xr.DataArray` can be used directly for postprocessing or moved to the GPU as a model
 initial state.
 
+## Writing output to Arraylake
+
+Earth2Studio's [`IceChunkBackend`](io.md) IO backend is not integrated with Arraylake:
+it only accepts a plain `icechunk.Storage | str | None` and always calls
+`icechunk.Repository.open_or_create()` itself, so there is no supported way to point it
+at an Arraylake-managed org/repo directly.
+
+To write inference output (or any data) into an Arraylake repository, use the
+`arraylake` client directly instead of an Earth2Studio IO backend:
+
+```python
+import arraylake as al
+import zarr
+
+client = al.Client()
+repo = client.create_repo("your-org/your-repo")  # or client.get_repo(...)
+
+session = repo.writable_session("main")
+root = zarr.group(session.store)
+# write with normal zarr/xarray operations against session.store
+session.commit(message="Add data")
+```
+
+See [Earthmover's version control guide](https://docs.earthmover.io/guide/version-control)
+for the full writable-session and commit workflow.
+
 ## Variable resolution
 
 [Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by Earth2Studio, so each Earthmover data

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -28,6 +28,26 @@ repository is hosted and subscribed to — dataset coverage, license and the
 **Subscribe** button all live there. Each data source class' docstring links to the
 same page.
 
+## How the data is hosted
+
+Marketplace data is **not copied into Earthmover's or your own storage**. Each dataset
+provider hosts their data in their own cloud object store (any S3-compatible store, GCS,
+or Azure Blob), and [Icechunk](https://icechunk.io/) — the versioned storage format
+Arraylake is built on — tracks it with cryptographically-addressed manifests.
+Subscribing does not trigger a download:
+
+- **Free listings** give you a direct read-only view: your repo points at the
+  provider's object store and reads chunks straight from it, including full commit
+  history.
+- **Paid ("filtered") listings** store only metadata (which chunks you're entitled to)
+  in your own organization's bucket; the chunk data itself is still read live from the
+  provider's store, scoped to what your subscription covers.
+
+In both cases, Icechunk's manifests prevent a subscriber from discovering or reading
+chunks outside their subscription. Arraylake reads lazily rather than downloading whole
+datasets, but (unlike Earth2Studio's other remote data sources) these classes do not
+maintain a local on-disk cache — every call re-reads from the provider's object store.
+
 ## 1. Subscribe to a dataset
 
 Marketplace datasets require an active subscription before they can be read, even for
@@ -50,6 +70,14 @@ than mirroring the full dataset.
 
 Attempting to read a repository without an active subscription raises a
 `PermissionError` pointing back to the listing page.
+
+!!! note "License & cost"
+    Each listing page states its own license and, for paid data, its pricing — set by
+    the provider, not Earth2Studio. Storage for a subscription repo lives in the
+    provider's bucket (free listings) or your own organization's bucket for the
+    subscription metadata (paid listings); either way you are not billed for storing a
+    copy of the underlying dataset. Check the listing page before subscribing to a
+    paid dataset for the applicable terms.
 
 ## 2. Authenticate
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -268,8 +268,8 @@ Earthmover-account-level process, per
 [Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by
 Earth2Studio, so each Earthmover data source resolves Earth2Studio variable ids (e.g.
 `t2m`, `z500`) against the repository's native variable metadata at read time,
-matching on GRIB `paramId`, GRIB `shortName` / `cfVarName`, or CF `standard_name`, in
-that priority order.
+matching on `paramId`, `shortName` / `cfVarName`, or CF `standard_name` metadata
+attributes, in that priority order.
 
 If a variable cannot be unambiguously resolved, the data source raises a `ValueError`
 listing which variables are available in the repository, rather than silently
@@ -279,7 +279,7 @@ returning the wrong field.
 
 The Earthmover data sources are not limited to catalog listings from the
 [Marketplace](https://app.earthmover.io/marketplace).
-Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF/GRIB-annotated Zarr layout,
+Any [Arraylake](https://docs.earthmover.io/) repository with a compatible CF-annotated Zarr layout,
 including your own private repositories, can be read by passing `repo="org/repo"` explicitly,
 as shown above.
 
@@ -299,7 +299,7 @@ as shown above.
 | `ValueError: Set EARTHMOVER_API_KEY ...` | No credentials found | Set `EARTHMOVER_API_KEY` or pass an authenticated `client=` |
 | `PermissionError: Access to Arraylake repo '...' was denied` | No active subscription | Subscribe on the dataset's Marketplace listing page |
 | `ValueError: Arraylake repo '...' was not found` | Wrong repo name, or subscription not yet active | Double check the `org/repo` name and subscription status |
-| `ValueError: Could not resolve Earth2Studio variable '...'` | Repository lacks GRIB/CF metadata for that variable | Check the error's list of available repository variables |
+| `ValueError: Could not resolve Earth2Studio variable '...'` | Repository lacks the expected metadata attributes for that variable | Check the error's list of available repository variables |
 
 ## Further reading
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -6,9 +6,11 @@ The [Earthmover Marketplace](https://app.earthmover.io/marketplace) is Earthmove
 ["modern, cloud-native data sharing experience for high-velocity gridded weather,
 climate, and geospatial datasets"](https://docs.earthmover.io/marketplace/data-users),
 stored as [Arraylake](https://docs.earthmover.io/) / [Icechunk](https://icechunk.io/)
-Zarr repositories. Earth2Studio ships a set of data sources under `earth2studio.data`
-that read directly from Marketplace repositories, so datasets can be used as initial
-conditions or verification data without writing any custom download or parsing code.
+Zarr repositories.
+
+Earth2Studio ships a set of data sources under `earth2studio.data` that read directly
+from Marketplace repositories, so datasets can be used as initial conditions or
+verification data without writing any custom download or parsing code.
 
 !!! note
     Arraylake-backed Earthmover data sources require **Python 3.12 or newer** and the
@@ -53,14 +55,17 @@ same page. Per the listing pages themselves:
 
 The underlying chunk data is **never copied into Earthmover's or your own storage**
 (a paid subscription's own bucket holds only metadata about which chunks you can
-access, not the data itself - see below). Per
-[Earthmover's storage docs](https://docs.earthmover.io/concepts/storage), "Arraylake
+access, not the data itself - see below).
+
+Per [Earthmover's storage docs](https://docs.earthmover.io/concepts/storage), "Arraylake
 works with a wide range of commercial and open-source object storage services,
 including any S3-compatible object store as well as Google Cloud Storage and Microsoft
 Azure Blob Storage," and providers typically use "BYOB - Bring your own bucket": "all
-the data live in your cloud in your own object storage bucket." [Icechunk](https://icechunk.io/)
-(the versioned storage format Arraylake is built on) tracks it with
-cryptographically-addressed manifests. Subscribing does not trigger a download:
+the data live in your cloud in your own object storage bucket."
+
+[Icechunk](https://icechunk.io/) (the versioned storage format Arraylake is built on)
+tracks it with cryptographically-addressed manifests. Subscribing does not trigger a
+download:
 
 - **Free listings** are a direct subscription. Per
   [Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers),
@@ -74,6 +79,7 @@ cryptographically-addressed manifests. Subscribing does not trigger a download:
 
 Either way, "due to Icechunk's cryptographically random keys, it is not possible for
 the subscriber to discover any data not explicitly included in their manifests."
+
 Arraylake reads lazily rather than downloading whole datasets. Unlike Earth2Studio's
 other remote data sources, these classes do not use Earth2Studio's own on-disk cache
 (the `cache` constructor argument is accepted for API compatibility but unused); any
@@ -96,7 +102,9 @@ Per [Earthmover's own docs](https://docs.earthmover.io/marketplace/data-users):
    this **organization name**, used to derive the repository path below.
 
 "When you subscribe to a dataset, a read-only repo appears in your Arraylake
-organization." The repo name is set by the provider and varies per listing - e.g.
+organization."
+
+The repo name is set by the provider and varies per listing - e.g.
 `<org>/era5-subscription` for ERA5, or
 `<org>/ecmwf-ifs-initial-conditions-open-subscription` for Brightband's IFS initial
 conditions - so check the listing page or the data source's docstring for the exact
@@ -105,9 +113,11 @@ name.
 "Many datasets on the Marketplace are freely available. Anyone with an Arraylake
 account can subscribe to free listings instantly." Free listings "use direct
 subscriptions" - "your repo is a complete mirror of the provider's repo," including
-full commit history. Paid listings are premium offerings that "use filtered
-subscriptions": "instead of mirroring the provider's entire repo, you receive a repo
-scoped to specific variables, time ranges, or spatial regions," and require a
+full commit history.
+
+Paid listings are premium offerings that "use filtered subscriptions": "instead of
+mirroring the provider's entire repo, you receive a repo scoped to specific variables,
+time ranges, or spatial regions," and require a
 [Professional Arraylake plan](https://docs.earthmover.io/marketplace/faq).
 
 Attempting to read a repository without an active subscription raises a
@@ -135,6 +145,7 @@ Set an [Arraylake](https://docs.earthmover.io/) API key. Per
 a new API key, click on the big purple 'New API Client' button" in your organization's
 settings on [app.earthmover.io](https://app.earthmover.io), "enter a name for the API
 key, then select the appropriate permissions (read/write), and the key's lifetime."
+
 The resulting "secret tokens are a single string, prefixed with the `ema_` identifier"
 (e.g. `ema_123456789123456789_123456789123456789123456789`) and "expire after 1 year by
 default." Tokens "should be considered secret, and should not be shared publicly":
@@ -227,8 +238,10 @@ for the full writable-session and commit workflow.
 
 Writing to your own repo is enough to use it as a `repo="org/repo"` data source (see
 [Custom or private Arraylake repositories](#custom-or-private-arraylake-repositories)
-below), but publishing it as a Marketplace listing so others can subscribe is a
-separate, Earthmover-account-level process, per
+below).
+
+Publishing it as a Marketplace listing so others can subscribe is a separate,
+Earthmover-account-level process, per
 [Earthmover's provider docs](https://docs.earthmover.io/marketplace/data-providers):
 
 1. Create an organization at
@@ -252,10 +265,12 @@ separate, Earthmover-account-level process, per
 
 ## Variable resolution
 
-[Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by Earth2Studio, so each Earthmover data
-source resolves Earth2Studio variable ids (e.g. `t2m`, `z500`) against the repository's
-native variable metadata at read time, matching on GRIB `paramId`, GRIB `shortName` /
-`cfVarName`, or CF `standard_name`, in that priority order.
+[Marketplace](https://app.earthmover.io/marketplace) repositories are not curated by
+Earth2Studio, so each Earthmover data source resolves Earth2Studio variable ids (e.g.
+`t2m`, `z500`) against the repository's native variable metadata at read time,
+matching on GRIB `paramId`, GRIB `shortName` / `cfVarName`, or CF `standard_name`, in
+that priority order.
+
 If a variable cannot be unambiguously resolved, the data source raises a `ValueError`
 listing which variables are available in the repository, rather than silently
 returning the wrong field.

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -18,16 +18,34 @@ conditions or verification data without writing any custom download or parsing c
 
 ## Available Marketplace Data Sources
 
-| Data source | Type | Dataset (hosted repo listing) |
-| --- | --- | --- |
-| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | [ERA5 0.25° reanalysis](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) |
-| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | [Brightband ECMWF IFS 0.25° initial conditions](https://app.earthmover.io/marketplace/697162921880507a6587c31b) |
-| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | [Brightband ECMWF IFS 0.1° (10 km) 15-day forecast](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
+| Data source | Type | Provider | Dataset (hosted repo listing) |
+| --- | --- | --- | --- |
+| [`earth2studio.data.EarthMoverERA5`](../../modules/datasources_analysis.md) | Analysis | `earthmover-public` | [ERA5 0.25° reanalysis](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2) |
+| [`earth2studio.data.EarthMoverBrightBandIFS`](../../modules/datasources_analysis.md) | Analysis | `brightband` | [Brightband ECMWF IFS 0.25° initial conditions](https://app.earthmover.io/marketplace/697162921880507a6587c31b) |
+| [`earth2studio.data.EarthMoverBrightBandIFS_FX`](../../modules/datasources_forecast.md) | Forecast | `brightband` | [Brightband ECMWF IFS 0.1° (10 km) 15-day forecast](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04) |
 
 Each dataset name links to its Marketplace listing page, which is where the Arraylake
 repository is hosted and subscribed to. Dataset coverage, license and the
 **Subscribe** button all live there. Each data source class' docstring links to the
-same page.
+same page. Per the listing pages themselves:
+
+<div class="grid cards" markdown>
+
+- [![ERA5 listing](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2/opengraph-image-9dzfy2?b1f408a208b63cfd)](https://app.earthmover.io/marketplace/6a19bcfe9aa6e97720a2fad2)
+
+    "ECMWF ERA5 hourly single and pressure levels starting 1940-01-01, updated every
+    three months."
+
+- [![ECMWF IFS Initial Conditions (open) listing](https://app.earthmover.io/marketplace/697162921880507a6587c31b/opengraph-image-9dzfy2?b1f408a208b63cfd)](https://app.earthmover.io/marketplace/697162921880507a6587c31b)
+
+    "Dataset containing variables from the ECMWF IFS atmospheric models necessary for
+    initializing MLWP models."
+
+- [![ECMWF IFS 15-day Forecast (open) listing](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04/opengraph-image-9dzfy2?b1f408a208b63cfd)](https://app.earthmover.io/marketplace/6971be98fc964a0d0fb66e04)
+
+    "ECMWF IFS 15-day forecast surface fields, available before ECMWF Open Data."
+
+</div>
 
 ## How the data is hosted
 

--- a/docs/userguide/components/earthmover_marketplace.md
+++ b/docs/userguide/components/earthmover_marketplace.md
@@ -99,34 +99,44 @@ directly to the data source via the `client` argument.
 With the repo name derived from `EARTHMOVER_ORGANIZATION`:
 
 ```python
+from datetime import datetime
 from earth2studio.data import EarthMoverERA5
 
 ds = EarthMoverERA5()
-da = ds(time="2021-06-01T00:00:00", variable=["t2m", "u10m", "z500"])
+da = ds(time=datetime(2021, 6, 1), variable=["t2m", "u10m", "z500"])
 ```
 
 Or pass an explicit `org/repo` to read a specific repository:
 
 ```python
+from datetime import datetime
 from earth2studio.data import EarthMoverBrightBandIFS
 
 ds = EarthMoverBrightBandIFS(repo="my-org/ecmwf-ifs-initial-conditions-open-subscription")
-da = ds(time="2024-01-01T00:00:00", variable=["t2m", "z500", "u850"])
+da = ds(time=datetime(2024, 1, 1), variable=["t2m", "z500", "u850"])
 ```
 
 Forecast sources additionally take a `lead_time`:
 
 ```python
+from datetime import datetime
+
 import numpy as np
 from earth2studio.data import EarthMoverBrightBandIFS_FX
 
 ds = EarthMoverBrightBandIFS_FX()
 da = ds(
-    time="2024-01-01T00:00:00",
+    time=datetime(2024, 1, 1),
     lead_time=np.array([np.timedelta64(h, "h") for h in [0, 6, 12]]),
     variable=["t2m", "u10m"],
 )
 ```
+
+!!! note
+    Pass `datetime` objects (or a list/array of them) directly to a data source, as
+    shown above; passing a raw ISO string is not supported. Workflow entry points such
+    as `earth2studio.run.deterministic` convert `list[str]` time inputs for you via
+    `earth2studio.utils.time.to_time_array`, but calling a data source directly does not.
 
 As with any [data source](datasources.md#datasources_userguide), the returned
 `xr.DataArray` can be used directly for postprocessing or moved to the GPU as a model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -517,6 +517,7 @@ nav:
     - Diagnostic Models: userguide/components/diagnostic.md
     - Data Assimilation Models: userguide/components/data_assimilation.md
     - Data Sources: userguide/components/datasources.md
+    - Earthmover Marketplace: userguide/components/earthmover_marketplace.md
     - Perturbations: userguide/components/perturbation.md
     - IO Backends: userguide/components/io.md
     - Statistics: userguide/components/statistics.md


### PR DESCRIPTION
# Earth2Studio Pull Request

## Description
Adds a new user guide page (`docs/userguide/components/earthmover_marketplace.md`)
documenting how to use Earth2Studio's Earthmover Marketplace data sources
(`EarthMoverERA5`, `EarthMoverBrightBandIFS`, `EarthMoverBrightBandIFS_FX`):
subscribing to a listing, authenticating, fetching data, how the data is hosted
(read live from the provider's own object store via Icechunk, not copied), writing
output back to Arraylake, and publishing your own Marketplace listing. Wired into
`mkdocs.yml` nav and cross-linked from the existing Data Sources page. Also fixes the
data-source usage examples to pass `datetime` objects instead of raw ISO strings,
which `prep_data_inputs` does not support outside of `run.deterministic`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [ ] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

None.