### PR TITLE
Fix CorrDiffCosmoEra5SDA divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `CorrDiffCosmoEra5SDA`: raised the default `sda_gamma` from `5e-5` to `1e-4`
-  to keep the observation-guided analysis stable (the old default could diverge
-  to non-finite output).
+- `CorrDiffCosmoEra5SDA`: retuned the default DPS guidance (`sda_std_obs`
+  `0.5` -> `0.75`, `sda_gamma` `5e-5` -> `7.5e-5`) to keep the observation-guided
+  analysis stable (the old defaults could diverge to non-finite output).
 - Fixed empty reduction dimensions in statistics, skipping for mean and
   rejecting as undefined for variance/std reductions.
 - `StormCast.__call__` no longer writes its output into the input tensor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `CorrDiffCosmoEra5SDA`: raised the default `sda_gamma` from `5e-5` to `1e-4`
+  to keep the observation-guided analysis stable (the old default could diverge
+  to non-finite output).
 - Fixed empty reduction dimensions in statistics, skipping for mean and
   rejecting as undefined for variance/std reductions.
 - `StormCast.__call__` no longer writes its output into the input tensor.

--- a/earth2studio/models/da/sda_corrdiff_cosmo_era5.py
+++ b/earth2studio/models/da/sda_corrdiff_cosmo_era5.py
@@ -118,7 +118,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         Diffusion sampler steps; defaults to the wrapped model's
         ``number_of_steps``.
     sda_std_obs : float | Mapping[str, float], optional
-        Observation-noise standard deviation for DPS guidance, by default 0.5.
+        Observation-noise standard deviation for DPS guidance, by default 0.75.
         A scalar is broadcast to every assimilated variable (in that variable's
         physical units); a mapping sets it per variable and must contain exactly the
         assimilated variables (unknown keys are rejected) -- e.g.
@@ -127,7 +127,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         finite and > 0. It is the effective uncertainty per occupied grid cell
         (multiple observations in one cell are averaged, not reduced by sqrt(n)).
     sda_gamma : float, optional
-        SDA covariance scaling in the DPS likelihood, by default 1e-4. Positive
+        SDA covariance scaling in the DPS likelihood, by default 7.5e-5. Positive
         values account for denoiser-estimate uncertainty across diffusion noise
         levels. Larger values weaken observation guidance, especially early in
         denoising, so the analysis stays closer to the unguided downscaler and may
@@ -154,8 +154,8 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         number_of_samples: int | None = None,
         sampler_steps: int | None = None,
-        sda_std_obs: float | Mapping[str, float] = 0.5,
-        sda_gamma: float = 1e-4,
+        sda_std_obs: float | Mapping[str, float] = 0.75,
+        sda_gamma: float = 7.5e-5,
         amp: bool = False,
     ) -> None:
         super().__init__()
@@ -733,8 +733,8 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         time_tolerance: TimeTolerance = np.timedelta64(10, "m"),
         number_of_samples: int | None = None,
         sampler_steps: int | None = None,
-        sda_std_obs: float | Mapping[str, float] = 0.5,
-        sda_gamma: float = 1e-4,
+        sda_std_obs: float | Mapping[str, float] = 0.75,
+        sda_gamma: float = 7.5e-5,
         amp: bool = False,
     ) -> AssimilationModel:
         """Load the assimilation model from a CorrDiff-COSMO package.
@@ -773,12 +773,12 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
             Number of diffusion sampler steps; defaults to the wrapped model's
             ``number_of_steps``.
         sda_std_obs : float | Mapping[str, float], optional
-            Assumed observation-noise std (lower trusts obs more), by default 0.5.
+            Assumed observation-noise std (lower trusts obs more), by default 0.75.
             A scalar broadcasts to every variable; a mapping sets it per variable and
             must contain exactly the assimilated variables (e.g.
             ``{"u10m": 0.5, "v10m": 0.5}``).
         sda_gamma : float, optional
-            SDA covariance scaling in the DPS likelihood, by default 1e-4. Positive
+            SDA covariance scaling in the DPS likelihood, by default 7.5e-5. Positive
             values account for denoiser-estimate uncertainty across diffusion noise
             levels. Larger values weaken observation guidance, especially early in
             denoising, so the analysis stays closer to the unguided downscaler and may

--- a/earth2studio/models/da/sda_corrdiff_cosmo_era5.py
+++ b/earth2studio/models/da/sda_corrdiff_cosmo_era5.py
@@ -127,7 +127,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         finite and > 0. It is the effective uncertainty per occupied grid cell
         (multiple observations in one cell are averaged, not reduced by sqrt(n)).
     sda_gamma : float, optional
-        SDA covariance scaling in the DPS likelihood, by default 5e-5. Positive
+        SDA covariance scaling in the DPS likelihood, by default 1e-4. Positive
         values account for denoiser-estimate uncertainty across diffusion noise
         levels. Larger values weaken observation guidance, especially early in
         denoising, so the analysis stays closer to the unguided downscaler and may
@@ -155,7 +155,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         number_of_samples: int | None = None,
         sampler_steps: int | None = None,
         sda_std_obs: float | Mapping[str, float] = 0.5,
-        sda_gamma: float = 5e-5,
+        sda_gamma: float = 1e-4,
         amp: bool = False,
     ) -> None:
         super().__init__()
@@ -734,7 +734,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
         number_of_samples: int | None = None,
         sampler_steps: int | None = None,
         sda_std_obs: float | Mapping[str, float] = 0.5,
-        sda_gamma: float = 5e-5,
+        sda_gamma: float = 1e-4,
         amp: bool = False,
     ) -> AssimilationModel:
         """Load the assimilation model from a CorrDiff-COSMO package.
@@ -778,7 +778,7 @@ class CorrDiffCosmoEra5SDA(torch.nn.Module, AutoModelMixin):
             must contain exactly the assimilated variables (e.g.
             ``{"u10m": 0.5, "v10m": 0.5}``).
         sda_gamma : float, optional
-            SDA covariance scaling in the DPS likelihood, by default 5e-5. Positive
+            SDA covariance scaling in the DPS likelihood, by default 1e-4. Positive
             values account for denoiser-estimate uncertainty across diffusion noise
             levels. Larger values weaken observation guidance, especially early in
             denoising, so the analysis stays closer to the unguided downscaler and may

--- a/examples/05_data_assimilation/03_corrdiff_cosmo_sda.py
+++ b/examples/05_data_assimilation/03_corrdiff_cosmo_sda.py
@@ -86,8 +86,8 @@ ASSIMILATE = ("u10m", "v10m")
 DOMAIN = dict(lat_min=50.2, lat_max=53.8, lon_min=4.6, lon_max=10.4)
 ENSEMBLE_SIZE = 1
 SAMPLER_STEPS = 12  # Reduced from 18 for this example.
-SDA_STD_OBS = 0.5
-SDA_GAMMA = 1e-4
+SDA_STD_OBS = 0.75
+SDA_GAMMA = 7.5e-5
 VAL_FRAC = 0.3
 OBS_TIME_TOLERANCE = timedelta(minutes=30)
 DEVICE = "cuda:0"

--- a/examples/05_data_assimilation/03_corrdiff_cosmo_sda.py
+++ b/examples/05_data_assimilation/03_corrdiff_cosmo_sda.py
@@ -87,7 +87,7 @@ DOMAIN = dict(lat_min=50.2, lat_max=53.8, lon_min=4.6, lon_max=10.4)
 ENSEMBLE_SIZE = 1
 SAMPLER_STEPS = 12  # Reduced from 18 for this example.
 SDA_STD_OBS = 0.5
-SDA_GAMMA = 5e-5
+SDA_GAMMA = 1e-4
 VAL_FRAC = 0.3
 OBS_TIME_TOLERANCE = timedelta(minutes=30)
 DEVICE = "cuda:0"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Earth2Studio Pull Request

Raises `CorrDiffCosmoEra5SDA`'s default `sda_gamma` from `5e-5` to `7.5e-5` and `sda_std_obs` from `0.5` to `0.75` to avoid non-finite (diverged) guided output; held-out skill unchanged.

closes #1145

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/earth2studio/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/earth2studio/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2studio/issues) is linked to this pull request.
- [x] Assess and address Greptile feedback (AI code review bot for guidance; use discretion, addressing all feedback is not required).

## Dependencies

<!-- Call out any new dependencies needed if any -->
