### PR TITLE
feat(skills): add checkpoint guidance to model creation skills

### DIFF
--- a/skills/earth2studio-create-diagnostic/SKILL.md
+++ b/skills/earth2studio-create-diagnostic/SKILL.md
@@ -24,6 +24,7 @@ success.
 - [ ] Read this SKILL.md completely first
 - [ ] Get the reference script, repo, paper, or model documentation (Step 0)
 - [ ] Classify the diagnostic as simple, AutoModel, or generative (Step 1)
+- [ ] Decide whether mutable RNG, sampler, or cache state requires checkpoint support
 - [ ] Propose dependency extras before editing dependency files (Step 1)
 - [ ] Create `earth2studio/models/dx/<name>.py` with diagnostic-only APIs
 - [ ] Create `test/models/dx/test_<name>.py` with mock tests
@@ -87,6 +88,7 @@ Load these files on demand during the matching workflow:
 | `references/skeleton-template.py` | Full diagnostic skeletons for simple, AutoModel, and generative wrappers | Steps 3-6 |
 | `references/method-templates.py` | Focused coordinate, loading, forward, and device method snippets | Steps 4-6 |
 | `references/testing-guide.py` | Mock, package, exception, sample, and seed test patterns | Step 7 |
+| `references/checkpointing.md` | Stateless and stateful diagnostic checkpoint patterns | Steps 1, 5, 7 |
 | `references/validation-guide.md` | Reference comparison, plots, PR hygiene, and review follow-up | Steps 10-11 |
 | `references/pr-body-template.md` | PR body template | Step 11 |
 | `references/pr-comment-template.md` | Validation comment template | Step 11 |
@@ -151,6 +153,7 @@ import numpy as np
 import torch
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.checkpoint import bind_checkpoint_state  # stateful models only
 from earth2studio.utils.type import CoordSystem
 ```
 
@@ -195,6 +198,10 @@ it a tensor dimension unless an existing dx pattern requires it.
 Then update output variables and, when needed, output lat/lon resolution.
 Generative diagnostics must add a `sample` dimension after `batch`.
 
+Deterministic stateless diagnostics do not need checkpoint state. Generative or
+otherwise stateful diagnostics must bind only the RNG, sampler, counter, or
+cache state needed by the next call.
+
 ### Step 5 - Implement Forward Pass
 
 Use a single-step `__call__`; never create an iterator. Validate coordinates
@@ -213,6 +220,13 @@ def __call__(self, x: torch.Tensor, coords: CoordSystem) -> tuple[torch.Tensor, 
 For generative diagnostics, loop over the batch dimension and generate
 `number_of_samples` per input item. Use explicit seeds for reproducibility when
 the reference implementation supports seeded sampling.
+
+If the diagnostic has mutable state, bind a dataclass with
+`bind_checkpoint_state` in `__init__`, restore it before the first call, and
+update it after a successful call. Construct restart-aware diagnostics inside
+the active checkpoint context. Do not checkpoint model weights, static buffers,
+or generated output history. If the diagnostic is stateless, document that
+checkpoint support is not required instead of adding a no-op state object.
 
 ### Step 6 - Implement Model Loading
 
@@ -239,6 +253,11 @@ Required tests:
 Generative diagnostics also require sample-count and deterministic-seed tests.
 Use `references/testing-guide.py`. Create a `Phoo<ModelName>` dummy that matches
 the real core model's interface and produces deterministic output.
+
+For stateful diagnostics, add a checkpoint round-trip test with a temporary
+checkpoint and verify that a resumed call produces the same next sample or
+counter value as an uninterrupted instance. Stateless diagnostics need no
+checkpoint-specific test.
 
 Run focused tests:
 
@@ -341,6 +360,7 @@ Do:
 - Keep `batch` as the first coordinate with `np.empty(0)` in `input_coords`.
 - Validate coordinates with `handshake_dim()` and `handshake_coords()`.
 - Add `sample` in generative `output_coords`.
+- Bind only required mutable state with `bind_checkpoint_state`; keep stateless diagnostics checkpoint-free.
 - Include the repo-standard SPDX/license header in every Python file.
 - Use `loguru.logger`, never `print()`, inside `earth2studio/`.
 

--- a/skills/earth2studio-create-diagnostic/references/checkpointing.md
+++ b/skills/earth2studio-create-diagnostic/references/checkpointing.md
@@ -1,0 +1,65 @@
+# Checkpointing Diagnostic Models
+
+Most deterministic diagnostic models are stateless: they transform one input
+state into one output state and do not need checkpoint support. Do not bind a
+checkpoint dataclass merely because a model loads weights or normalization
+buffers. Record that the model is stateless and test its ordinary forward path.
+
+## When State Is Required
+
+Bind state only when a diagnostic has mutable information that changes the next
+call, such as:
+
+- a random-number-generator state or sampling counter,
+- a stateful sampler, diffusion schedule, or cache,
+- mutable auxiliary data required to reproduce the next generated sample.
+
+There is no diagnostic iterator. A stateful diagnostic restores state during
+construction and updates it after a successful call. Model weights, static
+normalization tensors, and generated output history do not belong in the
+checkpoint.
+
+## Bind Component State
+
+Use a small dataclass and bind it in `__init__`:
+
+```python
+from dataclasses import dataclass
+
+import torch
+
+from earth2studio.utils.checkpoint import bind_checkpoint_state
+
+
+@dataclass
+class _DiagnosticCheckpointState:
+    rng_state: torch.Tensor | None = None
+    sample_count: int = 0
+
+
+class StatefulDiagnostic(...):
+    def __init__(self, ...) -> None:
+        super().__init__()
+        self.checkpoint = bind_checkpoint_state(_DiagnosticCheckpointState())
+        if self.checkpoint.rng_state is not None:
+            self.generator.set_state(self.checkpoint.rng_state)
+```
+
+Construct the diagnostic inside the active `Checkpoint` or
+`checkpoint.select(...)` context so saved state is restored before the first
+sample. After sampling, update only the state needed for the next call. Save
+RNG tensors with `detach().clone()` on `self.checkpoint.device` when required.
+Use a dedicated `torch.Generator` where possible instead of changing global
+RNG state.
+
+## Round-Trip Test
+
+For a stateful diagnostic, use a temporary `Checkpoint(..., level=1)` or the
+level required by the component. Call the diagnostic, record a checkpoint
+boundary with `ckpt.write(...)`, then construct a new instance inside
+`with checkpoint.select(-1):`. Verify that the resumed call matches the next
+call of an uninterrupted instance and that counters or RNG state advance once.
+
+For a stateless diagnostic, do not add a synthetic checkpoint field just to
+make this test pass. A normal forward test is sufficient; package tests should
+continue to verify loading and inference separately.

--- a/skills/earth2studio-create-diagnostic/references/skeleton-template.py
+++ b/skills/earth2studio-create-diagnostic/references/skeleton-template.py
@@ -34,6 +34,7 @@ Canonical method order:
 """
 
 from collections import OrderedDict
+from dataclasses import dataclass
 
 import numpy as np
 import torch
@@ -43,6 +44,7 @@ from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
 from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.checkpoint import bind_checkpoint_state
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
     check_optional_dependencies,
@@ -59,6 +61,14 @@ except ImportError:
 
 INPUT_VARIABLES = ["u10m", "v10m", "t2m", "msl"]
 OUTPUT_VARIABLES = ["tp"]
+
+
+# Only stateful or stochastic diagnostics need this pattern. Remove it for a
+# deterministic stateless diagnostic.
+@dataclass
+class _DiagnosticCheckpointState:
+    rng_state: torch.Tensor | None = None
+    sample_count: int = 0
 
 
 class SimpleDiagnostic(torch.nn.Module):
@@ -124,6 +134,9 @@ class AutoModelDiagnostic(torch.nn.Module, AutoModelMixin):
         self.core_model = core_model
         self.register_buffer("center", center)
         self.register_buffer("scale", scale)
+        # For a stateful diagnostic, bind _DiagnosticCheckpointState here and
+        # restore its RNG/sampler state before the first call.
+        # self.checkpoint = bind_checkpoint_state(_DiagnosticCheckpointState())
 
     def input_coords(self) -> CoordSystem:
         return OrderedDict(
@@ -221,6 +234,9 @@ class GenerativeDiagnostic(torch.nn.Module, AutoModelMixin):
         self.output_variables = output_variables
         self.number_of_samples = number_of_samples
         self.seed = seed
+        # A stochastic diagnostic with mutable sampler state should bind a
+        # checkpoint dataclass here. Stateless seeded sampling does not need it.
+        # self.checkpoint = bind_checkpoint_state(_DiagnosticCheckpointState())
         self.register_buffer("in_center", in_center)
         self.register_buffer("in_scale", in_scale)
         self.register_buffer("out_center", out_center)

--- a/skills/earth2studio-create-diagnostic/references/testing-guide.py
+++ b/skills/earth2studio-create-diagnostic/references/testing-guide.py
@@ -28,6 +28,13 @@ Required standard tests:
 
 Generative diagnostics also need sample-count and deterministic-seed coverage.
 Run tests with `uv run pytest`.
+
+Checkpoint coverage is conditional. Stateless diagnostics should document that
+no checkpoint state is required. Stateful or stochastic diagnostics need a
+round-trip test that writes a checkpoint boundary, constructs a new diagnostic
+inside `with checkpoint.select(-1):`, and verifies that the next sample or
+counter matches an uninterrupted instance. Keep model weights and output
+history outside component checkpoint state.
 """
 
 from collections import OrderedDict

--- a/skills/earth2studio-create-prognostic/SKILL.md
+++ b/skills/earth2studio-create-prognostic/SKILL.md
@@ -17,6 +17,7 @@ argument-hint: URL or local path to reference inference script (optional)
 
 - [ ] Read this SKILL.md completely first
 - [ ] Get reference script (Step 0)
+- [ ] Decide whether the model has mutable rollout state and apply checkpoint guidance
 - [ ] Create `earth2studio/models/px/<name>.py` with triple inheritance
 - [ ] Create `test/models/px/test_<name>.py` with mock tests
 - [ ] Run: `uv run pytest test/models/px/test_<name>.py -v`
@@ -55,6 +56,7 @@ Load on demand during the matching step:
 | `references/skeleton-template.py` | Full model skeleton with FILL comments | Steps 3–6 |
 | `references/method-templates.py` | Canonical method implementations | Steps 4–6 |
 | `references/testing-guide.py` | Test skeleton and mock patterns | Step 7 |
+| `references/checkpointing.md` | Checkpoint state and restart patterns | Steps 1, 5, 7 |
 | `references/validation-guide.md` | Comparison scripts, PR, code review | Steps 10–11 |
 
 ---
@@ -68,7 +70,9 @@ If `$ARGUMENTS` provided, use it. Otherwise ask:
 
 ### Step 1 — Analyze & Propose Dependencies
 
-Analyze: packages, architecture, I/O shapes, time step, resolution, checkpoint.
+Analyze: packages, architecture, I/O shapes, time step, resolution, and whether
+the wrapper has mutable rollout state that must survive a restart. Read
+`references/checkpointing.md` before choosing a state representation.
 
 Propose `pyproject.toml` group (alphabetical, add to `all`). Every
 prognostic model must have an optional dependency extra, even when no packages
@@ -105,6 +109,7 @@ from earth2studio.models.px.base import PrognosticMixin
 from earth2studio.models.utils import create_coords_from_lat_lon, handshake_dim
 from earth2studio.lexicon import E2STUDIO_VOCAB
 from earth2studio.utils import check_optional_dependencies
+from earth2studio.utils.checkpoint import bind_checkpoint_state  # stateful models only
 from loguru import logger
 ```
 
@@ -141,6 +146,15 @@ Reshape to model format → call model → reshape back.
 **`create_iterator`:** MUST yield initial condition first (step 0).
 Use `front_hook`/`rear_hook` for perturbation injection.
 
+If the wrapper has mutable rollout state, bind a dataclass with
+`bind_checkpoint_state` in `__init__`. Restore only when a selected checkpoint
+contains state at the requested level, save state after each successful forward
+step and rear hook, and stage tensor state on `self.checkpoint.device`. A fresh
+iterator yields the initial condition; a resumed iterator yields the next state
+after the saved boundary. Construct restart-aware models inside the active
+checkpoint context. Stateless wrappers should explicitly document that no
+component checkpoint state is required.
+
 ### Step 6 — Implement Model Loading
 
 **`load_default_package`:** Lock HuggingFace URLs: `hf://org/repo@commit`
@@ -161,6 +175,11 @@ decorate with `@check_optional_dependencies()`.
 | `test_<model>_package` | Real weights (`@pytest.mark.package`) |
 
 Create `PhooModelName` dummy matching interface for mock tests.
+
+For stateful models, add a checkpoint round-trip test using a temporary
+`Checkpoint(..., level=2)`: write a completed lead time, construct the model
+under `with checkpoint.select(-1):`, and verify that the next output matches an
+uninterrupted rollout. Do not force checkpoint fields into stateless models.
 
 **Run tests:**
 ```bash
@@ -292,6 +311,7 @@ def create_iterator(self, x, coords):
 - Inherit `torch.nn.Module + AutoModelMixin + PrognosticMixin`
 - Yield initial condition first in `create_iterator`
 - Use `front_hook()`/`rear_hook()` in `_default_generator`
+- Bind only required mutable rollout state with `bind_checkpoint_state`; test restart behavior
 - Include SPDX header in every .py file
 
 **DON'T:**

--- a/skills/earth2studio-create-prognostic/references/checkpointing.md
+++ b/skills/earth2studio-create-prognostic/references/checkpointing.md
@@ -1,0 +1,80 @@
+# Checkpointing Prognostic Models
+
+Use checkpoint support when a prognostic wrapper has mutable state that is
+needed to continue a rollout. A model that only applies a stateless forward
+map does not need to bind checkpoint state; document that fact in the PR and
+test the normal iterator path without checkpoint state.
+
+## Decide What Belongs in State
+
+Keep only restart state in the checkpoint dataclass:
+
+- rollout tensors that are not available from the workflow's next input,
+- rolling history or cached coordinates,
+- counters, sampler state, or component RNG state needed for the next step.
+
+Do not store model weights, normalization constants, or the complete forecast
+history. Weights and static tensors belong to the model package, and forecast
+fields belong in the configured IO backend.
+
+## Bind Component State
+
+Define a dataclass for the smallest restartable state and bind it in the model
+constructor:
+
+```python
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from earth2studio.utils.checkpoint import bind_checkpoint_state
+
+
+@dataclass
+class _ModelCheckpointState:
+    x: torch.Tensor | None = None
+    coord_keys: tuple[str, ...] = ()
+    coord_values: tuple[np.ndarray, ...] = ()
+
+
+class ModelName(...):
+    def __init__(self, ...) -> None:
+        super().__init__()
+        self.checkpoint = bind_checkpoint_state(_ModelCheckpointState())
+```
+
+Construct the model inside the active `Checkpoint` or
+`checkpoint.select(...)` context when an existing state must be restored during
+initialization. The bound proxy exposes `checkpoint_level`,
+`checkpoint_state_loaded`, `checkpoint_enabled`, and `device`.
+
+## Rollout Lifecycle
+
+1. At iterator setup, restore saved state only when
+   `checkpoint_level == 2` and `checkpoint_state_loaded` is true.
+2. On a fresh run, yield the supplied initial condition at lead time zero.
+3. On a resumed run, use the saved boundary and yield the next forecast state;
+   do not emit the already committed state twice.
+4. After a successful forward step and rear hook, save the state needed by the
+   next step. Clone and detach tensors, and stage them on
+   `self.checkpoint.device`.
+5. Let the workflow call `ckpt.write(...)` after the corresponding IO write;
+   component state becomes durable when the checkpoint is flushed.
+
+Checkpoint levels are user-configured: level 0 records workflow progress only,
+level 1 supports component state needed to restart workflow items, and level 2
+supports state needed to resume inside a rollout. A model must not assume that
+its component state is available at lower levels.
+
+## Round-Trip Test
+
+Add a focused test with a temporary checkpoint directory. Run one or more
+steps under `Checkpoint(..., level=2)`, call `ckpt.write` at the saved lead
+time, then construct a new model inside `with checkpoint.select(-1):`. Verify
+that the restored model emits the next lead time and the same state as an
+uninterrupted rollout. Also cover the no-checkpoint path and, when applicable,
+level 0 or level 1 behavior.
+
+Use `test/models/px/test_fcn.py` and
+`test/models/px/test_persistence.py` as reference implementations.

--- a/skills/earth2studio-create-prognostic/references/skeleton-template.py
+++ b/skills/earth2studio-create-prognostic/references/skeleton-template.py
@@ -39,6 +39,7 @@ See real examples:
 
 from collections import OrderedDict
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import numpy as np
 import torch
@@ -48,6 +49,7 @@ from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.px.base import PrognosticModel
 from earth2studio.models.px.utils import PrognosticMixin
 from earth2studio.utils import handshake_coords, handshake_dim
+from earth2studio.utils.checkpoint import bind_checkpoint_state
 from earth2studio.utils.imports import (
     OptionalDependencyFailure,
     check_optional_dependencies,
@@ -82,6 +84,15 @@ VARIABLES = [
     "u500",
     "v500",
 ]
+
+
+# Only add this state for mutable rollout state. Stateless wrappers should
+# remove the import and omit the binding below.
+@dataclass
+class _ModelCheckpointState:
+    x: torch.Tensor | None = None
+    coord_keys: tuple[str, ...] = ()
+    coord_values: tuple[np.ndarray, ...] = ()
 
 
 class ModelName(torch.nn.Module, AutoModelMixin, PrognosticMixin):
@@ -135,6 +146,9 @@ class ModelName(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         self.register_buffer("device_buffer", torch.empty(0))
         # TODO: Store time step as timedelta
         self._time_step = np.timedelta64(6, "h")
+        # Remove this binding for a stateless model. Construct the model inside
+        # an active checkpoint context when selected state must be restored.
+        # self.checkpoint = bind_checkpoint_state(_ModelCheckpointState())
 
     # =========================================================================
     # 2. INPUT COORDINATES
@@ -392,6 +406,8 @@ class ModelName(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             Predicted state and coordinates at each time step.
         """
         # MUST yield initial condition first (step 0)
+        # On a level-2 restart, restore saved state first and yield the next
+        # step instead of yielding the already committed boundary again.
         yield x, coords
 
         # Time integration loop (runs indefinitely)
@@ -406,6 +422,9 @@ class ModelName(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
             # Apply rear hook (for post-processing, etc.)
             current_x, current_coords = self.rear_hook(current_x, current_coords)
+
+            # For stateful models, save current_x/current_coords here after the
+            # successful step. Clone and detach tensors onto checkpoint.device.
 
             yield current_x, current_coords
 

--- a/skills/earth2studio-create-prognostic/references/testing-guide.py
+++ b/skills/earth2studio-create-prognostic/references/testing-guide.py
@@ -38,6 +38,14 @@ See real examples:
 - test/models/px/test_aurora.py
 
 Use `uv run pytest` to execute tests
+
+Checkpoint coverage is conditional. Stateless prognostic models should state
+that checkpoint state is not required. Stateful models must add a level-2
+round-trip test: run through a saved boundary, call `ckpt.write`, construct a
+new model inside `with checkpoint.select(-1):`, and verify that the resumed
+iterator yields the next lead time and agrees with an uninterrupted rollout.
+Use `earth2studio.utils.checkpoint.Checkpoint` with a temporary path. Do not
+serialize model weights or full forecast history as component state.
 """
 
 import gc


### PR DESCRIPTION
## Summary

- Add checkpoint state and restart guidance to the prognostic and diagnostic model creation skills.
- Add conditional checkpoint patterns to both skeleton templates and testing guides.
- Clarify stateless models, checkpoint levels, state boundaries, and round-trip tests.

Closes #933

## Validation

- `make format`
- `make lint`
- `make license`
- `uv run pytest test/utils/test_checkpoint.py test/models/px/test_persistence.py -m "not package" -k "cpu or checkpoint_state_round_trip" -q`
  - 18 passed

The full selected test command also exercises `cuda:0` parameterizations; those 17 cases cannot run on this macOS environment because the installed PyTorch has no CUDA support.